### PR TITLE
Redesign Assets Manager scanner UI

### DIFF
--- a/assets/src/css/frontend/assets-manager.css
+++ b/assets/src/css/frontend/assets-manager.css
@@ -1,122 +1,525 @@
 #perform-assets-manager {
 	position: fixed;
-	z-index: 9999;
+	z-index: 999999;
 	top: 32px;
+	right: 0;
 	bottom: 0;
 	left: 0;
-	right: 0;
-	background-color: var(--primary-color);
-	overflow-y: auto;
+	overflow: auto;
+	background: #f0f0f1;
+	color: #1e1e1e;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+	font-size: 13px;
+	line-height: 1.4;
+	isolation: isolate;
+}
+
+#perform-assets-manager,
+#perform-assets-manager * {
+	box-sizing: border-box;
+}
+
+#perform-assets-manager [hidden] {
+	display: none !important;
+}
+
+#perform-assets-manager a,
+#perform-assets-manager button,
+#perform-assets-manager input,
+#perform-assets-manager select {
+	font: inherit;
+}
+
+#perform-assets-manager code {
+	display: inline-block;
+	max-width: 100%;
+	padding: 2px 6px;
+	overflow-wrap: anywhere;
+	border-radius: 2px;
+	background: #f6f7f7;
+	color: #50575e;
+	font-family: Consolas, Monaco, monospace;
+	font-size: 12px;
+}
+
+#perform-assets-manager .screen-reader-text {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
 }
 
 .perform-assets-manager #perform-assets-manager--form {
-	.perform-assets-manager--header {
-		background-color: #fff;
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: 0 15px 0 0;
+	min-height: 100%;
+}
 
-		.perform-assets-manager--logo {
-			img {
-				width: 180px;
-			}
-		}
+.perform-assets-manager--header {
+	position: sticky;
+	z-index: 10;
+	top: 0;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+	padding: 12px 24px;
+	border-bottom: 1px solid #dcdcde;
+	background: #fff;
+	box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+}
 
-		.perform-assets-manager-header-actions {
-			input[type='submit'] {
-				background-color: var(--primary-color);
-				border: none;
-				padding: 8px 25px;
-				font-size: 13px;
-				color: #fff;
-				border-radius: 5px;
-				text-transform: uppercase;
-				font-weight: 700;
-				cursor: pointer;
-			}
-		}
-	}
+.perform-assets-manager--brand {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	min-width: 0;
+}
 
-	
+.perform-assets-manager--brand img {
+	width: 136px;
+	height: auto;
+	flex: 0 0 auto;
+}
+
+.perform-assets-manager--brand span {
+	display: block;
+	margin-bottom: 2px;
+	color: #646970;
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: .04em;
+	text-transform: uppercase;
+}
+
+.perform-assets-manager--brand strong {
+	display: block;
+	color: #1e1e1e;
+	font-size: 15px;
+	font-weight: 600;
+}
+
+.perform-assets-manager-header-actions {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.perform-assets-manager-button,
+.perform-assets-manager-button:visited,
+.perform-assets-manager-header-actions input[type='submit'] {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 36px;
+	padding: 6px 14px;
+	border: 1px solid #2271b1;
+	border-radius: 3px;
+	box-shadow: none;
+	cursor: pointer;
+	text-decoration: none;
+	font-weight: 500;
+}
+
+.perform-assets-manager-button--primary,
+.perform-assets-manager-header-actions input[type='submit'] {
+	background: #2271b1;
+	color: #fff;
+}
+
+.perform-assets-manager-button--secondary {
+	background: #fff;
+	color: #2271b1;
+}
+
+.perform-assets-manager-button:focus,
+.perform-assets-manager-header-actions input[type='submit']:focus,
+.perform-assets-manager--filters button:focus,
+.perform-status-select:focus,
+#perform-assets-manager-search:focus {
+	outline: 2px solid #2271b1;
+	outline-offset: 2px;
 }
 
 #perform-assets-manager--main {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: center;
-	width: 100%;
+	width: min(1280px, calc(100% - 32px));
+	margin: 0 auto;
+	padding: 24px 0 40px;
 }
 
 .perform-assets-manager--title {
-	text-align: center;
-	width: 100%;
-	background-color: var(--primary-color);
-	color: #fff;
-	padding: 20px 0;
+	display: grid;
+	gap: 8px;
+	padding: 24px;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	background: #fff;
+}
 
