### PR TITLE
Harden admin links and cache preload URLs

### DIFF
--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -119,7 +119,7 @@ class Actions {
 				'parent' => 'perform',
 				'id'     => 'assets-manager',
 				'title'  => $menu_text,
-				'href'   => $href,
+				'href'   => esc_url( $href ),
 			]
 		);
 

--- a/src/Admin/Filters.php
+++ b/src/Admin/Filters.php
@@ -45,7 +45,7 @@ class Filters {
 		}
 
 		$footer_text = sprintf(
-			'%1$s <strong>%2$s</strong> <a href="%4$s" target="_blank" class="perform-rating-link">%3$s</a> %5$s',
+			'%1$s <strong>%2$s</strong> <a href="%4$s" target="_blank" rel="noopener noreferrer" class="perform-rating-link">%3$s</a> %5$s',
 			esc_html__( 'If you love using', 'perform' ),
 			esc_html__( 'Perform WordPress Plugin', 'perform' ),
 			esc_html__( 'please leave us a rating', 'perform' ),
@@ -73,8 +73,8 @@ class Filters {
 				esc_html__( 'Settings', 'perform' )
 			),
 			'support'  => sprintf(
-				'<a target="_blank" href="%1$s">%2$s</a>',
-				esc_url_raw( 'https://wordpress.org/support/plugin/perform/' ),
+				'<a target="_blank" rel="noopener noreferrer" href="%1$s">%2$s</a>',
+				esc_url( 'https://wordpress.org/support/plugin/perform/' ),
 				esc_html__( 'Support', 'perform' )
 			),
 		];
@@ -93,7 +93,7 @@ class Filters {
 	public function add_row_actions( $actions, $post ) {
 		if ( 'publish' === $post->post_status ) {
 			$actions['assets_manager'] = sprintf(
-				'<a href="%1$s" target="_blank">%2$s</a>',
+				'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
 				esc_url( get_the_permalink( $post->ID ) . '?perform' ),
 				esc_html__( 'Manage Assets', 'perform' )
 			);

--- a/src/Admin/Settings/Api.php
+++ b/src/Admin/Settings/Api.php
@@ -133,7 +133,7 @@ class Api {
 		}
 
 		return sprintf(
-			'<a href="%s" class="perform-tooltip" target="_blank" title="%s">?</a>',
+			'<a href="%s" class="perform-tooltip" target="_blank" rel="noopener noreferrer" title="%s">?</a>',
 			esc_url( $url ),
 			esc_attr__( 'Learn more', 'perform' )
 		);

--- a/src/Modules/Assets/AssetsManager.php
+++ b/src/Modules/Assets/AssetsManager.php
@@ -104,7 +104,7 @@ class AssetsManager implements ModuleInterface {
 				<?php wp_nonce_field( 'perform_assets_manager_save', 'perform_assets_manager_nonce' ); ?>
 				<div class="perform-assets-manager--header">
 					<div class="perform-assets-manager--logo">
-						<img src="<?php echo PERFORM_PLUGIN_URL . 'assets/dist/images/logo.png'; ?>" alt="<?php esc_html_e( 'Perform', 'perform' ); ?>" />
+						<img src="<?php echo esc_url( PERFORM_PLUGIN_URL . 'assets/dist/images/logo.png' ); ?>" alt="<?php esc_html_e( 'Perform', 'perform' ); ?>" />
 					</div>
 					<div class="perform-assets-manager-header-actions">
 						<input type="submit" name="perform_assets_manager" value="<?php esc_html_e( 'Save', 'perform' ); ?>" />
@@ -124,7 +124,7 @@ class AssetsManager implements ModuleInterface {
 							if ( ! empty( $groups ) ) {
 								?>
 								<div class="perform-assets-manager--section">
-									<h3><?php echo ucwords( $category ); ?></h3>
+									<h3><?php echo esc_html( ucwords( $category ) ); ?></h3>
 									<?php
 										if ( 'misc' !== $category ) {
 											foreach ( $groups as $group => $details ) {
@@ -370,7 +370,7 @@ class AssetsManager implements ModuleInterface {
 						<?php $this->disable_single_asset_html( $type, $handle ); ?>
 					</td>
 					<td class="perform-assets-manager--url">
-						<a href="<?php echo esc_url( $src ); ?>" target="_blank"><?php esc_html_e( 'View File', 'perform' ); ?></a>
+						<a href="<?php echo esc_url( $src ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'View File', 'perform' ); ?></a>
 							<input type="hidden" name="<?php echo esc_attr( "relations[{$type}][{$handle}][category]" ); ?>" value="<?php echo esc_attr( $category ); ?>" />
 							<input type="hidden" name="<?php echo esc_attr( "relations[{$type}][{$handle}][group]" ); ?>" value="<?php echo esc_attr( $group ); ?>" />
 					</td>
@@ -461,7 +461,7 @@ class AssetsManager implements ModuleInterface {
 					$is_checked = checked( $is_disabled_key, 1, false );
 				}
 				?>
-				<label for="<?php echo esc_html( "disabled-{$type}-{$handle}-{$key}" ); ?>">
+				<label for="<?php echo esc_attr( "disabled-{$type}-{$handle}-{$key}" ); ?>">
 							<input type="radio" name="disabled[<?php echo esc_attr( $type ); ?>][<?php echo esc_attr( $handle ); ?>]" id="<?php echo esc_attr( "disabled-{$type}-{$handle}-{$key}" ); ?>" class="perform-disable-assets" value="<?php echo esc_attr( $key ); ?>"<?php echo $is_checked; ?>/>
 							<?php echo esc_html( $value ); ?>
 				</label>
@@ -489,7 +489,7 @@ class AssetsManager implements ModuleInterface {
 		$is_selected        = ( $is_disabled_handle && is_array( $this->selected_options['disabled'][ $type ][ $handle ] ) ) ? 'selected="selected"' : '';
 		$disable_class      = ! empty( $is_selected ) ? 'disabled' : '';
 		?>
-		<select name="status[<?php echo esc_html( $type ); ?>][<?php echo esc_html( $handle ); ?>]" class="perform-status-select <?php echo esc_html( $disable_class ); ?>">
+		<select name="status[<?php echo esc_attr( $type ); ?>][<?php echo esc_attr( $handle ); ?>]" class="perform-status-select <?php echo esc_attr( $disable_class ); ?>">
 			<option value='enabled' class='perform-option-enabled'>
 				<?php echo esc_attr__( 'ON', 'perform' ); ?>
 			</option>
@@ -551,7 +551,7 @@ class AssetsManager implements ModuleInterface {
 					foreach ( $post_types as $key => $value ) {
 						$is_post_type_selected = ( is_array( $selected_post_types ) && in_array( $key, $selected_post_types, true ) ) ? ' checked="checked"' : '';
 						?>
-						<label for="<?php echo "{$type}-{$handle}-enable-{$key}"; ?>">
+						<label for="<?php echo esc_attr( "{$type}-{$handle}-enable-{$key}" ); ?>">
 								<input type="checkbox" name="enabled[<?php echo esc_attr( $type ); ?>][<?php echo esc_attr( $handle ); ?>][post_types][]" id="<?php echo esc_attr( "{$type}-{$handle}-enable-{$key}" ); ?>" value="<?php echo esc_attr( $key ); ?>" <?php echo $is_post_type_selected; ?> />
 								<?php echo esc_html( $value->label ); ?>
 						</label>

--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -414,7 +414,7 @@ class PageCache implements ModuleInterface {
 
 		while ( $processed < $batch_size && ! empty( $queue ) ) {
 			$url = array_shift( $queue );
-			if ( ! is_string( $url ) || '' === $url ) {
+			if ( ! is_string( $url ) || '' === $url || ! $this->is_site_url( $url ) ) {
 				continue;
 			}
 
@@ -613,7 +613,7 @@ class PageCache implements ModuleInterface {
 		}
 
 		foreach ( $urls as $url ) {
-			if ( ! is_string( $url ) || '' === $url ) {
+			if ( ! is_string( $url ) || '' === $url || ! $this->is_site_url( $url ) ) {
 				continue;
 			}
 			$queue[] = esc_url_raw( $url );
@@ -656,7 +656,12 @@ class PageCache implements ModuleInterface {
 					continue;
 				}
 
-				$child_response = wp_remote_get( (string) $sitemap->loc, [ 'timeout' => 8 ] );
+				$child_sitemap_url = esc_url_raw( (string) $sitemap->loc );
+				if ( ! $this->is_site_url( $child_sitemap_url ) ) {
+					continue;
+				}
+
+				$child_response = wp_remote_get( $child_sitemap_url, [ 'timeout' => 8 ] );
 				if ( is_wp_error( $child_response ) ) {
 					continue;
 				}
@@ -673,7 +678,10 @@ class PageCache implements ModuleInterface {
 
 				foreach ( $child->url as $item ) {
 					if ( ! empty( $item->loc ) ) {
-						$urls[] = esc_url_raw( (string) $item->loc );
+						$item_url = esc_url_raw( (string) $item->loc );
+						if ( $this->is_site_url( $item_url ) ) {
+							$urls[] = $item_url;
+						}
 					}
 				}
 			}
@@ -762,7 +770,7 @@ class PageCache implements ModuleInterface {
 	 * @return void
 	 */
 	private function maybe_trigger_async_regeneration( $url ) {
-		if ( get_transient( $this->lock_key ) ) {
+		if ( get_transient( $this->lock_key ) || ! $this->is_site_url( $url ) ) {
 			return;
 		}
 
@@ -779,6 +787,45 @@ class PageCache implements ModuleInterface {
 				],
 			]
 		);
+	}
+
+	/**
+	 * Confirm a URL belongs to the current site before internal HTTP warmups.
+	 *
+	 * @param string $url URL to verify.
+	 *
+	 * @return bool
+	 */
+	private function is_site_url( $url ) {
+		if ( ! is_string( $url ) || '' === trim( $url ) ) {
+			return false;
+		}
+
+		$site_parts = wp_parse_url( home_url( '/' ) );
+		$url_parts  = wp_parse_url( $url );
+
+		if ( empty( $site_parts['host'] ) || false === $url_parts ) {
+			return false;
+		}
+
+		if ( empty( $url_parts['host'] ) ) {
+			$url_parts = wp_parse_url( home_url( $url ) );
+		}
+
+		if ( false === $url_parts || empty( $url_parts['host'] ) ) {
+			return false;
+		}
+
+		$scheme = isset( $url_parts['scheme'] ) ? strtolower( (string) $url_parts['scheme'] ) : '';
+		if ( ! in_array( $scheme, [ 'http', 'https' ], true ) ) {
+			return false;
+		}
+
+		$site_port = isset( $site_parts['port'] ) ? (int) $site_parts['port'] : null;
+		$url_port  = isset( $url_parts['port'] ) ? (int) $url_parts['port'] : null;
+
+		return strtolower( (string) $site_parts['host'] ) === strtolower( (string) $url_parts['host'] )
+			&& $site_port === $url_port;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Restrict page-cache preload and async regeneration requests to URLs on the current site host.
- Add `rel="noopener noreferrer"` to admin links that open new tabs.
- Tighten output escaping for admin bar and Asset Manager markup.

## Security notes
This PR intentionally handles security hardening directly instead of creating a public issue for the cache preload URL boundary.

## Validation
- `php -l src/Modules/Cache/PageCache.php`
- `php -l src/Admin/Settings/Api.php`
- `php -l src/Admin/Filters.php`
- `php -l src/Admin/Actions.php`
- `php -l src/Modules/Assets/AssetsManager.php`
- `git diff --check`

## Known gaps
Broader Composer/npm validation remains blocked by existing tooling issues tracked in #53 and the broader tooling modernization issue #86.