-	p {
-		font-size: 16px;
-	}
+.perform-assets-manager--title h2,
+.perform-assets-manager--title p {
+	margin: 0;
+}
+
+.perform-assets-manager--title h2 {
+	font-size: 28px;
+	font-weight: 600;
+	line-height: 1.2;
+}
+
+.perform-assets-manager--title p:not(.perform-assets-manager--eyebrow) {
+	max-width: 760px;
+	color: #50575e;
+	font-size: 14px;
+}
+
+.perform-assets-manager--eyebrow {
+	color: #2271b1;
+	font-size: 12px;
+	font-weight: 600;
+	letter-spacing: .04em;
+	text-transform: uppercase;
+}
+
+.perform-assets-manager--scanner {
+	display: grid;
+	gap: 16px;
+	margin: 16px 0;
+}
+
+.perform-assets-manager--summary-grid {
+	display: grid;
+	grid-template-columns: repeat(5, minmax(0, 1fr));
+	gap: 12px;
+}
+
+.perform-assets-manager--summary-card {
+	display: grid;
+	gap: 8px;
+	min-height: 96px;
+	padding: 16px;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	background: #fff;
+}
+
+.perform-assets-manager--summary-card span {
+	color: #646970;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
+.perform-assets-manager--summary-card strong {
+	color: #1e1e1e;
+	font-size: 28px;
+	font-weight: 600;
+	line-height: 1;
+}
+
+.perform-assets-manager--toolbar {
+	display: grid;
+	grid-template-columns: minmax(220px, 360px) 1fr;
+	gap: 12px;
+	align-items: center;
+	padding: 16px;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	background: #fff;
+}
+
+#perform-assets-manager-search {
+	width: 100%;
+	min-height: 36px;
+	padding: 6px 10px;
+	border: 1px solid #8c8f94;
+	border-radius: 3px;
+	background: #fff;
+	color: #1e1e1e;
+}
+
+.perform-assets-manager--filters {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.perform-assets-manager--filters button {
+	min-height: 32px;
+	padding: 4px 10px;
+	border: 1px solid #c3c4c7;
+	border-radius: 3px;
+	background: #fff;
+	color: #2c3338;
+	cursor: pointer;
+}
+
+.perform-assets-manager--filters button.is-active {
+	border-color: #2271b1;
+	background: #f0f6fc;
+	color: #0a4b78;
 }
 
 .perform-assets-manager--section {
-	width: 90%;
-	background-color: #fff;
-	margin: 15px 0;
+	margin: 16px 0 0;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	background: #fff;
+}
 
-	h3 {
-		color: var(--primary-color);
-		text-transform: uppercase;
-		font-size: 20px;
-		font-weight: 700;
-		padding: 10px;
+.perform-assets-manager--section > h3 {
+	margin: 0;
+	padding: 16px 20px;
+	border-bottom: 1px solid #dcdcde;
+	color: #1e1e1e;
+	font-size: 15px;
+	font-weight: 600;
+	text-transform: none;
+}
+
+.perform-assets-manager--group {
+	padding: 20px;
+	border-bottom: 1px solid #dcdcde;
+}
+
+.perform-assets-manager--group:last-child {
+	border-bottom: 0;
+}
+
+.perform-assets-manager-group--title {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+	margin-bottom: 16px;
+}
+
+.perform-assets-manager-group--title h4,
+.perform-assets-manager-group--title p {
+	margin: 0;
+}
+
+.perform-assets-manager-group--title h4 {
+	margin-top: 4px;
+	color: #1e1e1e;
+	font-size: 16px;
+	font-weight: 600;
+}
+
+.perform-assets-manager-group--title p {
+	margin-top: 4px;
+	color: #646970;
+}
+
+.perform-assets-manager--source-label,
+.perform-assets-manager--type-badge {
+	display: inline-flex;
+	align-items: center;
+	min-height: 22px;
+	padding: 2px 8px;
+	border-radius: 999px;
+	background: #f6f7f7;
+	color: #50575e;
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
+.perform-assets-manager--type-badge-js {
+	background: #fff8e5;
+	color: #7a4b00;
+}
+
+.perform-assets-manager--type-badge-css {
+	background: #edfaef;
+	color: #075e26;
+}
+
+.perform-status-select {
+	min-width: 88px;
+	min-height: 34px;
+	padding: 4px 28px 4px 10px;
+	border: 1px solid #8c8f94;
+	border-radius: 3px;
+	background-color: #fff;
+	color: #1e1e1e;
+}
+
+.perform-status-select.disabled {
+	border-color: #b32d2e;
+	color: #8a2424;
+}
+
+.perform-assets-manager--assets-table {
+	width: 100%;
+	border: 1px solid #dcdcde;
+	border-collapse: collapse;
+	background: #fff;
+}
+
+.perform-assets-manager--assets-table th,
+.perform-assets-manager--assets-table td {
+	padding: 12px;
+	border-bottom: 1px solid #dcdcde;
+	text-align: left;
+	vertical-align: top;
+}
+
+.perform-assets-manager--assets-table th {
+	background: #f6f7f7;
+	color: #50575e;
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
+.perform-assets-manager--assets-table tbody tr:last-child td {
+	border-bottom: 0;
+}
+
+.perform-assets-manager--handle strong {
+	display: block;
+	margin-bottom: 6px;
+	color: #1e1e1e;
+	font-weight: 600;
+}
+
+.perform-assets-manager--status {
+	min-width: 220px;
+}
+
+.perform-assets-manager--url a {
+	color: #2271b1;
+	font-weight: 500;
+	text-decoration: none;
+}
+
+.perform-assets-manager--url a:hover {
+	color: #135e96;
+	text-decoration: underline;
+}
+
+.perform-assets-manager-disable-assets {
+	margin-top: 12px;
+	padding: 12px;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	background: #f6f7f7;
+}
+
+.perform-assets-manager-disable-asset-option-selection {
+	padding: 0;
+	margin: 0;
+	border: 0;
+}
+
+.perform-assets-manager-disable-asset-option-selection legend,
+.perform-assets-manager-exceptions--title {
+	margin-bottom: 8px;
+	color: #1e1e1e;
+	font-weight: 600;
+}
+
+.perform-assets-manager--radio-group,
+.perform-assets-manager-exception--options {
+	display: grid;
+	gap: 8px;
+}
+
+.perform-assets-manager--radio-group label,
+.perform-assets-manager-exception--options label {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	color: #2c3338;
+}
+
+.perform-assets-manager--exceptions {
+	margin-top: 12px;
+	padding-top: 12px;
+	border-top: 1px solid #dcdcde;
+}
+
+.perform-assets-manager--no-results {
+	margin: 16px 0 0;
+	padding: 20px;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	background: #fff;
+	color: #646970;
+	text-align: center;
+}
+
+@media (max-width: 960px) {
+	.perform-assets-manager--summary-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 
-	.perform-assets-manager--group {
-		padding: 20px;
-		border-bottom: 2px solid var(--primary-color);
+	.perform-assets-manager--toolbar {
+		grid-template-columns: 1fr;
+	}
 
-		.perform-assets-manager-group--title {
-			display: flex;
-			justify-content: space-between;
-			align-items: center;
-		}
+	.perform-assets-manager--filters {
+		justify-content: flex-start;
+	}
+}
 
-		.perform-status-select {
-			padding: 3px 18px;
-			margin: 5px;
-			border-radius: 25px;
-			font-size: 1rem;
-			border: 2px solid;
-		}
+@media (max-width: 782px) {
+	#perform-assets-manager {
+		top: 46px;
+	}
 
-		table {
-			width: 100%;
-			border: none;
+	.perform-assets-manager--header,
+	.perform-assets-manager-group--title {
+		align-items: stretch;
+		flex-direction: column;
+	}
 
-			thead {
-				tr {
-					background-color: #fafafa;
+	.perform-assets-manager-header-actions {
+		justify-content: stretch;
+	}
 
-					th {
-						color: #71717a;
-						text-transform: uppercase;
-						font-size: 14px;
-					}
-				}
-			}
+	.perform-assets-manager-button,
+	.perform-assets-manager-header-actions input[type='submit'] {
+		width: 100%;
+	}
 
-			tbody {
-				tr {
-					border-bottom: 1px solid #e4e4e7;
+	.perform-assets-manager--summary-grid {
+		grid-template-columns: 1fr;
+	}
 
-					td {
-						padding: 0 10px;
-						font-size: 16px;
-					}
-				}
-			}
-		}
+	.perform-assets-manager--assets-table,
+	.perform-assets-manager--assets-table thead,
+	.perform-assets-manager--assets-table tbody,
+	.perform-assets-manager--assets-table tr,
+	.perform-assets-manager--assets-table th,
+	.perform-assets-manager--assets-table td {
+		display: block;
+	}
+
+	.perform-assets-manager--assets-table thead {
+		display: none;
+	}
+
+	.perform-assets-manager--assets-table tr {
+		border-bottom: 1px solid #dcdcde;
+	}
+
+	.perform-assets-manager--assets-table tr:last-child {
+		border-bottom: 0;
+	}
+
+	.perform-assets-manager--assets-table td {
+		border-bottom: 0;
+	}
+
+	.perform-assets-manager--status {
+		min-width: 0;
 	}
 }

--- a/assets/src/css/frontend/assets-manager.css
+++ b/assets/src/css/frontend/assets-manager.css
@@ -1,4 +1,15 @@
 #perform-assets-manager {
+	--perform-am-primary: var(--primary-color, #0046d1);
+	--perform-am-secondary: var(--secondary-color, #c8d8ff);
+	--perform-am-surface: var(--bg-color, #ffffff);
+	--perform-am-muted-surface: var(--menu-color, #f0f0f1);
+	--perform-am-hover-surface: var(--menu-hover-color, #f5f5f5);
+	--perform-am-text: var(--text-color, #333333);
+	--perform-am-white: var(--white-color, #ffffff);
+	--perform-am-border: #d8e2ff;
+	--perform-am-muted-text: #5a5f68;
+	--perform-am-danger: #b32d2e;
+
 	position: fixed;
 	z-index: 999999;
 	top: 32px;
@@ -6,8 +17,8 @@
 	bottom: 0;
 	left: 0;
 	overflow: auto;
-	background: #f0f0f1;
-	color: #1e1e1e;
+	background: var(--perform-am-muted-surface);
+	color: var(--perform-am-text);
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 	font-size: 13px;
 	line-height: 1.4;
@@ -36,8 +47,8 @@
 	padding: 2px 6px;
 	overflow-wrap: anywhere;
 	border-radius: 2px;
-	background: #f6f7f7;
-	color: #50575e;
+	background: var(--perform-am-hover-surface);
+	color: var(--perform-am-muted-text);
 	font-family: Consolas, Monaco, monospace;
 	font-size: 12px;
 }
@@ -67,8 +78,8 @@
 	justify-content: space-between;
 	gap: 16px;
 	padding: 12px 24px;
-	border-bottom: 1px solid #dcdcde;
-	background: #fff;
+	border-bottom: 1px solid var(--perform-am-border);
+	background: var(--perform-am-surface);
 	box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
 }
 
@@ -88,7 +99,7 @@
 .perform-assets-manager--brand span {
 	display: block;
 	margin-bottom: 2px;
-	color: #646970;
+	color: var(--perform-am-muted-text);
 	font-size: 11px;
 	font-weight: 600;
 	letter-spacing: .04em;
@@ -97,7 +108,7 @@
 
 .perform-assets-manager--brand strong {
 	display: block;
-	color: #1e1e1e;
+	color: var(--perform-am-text);
 	font-size: 15px;
 	font-weight: 600;
 }
@@ -118,7 +129,7 @@
 	justify-content: center;
 	min-height: 36px;
 	padding: 6px 14px;
-	border: 1px solid #2271b1;
+	border: 1px solid var(--perform-am-primary);
 	border-radius: 3px;
 	box-shadow: none;
 	cursor: pointer;
@@ -128,21 +139,20 @@
 
 .perform-assets-manager-button--primary,
 .perform-assets-manager-header-actions input[type='submit'] {
-	background: #2271b1;
-	color: #fff;
+	background: var(--perform-am-primary);
+	color: var(--perform-am-white);
 }
 
 .perform-assets-manager-button--secondary {
-	background: #fff;
-	color: #2271b1;
+	background: var(--perform-am-white);
+	color: var(--perform-am-primary);
 }
 
 .perform-assets-manager-button:focus,
 .perform-assets-manager-header-actions input[type='submit']:focus,
-.perform-assets-manager--filters button:focus,
-.perform-status-select:focus,
-#perform-assets-manager-search:focus {
-	outline: 2px solid #2271b1;
+.perform-assets-manager--controls .components-button:focus,
+.perform-status-select:focus {
+	outline: 2px solid var(--perform-am-primary);
 	outline-offset: 2px;
 }
 
@@ -156,9 +166,9 @@
 	display: grid;
 	gap: 8px;
 	padding: 24px;
-	border: 1px solid #dcdcde;
+	border: 1px solid var(--perform-am-border);
 	border-radius: 4px;
-	background: #fff;
+	background: var(--perform-am-surface);
 }
 
 .perform-assets-manager--title h2,
@@ -174,12 +184,12 @@
 
 .perform-assets-manager--title p:not(.perform-assets-manager--eyebrow) {
 	max-width: 760px;
-	color: #50575e;
+	color: var(--perform-am-muted-text);
 	font-size: 14px;
 }
 
 .perform-assets-manager--eyebrow {
-	color: #2271b1;
+	color: var(--perform-am-primary);
 	font-size: 12px;
 	font-weight: 600;
 	letter-spacing: .04em;
@@ -203,44 +213,80 @@
 	gap: 8px;
 	min-height: 96px;
 	padding: 16px;
-	border: 1px solid #dcdcde;
+	border: 1px solid var(--perform-am-border);
 	border-radius: 4px;
-	background: #fff;
+	background: var(--perform-am-surface);
 }
 
 .perform-assets-manager--summary-card span {
-	color: #646970;
+	color: var(--perform-am-muted-text);
 	font-size: 12px;
 	font-weight: 600;
 	text-transform: uppercase;
 }
 
 .perform-assets-manager--summary-card strong {
-	color: #1e1e1e;
+	color: var(--perform-am-text);
 	font-size: 28px;
 	font-weight: 600;
 	line-height: 1;
 }
 
 .perform-assets-manager--toolbar {
+	padding: 16px;
+	border: 1px solid var(--perform-am-border);
+	border-radius: 4px;
+	background: var(--perform-am-surface);
+}
+
+.perform-assets-manager--controls-root {
+	width: 100%;
+}
+
+.perform-assets-manager--controls {
 	display: grid;
 	grid-template-columns: minmax(220px, 360px) 1fr;
 	gap: 12px;
 	align-items: center;
-	padding: 16px;
-	border: 1px solid #dcdcde;
-	border-radius: 4px;
-	background: #fff;
 }
 
-#perform-assets-manager-search {
+#perform-assets-manager .perform-assets-manager--search {
+	margin: 0;
+}
+
+#perform-assets-manager .perform-assets-manager--search .components-base-control__field {
+	margin-bottom: 0;
+}
+
+#perform-assets-manager .perform-assets-manager--search .components-input-control__container {
+	background: var(--perform-am-white);
+}
+
+#perform-assets-manager .perform-assets-manager--search .components-input-control__backdrop {
+	border-color: var(--perform-am-border);
+}
+
+#perform-assets-manager .perform-assets-manager--search .components-search-control__input,
+#perform-assets-manager .perform-assets-manager--search .components-input-control__input {
 	width: 100%;
 	min-height: 36px;
-	padding: 6px 10px;
-	border: 1px solid #8c8f94;
+	border: 1px solid var(--perform-am-border);
 	border-radius: 3px;
-	background: #fff;
-	color: #1e1e1e;
+	box-shadow: none;
+	background: var(--perform-am-white);
+	color: var(--perform-am-text);
+}
+
+#perform-assets-manager .perform-assets-manager--search .components-search-control__input:focus,
+#perform-assets-manager .perform-assets-manager--search .components-input-control__input:focus {
+	border-color: var(--perform-am-primary);
+	box-shadow: 0 0 0 1px var(--perform-am-primary);
+	outline: 2px solid transparent;
+}
+
+#perform-assets-manager .perform-assets-manager--search .components-input-control__input:focus + .components-input-control__backdrop {
+	border-color: var(--perform-am-primary);
+	box-shadow: 0 0 0 1px var(--perform-am-primary);
 }
 
 .perform-assets-manager--filters {
@@ -250,34 +296,49 @@
 	flex-wrap: wrap;
 }
 
-.perform-assets-manager--filters button {
+#perform-assets-manager .perform-assets-manager--filters .components-button {
 	min-height: 32px;
-	padding: 4px 10px;
-	border: 1px solid #c3c4c7;
 	border-radius: 3px;
-	background: #fff;
-	color: #2c3338;
-	cursor: pointer;
+	box-shadow: none;
+	font-weight: 500;
 }
 
-.perform-assets-manager--filters button.is-active {
-	border-color: #2271b1;
-	background: #f0f6fc;
-	color: #0a4b78;
+#perform-assets-manager .perform-assets-manager--filters .components-button.is-primary {
+	border-color: var(--perform-am-primary);
+	background: var(--perform-am-primary);
+	color: var(--perform-am-white);
+}
+
+#perform-assets-manager .perform-assets-manager--filters .components-button.is-primary:hover:not(:disabled) {
+	border-color: var(--perform-am-primary);
+	background: var(--perform-am-primary);
+	color: var(--perform-am-white);
+}
+
+#perform-assets-manager .perform-assets-manager--filters .components-button.is-secondary {
+	border-color: var(--perform-am-border);
+	background: var(--perform-am-white);
+	color: var(--perform-am-primary);
+}
+
+#perform-assets-manager .perform-assets-manager--filters .components-button.is-secondary:hover:not(:disabled) {
+	border-color: var(--perform-am-primary);
+	background: var(--perform-am-secondary);
+	color: var(--perform-am-primary);
 }
 
 .perform-assets-manager--section {
 	margin: 16px 0 0;
-	border: 1px solid #dcdcde;
+	border: 1px solid var(--perform-am-border);
 	border-radius: 4px;
-	background: #fff;
+	background: var(--perform-am-surface);
 }
 
 .perform-assets-manager--section > h3 {
 	margin: 0;
 	padding: 16px 20px;
-	border-bottom: 1px solid #dcdcde;
-	color: #1e1e1e;
+	border-bottom: 1px solid var(--perform-am-border);
+	color: var(--perform-am-text);
 	font-size: 15px;
 	font-weight: 600;
 	text-transform: none;
@@ -285,7 +346,7 @@
 
 .perform-assets-manager--group {
 	padding: 20px;
-	border-bottom: 1px solid #dcdcde;
+	border-bottom: 1px solid var(--perform-am-border);
 }
 
 .perform-assets-manager--group:last-child {
@@ -307,14 +368,14 @@
 
 .perform-assets-manager-group--title h4 {
 	margin-top: 4px;
-	color: #1e1e1e;
+	color: var(--perform-am-text);
 	font-size: 16px;
 	font-weight: 600;
 }
 
 .perform-assets-manager-group--title p {
 	margin-top: 4px;
-	color: #646970;
+	color: var(--perform-am-muted-text);
 }
 
 .perform-assets-manager--source-label,
@@ -324,56 +385,56 @@
 	min-height: 22px;
 	padding: 2px 8px;
 	border-radius: 999px;
-	background: #f6f7f7;
-	color: #50575e;
+	background: var(--perform-am-hover-surface);
+	color: var(--perform-am-muted-text);
 	font-size: 11px;
 	font-weight: 600;
 	text-transform: uppercase;
 }
 
 .perform-assets-manager--type-badge-js {
-	background: #fff8e5;
-	color: #7a4b00;
+	background: var(--perform-am-secondary);
+	color: var(--perform-am-primary);
 }
 
 .perform-assets-manager--type-badge-css {
-	background: #edfaef;
-	color: #075e26;
+	background: var(--perform-am-hover-surface);
+	color: var(--perform-am-text);
 }
 
 .perform-status-select {
 	min-width: 88px;
 	min-height: 34px;
 	padding: 4px 28px 4px 10px;
-	border: 1px solid #8c8f94;
+	border: 1px solid var(--perform-am-border);
 	border-radius: 3px;
-	background-color: #fff;
-	color: #1e1e1e;
+	background-color: var(--perform-am-white);
+	color: var(--perform-am-text);
 }
 
 .perform-status-select.disabled {
-	border-color: #b32d2e;
-	color: #8a2424;
+	border-color: var(--perform-am-danger);
+	color: var(--perform-am-danger);
 }
 
 .perform-assets-manager--assets-table {
 	width: 100%;
-	border: 1px solid #dcdcde;
+	border: 1px solid var(--perform-am-border);
 	border-collapse: collapse;
-	background: #fff;
+	background: var(--perform-am-surface);
 }
 
 .perform-assets-manager--assets-table th,
 .perform-assets-manager--assets-table td {
 	padding: 12px;
-	border-bottom: 1px solid #dcdcde;
+	border-bottom: 1px solid var(--perform-am-border);
 	text-align: left;
 	vertical-align: top;
 }
 
 .perform-assets-manager--assets-table th {
-	background: #f6f7f7;
-	color: #50575e;
+	background: var(--perform-am-hover-surface);
+	color: var(--perform-am-muted-text);
 	font-size: 11px;
 	font-weight: 600;
 	text-transform: uppercase;
@@ -386,7 +447,7 @@
 .perform-assets-manager--handle strong {
 	display: block;
 	margin-bottom: 6px;
-	color: #1e1e1e;
+	color: var(--perform-am-text);
 	font-weight: 600;
 }
 
@@ -395,22 +456,22 @@
 }
 
 .perform-assets-manager--url a {
-	color: #2271b1;
+	color: var(--perform-am-primary);
 	font-weight: 500;
 	text-decoration: none;
 }
 
 .perform-assets-manager--url a:hover {
-	color: #135e96;
+	color: var(--perform-am-primary);
 	text-decoration: underline;
 }
 
 .perform-assets-manager-disable-assets {
 	margin-top: 12px;
 	padding: 12px;
-	border: 1px solid #dcdcde;
+	border: 1px solid var(--perform-am-border);
 	border-radius: 4px;
-	background: #f6f7f7;
+	background: var(--perform-am-hover-surface);
 }
 
 .perform-assets-manager-disable-asset-option-selection {
@@ -422,7 +483,7 @@
 .perform-assets-manager-disable-asset-option-selection legend,
 .perform-assets-manager-exceptions--title {
 	margin-bottom: 8px;
-	color: #1e1e1e;
+	color: var(--perform-am-text);
 	font-weight: 600;
 }
 
@@ -437,22 +498,22 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	color: #2c3338;
+	color: var(--perform-am-text);
 }
 
 .perform-assets-manager--exceptions {
 	margin-top: 12px;
 	padding-top: 12px;
-	border-top: 1px solid #dcdcde;
+	border-top: 1px solid var(--perform-am-border);
 }
 
 .perform-assets-manager--no-results {
 	margin: 16px 0 0;
 	padding: 20px;
-	border: 1px solid #dcdcde;
+	border: 1px solid var(--perform-am-border);
 	border-radius: 4px;
-	background: #fff;
-	color: #646970;
+	background: var(--perform-am-surface);
+	color: var(--perform-am-muted-text);
 	text-align: center;
 }
 
@@ -462,6 +523,10 @@
 	}
 
 	.perform-assets-manager--toolbar {
+		padding: 12px;
+	}
+
+	.perform-assets-manager--controls {
 		grid-template-columns: 1fr;
 	}
 
@@ -508,7 +573,7 @@
 	}
 
 	.perform-assets-manager--assets-table tr {
-		border-bottom: 1px solid #dcdcde;
+		border-bottom: 1px solid var(--perform-am-border);
 	}
 
 	.perform-assets-manager--assets-table tr:last-child {

--- a/assets/src/js/frontend/main.js
+++ b/assets/src/js/frontend/main.js
@@ -1,66 +1,178 @@
-document.addEventListener( 'DOMContentLoaded', function() {
-	const allStatusDropdown = document.querySelectorAll( '.perform-status-select' );
-	const allStatusDropdownWrap = document.querySelectorAll( '.perform-assets-manager--status' );
-	const allDisableAssetsWrap = document.querySelectorAll( '.perform-assets-manager-disable-assets' );
-	const allAssetsGroup = document.querySelectorAll( '.perform-assets-manager--group' );
+( function () {
+	function setHidden( element, hidden ) {
+		if ( ! element ) {
+			return;
+		}
 
-	Array.prototype.forEach.call( allStatusDropdown, function( element ) {
-		element.addEventListener( 'change', function( e ) {
-			if ( this.classList.contains( 'disabled' ) ) {
-				this.classList.remove( 'disabled' );
-			} else {
-				this.classList.add( 'disabled' );
-			}
+		element.hidden = hidden;
+	}
+
+	function syncAssetStatus( selectElement ) {
+		const isDisabled = 'disabled' === selectElement.value;
+		const statusCell = selectElement.closest( '.perform-assets-manager--status' );
+		const row = selectElement.closest( '[data-perform-asset-row]' );
+		const singleOptions = statusCell
+			? statusCell.querySelector( '.perform-assets-manager-disable-single-asset' )
+			: null;
+
+		selectElement.classList.toggle( 'disabled', isDisabled );
+		setHidden( singleOptions, ! isDisabled );
+
+		if ( row ) {
+			row.dataset.performAssetStatus = isDisabled ? 'disabled' : 'enabled';
+			row.dataset.performOwnStatus = row.dataset.performAssetStatus;
+		}
+
+		document.dispatchEvent( new Event( 'performAssetsManagerFilterRefresh' ) );
+	}
+
+	function syncGroupStatus( selectElement ) {
+		const group = selectElement.closest( '[data-perform-group]' );
+
+		if ( ! group ) {
+			return;
+		}
+
+		const isDisabled = 'disabled' === selectElement.value;
+		const groupOptions = group.querySelector( '.perform-assets-manager-disable-group-assets' );
+		const assetTable = group.querySelector( '.perform-assets-manager--assets-table' );
+
+		selectElement.classList.toggle( 'disabled', isDisabled );
+		setHidden( groupOptions, ! isDisabled );
+		setHidden( assetTable, isDisabled );
+
+		group.querySelectorAll( '[data-perform-asset-row]' ).forEach( function ( row ) {
+			row.dataset.performAssetStatus = isDisabled ? 'disabled' : row.dataset.performOwnStatus || 'enabled';
 		} );
-	} );
 
-	Array.prototype.forEach.call( allStatusDropdownWrap, function( element ) {
-		element.querySelector( '.perform-status-select' ).addEventListener( 'change', function( e ) {
-			const disablePages = element.querySelector( '.perform-assets-manager-disable-single-asset' );
-			if ( this.classList.contains( 'disabled' ) ) {
-				disablePages.style.display = 'block';
-			} else {
-				disablePages.style.display = 'none';
+		document.dispatchEvent( new Event( 'performAssetsManagerFilterRefresh' ) );
+	}
+
+	function syncExceptions( inputElement ) {
+		const options = inputElement.closest( '.perform-assets-manager-disable-assets' );
+		const exceptions = options ? options.querySelector( '.perform-assets-manager--exceptions' ) : null;
+
+		setHidden( exceptions, 'everywhere' !== inputElement.value || ! inputElement.checked );
+	}
+
+	function setupScannerFilters() {
+		const manager = document.getElementById( 'perform-assets-manager' );
+
+		if ( ! manager ) {
+			return;
+		}
+
+		const searchInput = manager.querySelector( '#perform-assets-manager-search' );
+		const filterButtons = manager.querySelectorAll( '[data-perform-filter]' );
+		const noResults = manager.querySelector( '.perform-assets-manager--no-results' );
+		const state = {
+			filter: 'all',
+			query: '',
+		};
+
+		function rowMatchesFilter( row ) {
+			if ( 'all' === state.filter ) {
+				return true;
 			}
-		} );
-	} );
 
-	Array.prototype.forEach.call( allDisableAssetsWrap, function( mainElement ) {
-		Array.prototype.forEach.call( mainElement.querySelectorAll( '.perform-disable-assets' ), function( inputElement ) {
-			inputElement.addEventListener( 'change', function() {
-				const showExceptions = mainElement.querySelector( '.perform-assets-manager--exceptions' );
+			if ( 'disabled' === state.filter ) {
+				return 'disabled' === row.dataset.performAssetStatus;
+			}
 
-				if ( 'everywhere' === this.value ) {
-					showExceptions.style.display = 'block';
-				} else {
-					showExceptions.style.display = 'none';
+			return state.filter === row.dataset.performAssetType || state.filter === row.dataset.performAssetSource;
+		}
+
+		function rowMatchesSearch( row ) {
+			if ( '' === state.query ) {
+				return true;
+			}
+
+			return row.textContent.toLowerCase().indexOf( state.query ) !== -1;
+		}
+
+		function applyFilters() {
+			let visibleRows = 0;
+
+			manager.querySelectorAll( '[data-perform-asset-row]' ).forEach( function ( row ) {
+				const isVisible = rowMatchesFilter( row ) && rowMatchesSearch( row );
+				setHidden( row, ! isVisible );
+
+				if ( isVisible ) {
+					visibleRows++;
 				}
 			} );
-		} );
-	} );
 
-	Array.prototype.forEach.call( allAssetsGroup, function( mainElement ) {
-		const titleElement = mainElement.querySelector( '.perform-assets-manager-group--title' );
+			manager.querySelectorAll( '[data-perform-group]' ).forEach( function ( group ) {
+				const visibleGroupRows = group.querySelectorAll( '[data-perform-asset-row]:not([hidden])' ).length;
+				setHidden( group, 0 === visibleGroupRows );
+			} );
 
-		if ( null !== titleElement ) {
-			const selectElement = titleElement.querySelector( '.perform-assets-manager-group--status' ).querySelector( '.perform-status-select' );
-			const assetOptionsElement = mainElement.querySelector( '.perform-assets-manager-disable-group-assets' );
-			const assetTableElement = mainElement.querySelector( 'table' );
+			manager.querySelectorAll( '[data-perform-section]' ).forEach( function ( section ) {
+				const visibleGroups = section.querySelectorAll( '[data-perform-group]:not([hidden])' ).length;
+				setHidden( section, 0 === visibleGroups );
+			} );
 
-			if ( 'disabled' === selectElement.value ) {
-				assetOptionsElement.style.display = 'block';
-				assetTableElement.style.display = 'none';
-			}
+			setHidden( noResults, visibleRows > 0 );
+		}
 
-			selectElement.addEventListener( 'change', function() {
-				if ( 'enabled' === this.value ) {
-					assetOptionsElement.style.display = 'none';
-					assetTableElement.style.display = 'table';
-				} else {
-					assetOptionsElement.style.display = 'block';
-					assetTableElement.style.display = 'none';
-				}
+		if ( searchInput ) {
+			searchInput.addEventListener( 'input', function () {
+				state.query = searchInput.value.trim().toLowerCase();
+				applyFilters();
 			} );
 		}
+
+		filterButtons.forEach( function ( button ) {
+			button.addEventListener( 'click', function () {
+				state.filter = button.dataset.performFilter;
+
+				filterButtons.forEach( function ( filterButton ) {
+					const isActive = filterButton === button;
+					filterButton.classList.toggle( 'is-active', isActive );
+					filterButton.setAttribute( 'aria-pressed', isActive ? 'true' : 'false' );
+				} );
+
+				applyFilters();
+			} );
+		} );
+
+		document.addEventListener( 'performAssetsManagerFilterRefresh', applyFilters );
+		applyFilters();
+	}
+
+	document.addEventListener( 'DOMContentLoaded', function () {
+		document.querySelectorAll( '[data-perform-asset-row]' ).forEach( function ( row ) {
+			row.dataset.performOwnStatus = row.dataset.performAssetStatus || 'enabled';
+		} );
+
+		document.querySelectorAll( '.perform-status-select' ).forEach( function ( selectElement ) {
+			const isGroupSelect = Boolean( selectElement.closest( '.perform-assets-manager-group--status' ) );
+
+			if ( isGroupSelect ) {
+				syncGroupStatus( selectElement );
+			} else {
+				syncAssetStatus( selectElement );
+			}
+
+			selectElement.addEventListener( 'change', function () {
+				if ( isGroupSelect ) {
+					syncGroupStatus( selectElement );
+				} else {
+					syncAssetStatus( selectElement );
+				}
+			} );
+		} );
+
+		document.querySelectorAll( '.perform-disable-assets' ).forEach( function ( inputElement ) {
+			if ( inputElement.checked ) {
+				syncExceptions( inputElement );
+			}
+
+			inputElement.addEventListener( 'change', function () {
+				syncExceptions( inputElement );
+			} );
+		} );
+
+		setupScannerFilters();
 	} );
-} );
+} )();

--- a/assets/src/js/frontend/main.js
+++ b/assets/src/js/frontend/main.js
@@ -1,12 +1,164 @@
-( function () {
-	function setHidden( element, hidden ) {
-		if ( ! element ) {
-			return;
-		}
+import {Button, SearchControl} from '@wordpress/components';
+import {render, useEffect, useMemo, useState} from '@wordpress/element';
 
-		element.hidden = hidden;
+const DEFAULT_CONTROL_LABELS = {
+	search: 'Search detected assets',
+	searchPlaceholder: 'Search by handle, source, or file URL',
+	filters: 'Filter detected assets',
+	all: 'All',
+	plugins: 'Plugins',
+	themes: 'Themes',
+	misc: 'Other',
+	js: 'JS',
+	css: 'CSS',
+	disabled: 'Disabled',
+};
+
+const SCANNER_FILTERS = [
+	{value: 'all', labelKey: 'all'},
+	{value: 'plugins', labelKey: 'plugins'},
+	{value: 'themes', labelKey: 'themes'},
+	{value: 'misc', labelKey: 'misc'},
+	{value: 'js', labelKey: 'js'},
+	{value: 'css', labelKey: 'css'},
+	{value: 'disabled', labelKey: 'disabled'},
+];
+
+function setHidden( element, hidden ) {
+	if ( ! element ) {
+		return;
 	}
 
+	element.hidden = hidden;
+}
+
+function getControlLabels( root ) {
+	if ( ! root || ! root.dataset.labels ) {
+		return DEFAULT_CONTROL_LABELS;
+	}
+
+	try {
+		return {
+			...DEFAULT_CONTROL_LABELS,
+			...JSON.parse( root.dataset.labels ),
+		};
+	} catch ( error ) {
+		return DEFAULT_CONTROL_LABELS;
+	}
+}
+
+function rowMatchesFilter( row, filter ) {
+	if ( 'all' === filter ) {
+		return true;
+	}
+
+	if ( 'disabled' === filter ) {
+		return 'disabled' === row.dataset.performAssetStatus;
+	}
+
+	return filter === row.dataset.performAssetType || filter === row.dataset.performAssetSource;
+}
+
+function rowMatchesSearch( row, query ) {
+	if ( '' === query ) {
+		return true;
+	}
+
+	return row.textContent.toLowerCase().indexOf( query ) !== -1;
+}
+
+function applyScannerFilters( manager, filter, query ) {
+	const noResults = manager.querySelector( '.perform-assets-manager--no-results' );
+	const normalizedQuery = query.trim().toLowerCase();
+	let visibleRows = 0;
+
+	manager.querySelectorAll( '[data-perform-asset-row]' ).forEach( function ( row ) {
+		const isVisible = rowMatchesFilter( row, filter ) && rowMatchesSearch( row, normalizedQuery );
+		setHidden( row, ! isVisible );
+
+		if ( isVisible ) {
+			visibleRows++;
+		}
+	} );
+
+	manager.querySelectorAll( '[data-perform-group]' ).forEach( function ( group ) {
+		const visibleGroupRows = group.querySelectorAll( '[data-perform-asset-row]:not([hidden])' ).length;
+		setHidden( group, 0 === visibleGroupRows );
+	} );
+
+	manager.querySelectorAll( '[data-perform-section]' ).forEach( function ( section ) {
+		const visibleGroups = section.querySelectorAll( '[data-perform-group]:not([hidden])' ).length;
+		setHidden( section, 0 === visibleGroups );
+	} );
+
+	setHidden( noResults, visibleRows > 0 );
+}
+
+function AssetsManagerControls( {manager, labels} ) {
+	const [ filter, setFilter ] = useState( 'all' );
+	const [ query, setQuery ] = useState( '' );
+	const filters = useMemo(
+		() =>
+			SCANNER_FILTERS.map( ( item ) => ( {
+				...item,
+				label: labels[ item.labelKey ],
+			} ) ),
+		[ labels ]
+	);
+
+	useEffect( () => {
+		const refreshFilters = () => applyScannerFilters( manager, filter, query );
+
+		refreshFilters();
+		document.addEventListener( 'performAssetsManagerFilterRefresh', refreshFilters );
+
+		return () => {
+			document.removeEventListener( 'performAssetsManagerFilterRefresh', refreshFilters );
+		};
+	}, [ manager, filter, query ] );
+
+	return (
+		<div className="perform-assets-manager--controls">
+			<SearchControl
+				className="perform-assets-manager--search"
+				hideLabelFromVision
+				label={ labels.search }
+				onChange={ ( nextQuery = '' ) => setQuery( nextQuery ) }
+				placeholder={ labels.searchPlaceholder }
+				value={ query }
+			/>
+			<div className="perform-assets-manager--filters" aria-label={ labels.filters }>
+				{ filters.map( ( {value, label} ) => {
+					const isActive = value === filter;
+
+					return (
+						<Button
+							key={ value }
+							aria-pressed={ isActive }
+							className="perform-assets-manager--filter"
+							onClick={ () => setFilter( value ) }
+							variant={ isActive ? 'primary' : 'secondary' }
+						>
+							{ label }
+						</Button>
+					);
+				} ) }
+			</div>
+		</div>
+	);
+}
+
+function mountScannerControls( manager ) {
+	const root = manager.querySelector( '#perform-assets-manager-controls-root' );
+
+	if ( ! root ) {
+		return;
+	}
+
+	render( <AssetsManagerControls manager={ manager } labels={ getControlLabels( root ) } />, root );
+}
+
+( function () {
 	function syncAssetStatus( selectElement ) {
 		const isDisabled = 'disabled' === selectElement.value;
 		const statusCell = selectElement.closest( '.perform-assets-manager--status' );
@@ -55,92 +207,9 @@
 		setHidden( exceptions, 'everywhere' !== inputElement.value || ! inputElement.checked );
 	}
 
-	function setupScannerFilters() {
+	document.addEventListener( 'DOMContentLoaded', function () {
 		const manager = document.getElementById( 'perform-assets-manager' );
 
-		if ( ! manager ) {
-			return;
-		}
-
-		const searchInput = manager.querySelector( '#perform-assets-manager-search' );
-		const filterButtons = manager.querySelectorAll( '[data-perform-filter]' );
-		const noResults = manager.querySelector( '.perform-assets-manager--no-results' );
-		const state = {
-			filter: 'all',
-			query: '',
-		};
-
-		function rowMatchesFilter( row ) {
-			if ( 'all' === state.filter ) {
-				return true;
-			}
-
-			if ( 'disabled' === state.filter ) {
-				return 'disabled' === row.dataset.performAssetStatus;
-			}
-
-			return state.filter === row.dataset.performAssetType || state.filter === row.dataset.performAssetSource;
-		}
-
-		function rowMatchesSearch( row ) {
-			if ( '' === state.query ) {
-				return true;
-			}
-
-			return row.textContent.toLowerCase().indexOf( state.query ) !== -1;
-		}
-
-		function applyFilters() {
-			let visibleRows = 0;
-
-			manager.querySelectorAll( '[data-perform-asset-row]' ).forEach( function ( row ) {
-				const isVisible = rowMatchesFilter( row ) && rowMatchesSearch( row );
-				setHidden( row, ! isVisible );
-
-				if ( isVisible ) {
-					visibleRows++;
-				}
-			} );
-
-			manager.querySelectorAll( '[data-perform-group]' ).forEach( function ( group ) {
-				const visibleGroupRows = group.querySelectorAll( '[data-perform-asset-row]:not([hidden])' ).length;
-				setHidden( group, 0 === visibleGroupRows );
-			} );
-
-			manager.querySelectorAll( '[data-perform-section]' ).forEach( function ( section ) {
-				const visibleGroups = section.querySelectorAll( '[data-perform-group]:not([hidden])' ).length;
-				setHidden( section, 0 === visibleGroups );
-			} );
-
-			setHidden( noResults, visibleRows > 0 );
-		}
-
-		if ( searchInput ) {
-			searchInput.addEventListener( 'input', function () {
-				state.query = searchInput.value.trim().toLowerCase();
-				applyFilters();
-			} );
-		}
-
-		filterButtons.forEach( function ( button ) {
-			button.addEventListener( 'click', function () {
-				state.filter = button.dataset.performFilter;
-
-				filterButtons.forEach( function ( filterButton ) {
-					const isActive = filterButton === button;
-					filterButton.classList.toggle( 'is-active', isActive );
-					filterButton.setAttribute( 'aria-pressed', isActive ? 'true' : 'false' );
-				} );
-
-				applyFilters();
-			} );
-		} );
-
-		document.addEventListener( 'performAssetsManagerFilterRefresh', applyFilters );
-		applyFilters();
-	}
-
-	document.addEventListener( 'DOMContentLoaded', function () {
 		document.querySelectorAll( '[data-perform-asset-row]' ).forEach( function ( row ) {
 			row.dataset.performOwnStatus = row.dataset.performAssetStatus || 'enabled';
 		} );
@@ -173,6 +242,8 @@
 			} );
 		} );
 
-		setupScannerFilters();
+		if ( manager ) {
+			mountScannerControls( manager );
+		}
 	} );
 } )();

--- a/languages/perform.pot
+++ b/languages/perform.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: PerformWP <hello@performwp.com>\n"
-"POT-Creation-Date: 2026-05-15 15:00+0000\n"
+"POT-Creation-Date: 2026-05-15 15:29+0000\n"
 "Report-Msgid-Bugs-To: https://github.com/performwp/perform/issues/new\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
@@ -20,11 +20,11 @@ msgstr ""
 msgid "Close Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:102, src/Modules/Assets/AssetsManager.php:129
+#: src/Admin/Actions.php:102, src/Modules/Assets/AssetsManager.php:141
 msgid "Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:111, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:112
+#: src/Admin/Actions.php:111, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:124
 msgid "Perform"
 msgstr ""
 
@@ -576,162 +576,162 @@ msgstr ""
 msgid "Settings saved successfully."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:114
-msgid "Page asset scanner"
-msgstr ""
-
-#: src/Modules/Assets/AssetsManager.php:115
-msgid "Perform Assets Manager"
-msgstr ""
-
-#: src/Modules/Assets/AssetsManager.php:119
-msgid "Close"
-msgstr ""
-
-#: src/Modules/Assets/AssetsManager.php:120
-msgid "Save changes"
-msgstr ""
-
-#: src/Modules/Assets/AssetsManager.php:126
-msgid "Current page"
-msgstr ""
-
-#: src/Modules/Assets/AssetsManager.php:132
-msgid "Review scripts and styles detected on this page, then disable only the assets you have verified are not needed."
-msgstr ""
-
-#: src/Modules/Assets/AssetsManager.php:136
-msgid "Asset scan summary"
-msgstr ""
-
-#: src/Modules/Assets/AssetsManager.php:139
-msgid "Detected assets"
-msgstr ""
-
-#: src/Modules/Assets/AssetsManager.php:143
-msgid "JavaScript"
-msgstr ""
-
-#: src/Modules/Assets/AssetsManager.php:147, src/Modules/Assets/AssetsManager.php:168
-msgid "CSS"
-msgstr ""
-
-#: src/Modules/Assets/AssetsManager.php:151
-msgid "Disabled rules"
-msgstr ""
-
-#: src/Modules/Assets/AssetsManager.php:155
-msgid "Known file size"
-msgstr ""
-
-#: src/Modules/Assets/AssetsManager.php:160
+#: src/Modules/Assets/AssetsManager.php:103
 msgid "Search detected assets"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:161
+#: src/Modules/Assets/AssetsManager.php:104
 msgid "Search by handle, source, or file URL"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:162
+#: src/Modules/Assets/AssetsManager.php:105
 msgid "Filter detected assets"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:163
+#: src/Modules/Assets/AssetsManager.php:106
 msgid "All"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:164
+#: src/Modules/Assets/AssetsManager.php:107
 msgid "Plugins"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:165
+#: src/Modules/Assets/AssetsManager.php:108
 msgid "Themes"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:166, src/Modules/Assets/AssetsManager.php:487
+#: src/Modules/Assets/AssetsManager.php:109, src/Modules/Assets/AssetsManager.php:493
 msgid "Other"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:167
+#: src/Modules/Assets/AssetsManager.php:110
 msgid "JS"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:169
+#: src/Modules/Assets/AssetsManager.php:111, src/Modules/Assets/AssetsManager.php:159
+msgid "CSS"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:112
 msgid "Disabled"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:198
+#: src/Modules/Assets/AssetsManager.php:126
+msgid "Page asset scanner"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:127
+msgid "Perform Assets Manager"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:131
+msgid "Close"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:132
+msgid "Save changes"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:138
+msgid "Current page"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:144
+msgid "Review scripts and styles detected on this page, then disable only the assets you have verified are not needed."
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:148
+msgid "Asset scan summary"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:151
+msgid "Detected assets"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:155
+msgid "JavaScript"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:163
+msgid "Disabled rules"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:167
+msgid "Known file size"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:204
 msgid "No assets match the current scan filter."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:488
+#: src/Modules/Assets/AssetsManager.php:494
 msgid "WordPress core, CDN, and uncategorized assets"
 msgstr ""
 
 #. translators: %d: number of assets.
-#: src/Modules/Assets/AssetsManager.php:493, src/Modules/Assets/AssetsManager.php:472
+#: src/Modules/Assets/AssetsManager.php:499, src/Modules/Assets/AssetsManager.php:478
 msgid "%d detected asset"
 msgid_plural "%d detected assets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Modules/Assets/AssetsManager.php:507
+#: src/Modules/Assets/AssetsManager.php:513
 msgid "Handle"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:510
+#: src/Modules/Assets/AssetsManager.php:516
 msgid "Type"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:513
+#: src/Modules/Assets/AssetsManager.php:519
 msgid "Size"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:516
+#: src/Modules/Assets/AssetsManager.php:522
 msgid "Status"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:519
+#: src/Modules/Assets/AssetsManager.php:525
 msgid "Actions"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:577
+#: src/Modules/Assets/AssetsManager.php:583
 msgid "External"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:585
+#: src/Modules/Assets/AssetsManager.php:591
 msgid "View File"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:632
+#: src/Modules/Assets/AssetsManager.php:638
 msgid "All assets in this group have been disabled. Enable the group again to manage individual assets."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:653, src/Modules/Assets/AssetsManager.php:743
+#: src/Modules/Assets/AssetsManager.php:659, src/Modules/Assets/AssetsManager.php:749
 msgid "Current URL"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:654
+#: src/Modules/Assets/AssetsManager.php:660
 msgid "Everywhere"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:659
+#: src/Modules/Assets/AssetsManager.php:665
 msgid "Disable on"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:705
+#: src/Modules/Assets/AssetsManager.php:711
 msgid "Asset loading status"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:707
+#: src/Modules/Assets/AssetsManager.php:713
 msgid "ON"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:710
+#: src/Modules/Assets/AssetsManager.php:716
 msgid "OFF"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:736
+#: src/Modules/Assets/AssetsManager.php:742
 msgid "Exceptions"
 msgstr ""
 

--- a/languages/perform.pot
+++ b/languages/perform.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: PerformWP <hello@performwp.com>\n"
-"POT-Creation-Date: 2026-04-17 06:06+0000\n"
+"POT-Creation-Date: 2026-05-15 15:00+0000\n"
 "Report-Msgid-Bugs-To: https://github.com/performwp/perform/issues/new\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
@@ -20,11 +20,11 @@ msgstr ""
 msgid "Close Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:102, src/Modules/Assets/AssetsManager.php:116
+#: src/Admin/Actions.php:102, src/Modules/Assets/AssetsManager.php:129
 msgid "Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:111, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:107
+#: src/Admin/Actions.php:111, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:112
 msgid "Perform"
 msgstr ""
 
@@ -576,63 +576,162 @@ msgstr ""
 msgid "Settings saved successfully."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:110
-msgid "Save"
+#: src/Modules/Assets/AssetsManager.php:114
+msgid "Page asset scanner"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:115
+msgid "Perform Assets Manager"
 msgstr ""
 
 #: src/Modules/Assets/AssetsManager.php:119
-msgid "Offload unnecessary assets (JS and CSS) from this page."
+msgid "Close"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:300
+#: src/Modules/Assets/AssetsManager.php:120
+msgid "Save changes"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:126
+msgid "Current page"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:132
+msgid "Review scripts and styles detected on this page, then disable only the assets you have verified are not needed."
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:136
+msgid "Asset scan summary"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:139
+msgid "Detected assets"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:143
+msgid "JavaScript"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:147, src/Modules/Assets/AssetsManager.php:168
+msgid "CSS"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:151
+msgid "Disabled rules"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:155
+msgid "Known file size"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:160
+msgid "Search detected assets"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:161
+msgid "Search by handle, source, or file URL"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:162
+msgid "Filter detected assets"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:163
+msgid "All"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:164
+msgid "Plugins"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:165
+msgid "Themes"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:166, src/Modules/Assets/AssetsManager.php:487
+msgid "Other"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:167
+msgid "JS"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:169
+msgid "Disabled"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:198
+msgid "No assets match the current scan filter."
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:488
+msgid "WordPress core, CDN, and uncategorized assets"
+msgstr ""
+
+#. translators: %d: number of assets.
+#: src/Modules/Assets/AssetsManager.php:493, src/Modules/Assets/AssetsManager.php:472
+msgid "%d detected asset"
+msgid_plural "%d detected assets"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Modules/Assets/AssetsManager.php:507
 msgid "Handle"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:303
+#: src/Modules/Assets/AssetsManager.php:510
 msgid "Type"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:306
+#: src/Modules/Assets/AssetsManager.php:513
 msgid "Size"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:309
+#: src/Modules/Assets/AssetsManager.php:516
 msgid "Status"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:312
+#: src/Modules/Assets/AssetsManager.php:519
 msgid "Actions"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:373
+#: src/Modules/Assets/AssetsManager.php:577
+msgid "External"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:585
 msgid "View File"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:421
-msgid "All assets in this group have been disabled. Please enable the group to individually manager assets."
+#: src/Modules/Assets/AssetsManager.php:632
+msgid "All assets in this group have been disabled. Enable the group again to manage individual assets."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:442, src/Modules/Assets/AssetsManager.php:531
+#: src/Modules/Assets/AssetsManager.php:653, src/Modules/Assets/AssetsManager.php:743
 msgid "Current URL"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:443
+#: src/Modules/Assets/AssetsManager.php:654
 msgid "Everywhere"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:448
+#: src/Modules/Assets/AssetsManager.php:659
 msgid "Disable on"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:494
+#: src/Modules/Assets/AssetsManager.php:705
+msgid "Asset loading status"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:707
 msgid "ON"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:497
+#: src/Modules/Assets/AssetsManager.php:710
 msgid "OFF"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:524
+#: src/Modules/Assets/AssetsManager.php:736
 msgid "Exceptions"
 msgstr ""
 

--- a/src/Includes/Actions.php
+++ b/src/Includes/Actions.php
@@ -42,7 +42,8 @@ class Actions {
 			return;
 		}
 
-		wp_enqueue_style( 'perform', PERFORM_PLUGIN_URL . 'assets/dist/css/perform.css' );
+		wp_enqueue_style( 'wp-components' );
+		wp_enqueue_style( 'perform', PERFORM_PLUGIN_URL . 'assets/dist/css/perform.css', [ 'wp-components' ], PERFORM_VERSION );
 	}
 
 	/**
@@ -60,6 +61,6 @@ class Actions {
 			return;
 		}
 
-		wp_enqueue_script( 'perform', PERFORM_PLUGIN_URL . 'assets/dist/js/perform.min.js', '', PERFORM_VERSION, false );
+		wp_enqueue_script( 'perform', PERFORM_PLUGIN_URL . 'assets/dist/js/perform.min.js', [ 'wp-components', 'wp-element', 'wp-i18n' ], PERFORM_VERSION, false );
 	}
 }

--- a/src/Modules/Assets/AssetsManager.php
+++ b/src/Modules/Assets/AssetsManager.php
@@ -97,9 +97,21 @@ class AssetsManager implements ModuleInterface {
 	 * @return mixed
 	 */
 	public function assets_manager_html() {
-		$assets_list = $this->prepare_assets_list();
-		$summary     = $this->get_assets_summary( $assets_list );
-		$current_url = get_permalink();
+		$assets_list              = $this->prepare_assets_list();
+		$summary                  = $this->get_assets_summary( $assets_list );
+		$scanner_controls_labels  = [
+			'search'            => __( 'Search detected assets', 'perform' ),
+			'searchPlaceholder' => __( 'Search by handle, source, or file URL', 'perform' ),
+			'filters'           => __( 'Filter detected assets', 'perform' ),
+			'all'               => __( 'All', 'perform' ),
+			'plugins'           => __( 'Plugins', 'perform' ),
+			'themes'            => __( 'Themes', 'perform' ),
+			'misc'              => __( 'Other', 'perform' ),
+			'js'                => __( 'JS', 'perform' ),
+			'css'               => __( 'CSS', 'perform' ),
+			'disabled'          => __( 'Disabled', 'perform' ),
+		];
+		$current_url              = get_permalink();
 		if ( empty( $current_url ) ) {
 			$current_url = home_url( add_query_arg( [] ) );
 		}
@@ -157,17 +169,11 @@ class AssetsManager implements ModuleInterface {
 							</div>
 						</div>
 						<div class="perform-assets-manager--toolbar">
-							<label class="screen-reader-text" for="perform-assets-manager-search"><?php esc_html_e( 'Search detected assets', 'perform' ); ?></label>
-							<input id="perform-assets-manager-search" type="search" placeholder="<?php esc_attr_e( 'Search by handle, source, or file URL', 'perform' ); ?>" />
-							<div class="perform-assets-manager--filters" aria-label="<?php esc_attr_e( 'Filter detected assets', 'perform' ); ?>">
-								<button type="button" class="is-active" data-perform-filter="all" aria-pressed="true"><?php esc_html_e( 'All', 'perform' ); ?></button>
-								<button type="button" data-perform-filter="plugins" aria-pressed="false"><?php esc_html_e( 'Plugins', 'perform' ); ?></button>
-								<button type="button" data-perform-filter="themes" aria-pressed="false"><?php esc_html_e( 'Themes', 'perform' ); ?></button>
-								<button type="button" data-perform-filter="misc" aria-pressed="false"><?php esc_html_e( 'Other', 'perform' ); ?></button>
-								<button type="button" data-perform-filter="js" aria-pressed="false"><?php esc_html_e( 'JS', 'perform' ); ?></button>
-								<button type="button" data-perform-filter="css" aria-pressed="false"><?php esc_html_e( 'CSS', 'perform' ); ?></button>
-								<button type="button" data-perform-filter="disabled" aria-pressed="false"><?php esc_html_e( 'Disabled', 'perform' ); ?></button>
-							</div>
+							<div
+								id="perform-assets-manager-controls-root"
+								class="perform-assets-manager--controls-root"
+								data-labels="<?php echo esc_attr( wp_json_encode( $scanner_controls_labels ) ); ?>"
+							></div>
 						</div>
 					</div>
 						<?php

--- a/src/Modules/Assets/AssetsManager.php
+++ b/src/Modules/Assets/AssetsManager.php
@@ -98,32 +98,83 @@ class AssetsManager implements ModuleInterface {
 	 */
 	public function assets_manager_html() {
 		$assets_list = $this->prepare_assets_list();
+		$summary     = $this->get_assets_summary( $assets_list );
+		$current_url = get_permalink();
+		if ( empty( $current_url ) ) {
+			$current_url = home_url( add_query_arg( [] ) );
+		}
 		?>
-		<div id="perform-assets-manager" class="perform-assets-manager">
+		<div id="perform-assets-manager" class="perform-assets-manager" role="dialog" aria-modal="true" aria-labelledby="perform-assets-manager-title">
 			<form id="perform-assets-manager--form" method="POST">
 				<?php wp_nonce_field( 'perform_assets_manager_save', 'perform_assets_manager_nonce' ); ?>
 				<div class="perform-assets-manager--header">
-					<div class="perform-assets-manager--logo">
-						<img src="<?php echo esc_url( PERFORM_PLUGIN_URL . 'assets/dist/images/logo.png' ); ?>" alt="<?php esc_html_e( 'Perform', 'perform' ); ?>" />
+					<div class="perform-assets-manager--brand">
+						<img src="<?php echo esc_url( PERFORM_PLUGIN_URL . 'assets/dist/images/logo.png' ); ?>" alt="<?php esc_attr_e( 'Perform', 'perform' ); ?>" />
+						<div>
+							<span><?php esc_html_e( 'Page asset scanner', 'perform' ); ?></span>
+							<strong><?php esc_html_e( 'Perform Assets Manager', 'perform' ); ?></strong>
+						</div>
 					</div>
 					<div class="perform-assets-manager-header-actions">
-						<input type="submit" name="perform_assets_manager" value="<?php esc_html_e( 'Save', 'perform' ); ?>" />
+						<a class="perform-assets-manager-button perform-assets-manager-button--secondary" href="<?php echo esc_url( remove_query_arg( 'perform' ) ); ?>"><?php esc_html_e( 'Close', 'perform' ); ?></a>
+						<input class="perform-assets-manager-button perform-assets-manager-button--primary" type="submit" name="perform_assets_manager" value="<?php esc_attr_e( 'Save changes', 'perform' ); ?>" />
 					</div>
 				</div>
 				<div id="perform-assets-manager--main">
 					<div class='perform-assets-manager--title'>
-						<h3>
-							<?php esc_html_e( 'Assets Manager', 'perform' ); ?>
-						</h3>
-						<p>
-							<?php esc_html_e( 'Offload unnecessary assets (JS and CSS) from this page.', 'perform' ); ?>
+						<p class="perform-assets-manager--eyebrow">
+							<?php esc_html_e( 'Current page', 'perform' ); ?>
 						</p>
+						<h2 id="perform-assets-manager-title">
+							<?php esc_html_e( 'Assets Manager', 'perform' ); ?>
+						</h2>
+						<p>
+							<?php esc_html_e( 'Review scripts and styles detected on this page, then disable only the assets you have verified are not needed.', 'perform' ); ?>
+						</p>
+						<code><?php echo esc_html( $current_url ); ?></code>
+					</div>
+					<div class="perform-assets-manager--scanner" aria-label="<?php esc_attr_e( 'Asset scan summary', 'perform' ); ?>">
+						<div class="perform-assets-manager--summary-grid">
+							<div class="perform-assets-manager--summary-card">
+								<span><?php esc_html_e( 'Detected assets', 'perform' ); ?></span>
+								<strong><?php echo esc_html( (string) $summary['total'] ); ?></strong>
+							</div>
+							<div class="perform-assets-manager--summary-card">
+								<span><?php esc_html_e( 'JavaScript', 'perform' ); ?></span>
+								<strong><?php echo esc_html( (string) $summary['js'] ); ?></strong>
+							</div>
+							<div class="perform-assets-manager--summary-card">
+								<span><?php esc_html_e( 'CSS', 'perform' ); ?></span>
+								<strong><?php echo esc_html( (string) $summary['css'] ); ?></strong>
+							</div>
+							<div class="perform-assets-manager--summary-card">
+								<span><?php esc_html_e( 'Disabled rules', 'perform' ); ?></span>
+								<strong><?php echo esc_html( (string) $summary['disabled'] ); ?></strong>
+							</div>
+							<div class="perform-assets-manager--summary-card">
+								<span><?php esc_html_e( 'Known file size', 'perform' ); ?></span>
+								<strong><?php echo esc_html( $this->format_asset_size( $summary['size'] ) ); ?></strong>
+							</div>
+						</div>
+						<div class="perform-assets-manager--toolbar">
+							<label class="screen-reader-text" for="perform-assets-manager-search"><?php esc_html_e( 'Search detected assets', 'perform' ); ?></label>
+							<input id="perform-assets-manager-search" type="search" placeholder="<?php esc_attr_e( 'Search by handle, source, or file URL', 'perform' ); ?>" />
+							<div class="perform-assets-manager--filters" aria-label="<?php esc_attr_e( 'Filter detected assets', 'perform' ); ?>">
+								<button type="button" class="is-active" data-perform-filter="all" aria-pressed="true"><?php esc_html_e( 'All', 'perform' ); ?></button>
+								<button type="button" data-perform-filter="plugins" aria-pressed="false"><?php esc_html_e( 'Plugins', 'perform' ); ?></button>
+								<button type="button" data-perform-filter="themes" aria-pressed="false"><?php esc_html_e( 'Themes', 'perform' ); ?></button>
+								<button type="button" data-perform-filter="misc" aria-pressed="false"><?php esc_html_e( 'Other', 'perform' ); ?></button>
+								<button type="button" data-perform-filter="js" aria-pressed="false"><?php esc_html_e( 'JS', 'perform' ); ?></button>
+								<button type="button" data-perform-filter="css" aria-pressed="false"><?php esc_html_e( 'CSS', 'perform' ); ?></button>
+								<button type="button" data-perform-filter="disabled" aria-pressed="false"><?php esc_html_e( 'Disabled', 'perform' ); ?></button>
+							</div>
+						</div>
 					</div>
 						<?php
 						foreach ( $assets_list as $category => $groups ) {
 							if ( ! empty( $groups ) ) {
 								?>
-								<div class="perform-assets-manager--section">
+								<div class="perform-assets-manager--section" data-perform-section="<?php echo esc_attr( $category ); ?>">
 									<h3><?php echo esc_html( ucwords( $category ) ); ?></h3>
 									<?php
 										if ( 'misc' !== $category ) {
@@ -144,6 +195,7 @@ class AssetsManager implements ModuleInterface {
 							}
 						}
 						?>
+						<p class="perform-assets-manager--no-results" hidden><?php esc_html_e( 'No assets match the current scan filter.', 'perform' ); ?></p>
 				</div>
 				<div id="perform-assets-manager--footer">
 				</div>
@@ -267,6 +319,130 @@ class AssetsManager implements ModuleInterface {
 	}
 
 	/**
+	 * Build scan summary data for the current page.
+	 *
+	 * @param array $assets_list Grouped assets list.
+	 *
+	 * @return array
+	 */
+	private function get_assets_summary( $assets_list ) {
+		$summary = [
+			'total'    => 0,
+			'js'       => 0,
+			'css'      => 0,
+			'disabled' => 0,
+			'size'     => 0,
+		];
+
+		foreach ( $assets_list as $category => $groups ) {
+			$groups = 'misc' === $category ? [ 'misc' => [ 'assets' => $groups ] ] : $groups;
+
+			foreach ( $groups as $group => $details ) {
+				if ( empty( $details['assets'] ) || ! is_array( $details['assets'] ) ) {
+					continue;
+				}
+
+				foreach ( $details['assets'] as $asset ) {
+					if ( empty( $asset['type'] ) || empty( $asset['handle'] ) ) {
+						continue;
+					}
+
+					$type   = $asset['type'];
+					$handle = $asset['handle'];
+					$src    = $this->get_asset_src( $type, $handle );
+
+					if ( empty( $src ) ) {
+						continue;
+					}
+
+					$summary['total']++;
+					if ( isset( $summary[ $type ] ) ) {
+						$summary[ $type ]++;
+					}
+
+					if ( $this->is_rule_disabled( $type, $handle ) || ( 'misc' !== $category && $this->is_rule_disabled( $category, $group ) ) ) {
+						$summary['disabled']++;
+					}
+
+					$summary['size'] += $this->get_asset_size( $src );
+				}
+			}
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Format bytes for scanner display.
+	 *
+	 * @param int $bytes File size in bytes.
+	 *
+	 * @return string
+	 */
+	private function format_asset_size( $bytes ) {
+		$bytes = (int) $bytes;
+		if ( $bytes <= 0 ) {
+			return '0 KB';
+		}
+
+		if ( $bytes >= 1048576 ) {
+			return round( $bytes / 1048576, 1 ) . ' MB';
+		}
+
+		return round( $bytes / 1024, 1 ) . ' KB';
+	}
+
+	/**
+	 * Get registered asset URL.
+	 *
+	 * @param string $type   Asset type.
+	 * @param string $handle Asset handle.
+	 *
+	 * @return string
+	 */
+	private function get_asset_src( $type, $handle ) {
+		if ( empty( $this->loaded_assets[ $type ]['scripts']->registered[ $handle ]->src ) ) {
+			return '';
+		}
+
+		return (string) $this->loaded_assets[ $type ]['scripts']->registered[ $handle ]->src;
+	}
+
+	/**
+	 * Get local file size for a registered asset when it can be resolved.
+	 *
+	 * @param string $src Asset source URL.
+	 *
+	 * @return int
+	 */
+	private function get_asset_size( $src ) {
+		$site_url = site_url( '/' );
+		if ( 0 !== strpos( $src, $site_url ) ) {
+			return 0;
+		}
+
+		$asset_path = ABSPATH . ltrim( str_replace( $site_url, '', $src ), '/' );
+		if ( ! file_exists( $asset_path ) ) {
+			return 0;
+		}
+
+		return (int) filesize( $asset_path );
+	}
+
+	/**
+	 * Check whether an asset or group has a disabled rule.
+	 *
+	 * @param string $type   Asset type or source category.
+	 * @param string $handle Asset handle or source group.
+	 *
+	 * @return bool
+	 */
+	private function is_rule_disabled( $type, $handle ) {
+		return ! empty( $this->selected_options['disabled'][ $type ][ $handle ] )
+			&& is_array( $this->selected_options['disabled'][ $type ][ $handle ] );
+	}
+
+	/**
 	 * This function is used to print section for assets manager.
 	 *
 	 * @param $category
@@ -279,21 +455,52 @@ class AssetsManager implements ModuleInterface {
 	 * @return mixed
 	 */
 	public function print_assets_manager_group( $category, $group, $asset_details ) {
+		$asset_count = ! empty( $asset_details['assets'] ) && is_array( $asset_details['assets'] ) ? count( $asset_details['assets'] ) : 0;
 		?>
-		<div class="perform-assets-manager--group">
+		<div class="perform-assets-manager--group" data-perform-group data-perform-source="<?php echo esc_attr( $category ); ?>">
 			<?php
 			if ( 'misc' !== $category ) {
 				?>
 				<div class="perform-assets-manager-group--title">
-					<h4><?php echo esc_html( $asset_details['name'] ); ?></h4>
+					<div>
+						<span class="perform-assets-manager--source-label"><?php echo esc_html( ucwords( $category ) ); ?></span>
+						<h4><?php echo esc_html( $asset_details['name'] ); ?></h4>
+						<p>
+							<?php
+							printf(
+								/* translators: %d: number of assets. */
+								esc_html( _n( '%d detected asset', '%d detected assets', $asset_count, 'perform' ) ),
+								(int) $asset_count
+							);
+							?>
+						</p>
+					</div>
 					<div class='perform-assets-manager-group--status'>
 						<?php $this->print_assets_manager_status( $category, $group ); ?>
 					</div>
 				</div>
 				<?php
+			} else {
+				?>
+				<div class="perform-assets-manager-group--title perform-assets-manager-group--title-misc">
+					<div>
+						<span class="perform-assets-manager--source-label"><?php esc_html_e( 'Other', 'perform' ); ?></span>
+						<h4><?php esc_html_e( 'WordPress core, CDN, and uncategorized assets', 'perform' ); ?></h4>
+						<p>
+							<?php
+							printf(
+								/* translators: %d: number of assets. */
+								esc_html( _n( '%d detected asset', '%d detected assets', $asset_count, 'perform' ) ),
+								(int) $asset_count
+							);
+							?>
+						</p>
+					</div>
+				</div>
+				<?php
 			}
 			?>
-			<table cellspacing="0" cellpadding="0">
+			<table cellspacing="0" cellpadding="0" class="perform-assets-manager--assets-table">
 				<thead>
 					<tr>
 						<th>
@@ -342,27 +549,32 @@ class AssetsManager implements ModuleInterface {
 	public function print_assets_manager_script( $category, $group, $script, $type ) {
 			$data   = $this->loaded_assets[ $type ];
 			$handle = $data['scripts']->registered[ $script ]->handle;
-			$src    = $data['scripts']->registered[ $script ]->src;
+			$src    = $this->get_asset_src( $type, $script );
 
 		if ( ! empty( $src ) ) {
+			$asset_size   = $this->get_asset_size( $src );
+			$is_disabled  = $this->is_rule_disabled( $type, $handle ) || ( 'misc' !== $category && $this->is_rule_disabled( $category, $group ) );
+			$asset_status = $is_disabled ? 'disabled' : 'enabled';
 			?>
-				<tr>
+				<tr data-perform-asset-row data-perform-asset-type="<?php echo esc_attr( $type ); ?>" data-perform-asset-source="<?php echo esc_attr( $category ); ?>" data-perform-asset-status="<?php echo esc_attr( $asset_status ); ?>" data-perform-asset-handle="<?php echo esc_attr( $handle ); ?>">
 					<td class="perform-assets-manager--handle">
-					<?php echo esc_html( $handle ); ?>
+						<strong><?php echo esc_html( $handle ); ?></strong>
+						<code><?php echo esc_html( $src ); ?></code>
 					</td>
 					<td class="perform-assets-manager--type">
 					<?php
 					if ( ! empty( $type ) ) {
-						echo esc_html( $type );
+						printf(
+							'<span class="perform-assets-manager--type-badge perform-assets-manager--type-badge-%1$s">%2$s</span>',
+							esc_attr( $type ),
+							esc_html( strtoupper( $type ) )
+						);
 					}
 					?>
 					</td>
 					<td class='perform-assets-manager--size'>
 					<?php
-					$asset_path = ABSPATH . str_replace( site_url( '/' ), '', $data['scripts']->registered[ $script ]->src );
-					if ( file_exists( $asset_path ) ) {
-						echo esc_html( round( filesize( $asset_path ) / 1024, 1 ) . ' KB' );
-					}
+					echo $asset_size > 0 ? esc_html( $this->format_asset_size( $asset_size ) ) : esc_html__( 'External', 'perform' );
 					?>
 					</td>
 					<td class='perform-assets-manager--status'>
@@ -394,9 +606,8 @@ class AssetsManager implements ModuleInterface {
 		$is_disabled_type   = isset( $this->selected_options['disabled'][ $type ] );
 		$is_disabled_handle = $is_disabled_type && isset( $this->selected_options['disabled'][ $type ][ $handle ] );
 		$is_selected        = $is_disabled_handle && is_array( $this->selected_options['disabled'][ $type ][ $handle ] ) ? 'selected="selected"' : '';
-		$show_options       = $is_selected ? 'display: block;' : 'display: none;';
 		?>
-		<div class="perform-assets-manager-disable-single-asset perform-assets-manager-disable-assets" style="<?php echo esc_html( $show_options ); ?>">
+		<div class="perform-assets-manager-disable-single-asset perform-assets-manager-disable-assets" <?php echo empty( $is_selected ) ? 'hidden' : ''; ?>>
 			<?php $this->disable_assets_html( $type, $handle ); ?>
 		</div>
 		<?php
@@ -415,10 +626,10 @@ class AssetsManager implements ModuleInterface {
 	 */
 	public function disable_group_assets_html( $type, $handle ) {
 		?>
-		<div class="perform-assets-manager-disable-group-assets perform-assets-manager-disable-assets" style="display: none;">
+		<div class="perform-assets-manager-disable-group-assets perform-assets-manager-disable-assets" hidden>
 			<?php $this->disable_assets_html( $type, $handle ); ?>
 			<p>
-				<?php esc_html_e( 'All assets in this group have been disabled. Please enable the group to individually manager assets.', 'perform' ); ?>
+				<?php esc_html_e( 'All assets in this group have been disabled. Enable the group again to manage individual assets.', 'perform' ); ?>
 			</p>
 		</div>
 		<?php
@@ -443,10 +654,11 @@ class AssetsManager implements ModuleInterface {
 			'everywhere' => esc_html__( 'Everywhere', 'perform' ),
 		];
 		?>
-		<div class="perform-assets-manager-disable-asset-option-selection">
-			<strong>
+		<fieldset class="perform-assets-manager-disable-asset-option-selection">
+			<legend>
 				<?php esc_html_e( 'Disable on', 'perform' ); ?>
-			</strong>
+			</legend>
+			<div class="perform-assets-manager--radio-group">
 			<?php
 			foreach ( $radio_inputs as $key => $value ) {
 				$is_disabled_key = isset( $this->selected_options['disabled'][ $type ][ $handle ][ $key ] ) ? $this->selected_options['disabled'][ $type ][ $handle ][ $key ] : false;
@@ -468,8 +680,9 @@ class AssetsManager implements ModuleInterface {
 				<?php
 			}
 			?>
+			</div>
 			<?php $this->print_assets_manager_exceptions( $type, $handle ); ?>
-		</div>
+		</fieldset>
 		<?php
 	}
 
@@ -489,7 +702,7 @@ class AssetsManager implements ModuleInterface {
 		$is_selected        = ( $is_disabled_handle && is_array( $this->selected_options['disabled'][ $type ][ $handle ] ) ) ? 'selected="selected"' : '';
 		$disable_class      = ! empty( $is_selected ) ? 'disabled' : '';
 		?>
-		<select name="status[<?php echo esc_attr( $type ); ?>][<?php echo esc_attr( $handle ); ?>]" class="perform-status-select <?php echo esc_attr( $disable_class ); ?>">
+		<select name="status[<?php echo esc_attr( $type ); ?>][<?php echo esc_attr( $handle ); ?>]" class="perform-status-select <?php echo esc_attr( $disable_class ); ?>" aria-label="<?php esc_attr_e( 'Asset loading status', 'perform' ); ?>">
 			<option value='enabled' class='perform-option-enabled'>
 				<?php echo esc_attr__( 'ON', 'perform' ); ?>
 			</option>
@@ -515,11 +728,10 @@ class AssetsManager implements ModuleInterface {
 		$current_id          = get_the_ID();
 		$selected_post_types = isset( $this->selected_options['enabled'][ $type ][ $handle ]['post_types'] ) ? $this->selected_options['enabled'][ $type ][ $handle ]['post_types'] : false;
 		$is_selected         = isset( $this->selected_options['disabled'][ $type ][ $handle ]['everywhere'] ) ? selected( $this->selected_options['disabled'][ $type ][ $handle ]['everywhere'], 1, false ) : '';
-		$show_options        = $is_selected ? 'display: block;' : 'display: none;';
 		$current_exception   = isset( $this->selected_options['enabled'][ $type ][ $handle ]['current'] ) ? $this->selected_options['enabled'][ $type ][ $handle ]['current'] : false;
 		$is_current_checked  = ( is_array( $current_exception ) && in_array( $current_id, $current_exception, true ) ) ? ' checked="checked"' : '';
 		?>
-		<div class="perform-assets-manager--exceptions" style="<?php echo esc_html( $show_options ); ?>">
+		<div class="perform-assets-manager--exceptions" <?php echo empty( $is_selected ) ? 'hidden' : ''; ?>>
 			<div class="perform-assets-manager-exceptions--title">
 				<?php esc_html_e( 'Exceptions', 'perform' ); ?>
 			</div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,11 @@ const config = {
 		perform: [ './assets/src/js/frontend/main.js', './assets/src/css/frontend/main.css'],
 		admin: [ './assets/src/css/admin/admin.css', './assets/src/js/admin/main.js'],
 	},
+	externals: {
+		...( defaultConfig.externals || {} ),
+		'@wordpress/components': 'wp.components',
+		'@wordpress/element': 'wp.element',
+	},
 	output: {
 		...defaultConfig.output,
 		path: path.join(__dirname, 'assets/dist/'),


### PR DESCRIPTION
## Summary
- Refactors the frontend Asset Manager overlay into a WordPress-style scanner workspace with a sticky action header, scan summary cards, search, and source/type/status filters.
- Renders the scanner search and filter controls with WordPress React components from `@wordpress/components` and `@wordpress/element`.
- Aligns the Asset Manager color palette with the Perform settings UI tokens, including the primary `#0046d1` and secondary `#c8d8ff` styling.
- Keeps the existing `perform_assets_manager_options` storage contract and save flow intact.
- Improves theme compatibility by scoping the overlay CSS, resetting inherited typography/control behavior inside the manager, and adding responsive asset rows for narrow screens.
- Externalizes WordPress package imports to core-provided `wp.components` and `wp.element` globals so the frontend bundle stays small.
- Refreshes the translation template for the new UI strings.

## Validation
- `php -l src/Modules/Assets/AssetsManager.php && php -l src/Includes/Actions.php`
- `composer check-cs -- src/Modules/Assets/AssetsManager.php`
- `git diff --check`
- `npx -p node@20 -c 'npm run lint:js -- assets/src/js/frontend/main.js && npm run build'`
- Local Studio frontend smoke: activated Perform, enabled Asset Manager, loaded `https://development.wp.local/?perform=1`, verified `wp.components`/`wp.element`, 34 detected asset rows, 7 React-rendered filter buttons, Perform color tokens, search empty-state behavior, and JS filter behavior.
- Local Studio mobile smoke at 390px viewport verified the manager is visible, asset rows switch to block layout, and controls collapse to one column.
- Local Studio save-flow smoke persisted `{disabled:{js:{react:{current:[0]}}}}`, then the test option was removed.
- Local Studio settings-page smoke verified the existing settings React UI still loads after build externalization.

## Notes
- `npm run lint:css -- assets/src/css/frontend/assets-manager.css` is still blocked by the existing missing `stylelint-config-wordpress` dependency; this is covered by the broader tooling modernization issue #86.
- Local Studio plugin activation/settings were restored after smoke testing.

Closes #18.
