### PR TITLE
Harden cache runtime writes

### DIFF
--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -249,15 +249,8 @@ class PageCache implements ModuleInterface {
 				return $html;
 			}
 
-			if ( http_response_code() >= 400 ) {
+			if ( ! $this->is_cacheable_response( $html ) ) {
 				return $html;
-			}
-
-			// Don't cache responses setting cookies.
-			foreach ( headers_list() as $header_line ) {
-				if ( 0 === stripos( $header_line, 'Set-Cookie:' ) ) {
-					return $html;
-				}
 			}
 
 			$ttl_seconds  = (int) Helpers::get_option( 'page_cache_ttl', 'perform_settings', 3600 );
@@ -270,8 +263,13 @@ class PageCache implements ModuleInterface {
 				'swr_expires' => $created + max( 120, $ttl_seconds + $swr_seconds ),
 			];
 
-			$this->write_cache_meta( $this->current_cache_key, $meta_payload );
-			$this->write_cache_body( $this->current_cache_key, $html );
+			if ( ! $this->write_cache_body( $this->current_cache_key, $html ) ) {
+				return $html;
+			}
+
+			if ( ! $this->write_cache_meta( $this->current_cache_key, $meta_payload ) ) {
+				wp_delete_file( $this->get_body_file_path( $this->current_cache_key ) );
+			}
 		} finally {
 			$this->release_lock();
 		}
@@ -892,6 +890,62 @@ class PageCache implements ModuleInterface {
 	}
 
 	/**
+	 * Whether the rendered response is safe to persist as a page-cache entry.
+	 *
+	 * @param string $html Rendered response body.
+	 *
+	 * @return bool
+	 */
+	private function is_cacheable_response( $html ) {
+		$current_status = http_response_code();
+		$status_code    = false === $current_status ? 200 : (int) $current_status;
+		if ( 200 !== $status_code ) {
+			return false;
+		}
+
+		$has_content_type = false;
+
+		foreach ( headers_list() as $header_line ) {
+			if ( 0 === stripos( $header_line, 'Set-Cookie:' ) ) {
+				return false;
+			}
+
+			if ( 0 === stripos( $header_line, 'Location:' ) ) {
+				return false;
+			}
+
+			if ( 0 === stripos( $header_line, 'Content-Type:' ) ) {
+				$has_content_type = true;
+
+				if ( false === stripos( $header_line, 'text/html' ) ) {
+					return false;
+				}
+			}
+		}
+
+		if ( ! $has_content_type && ! $this->looks_like_html_response( $html ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Lightweight fallback for hosts that have not sent Content-Type yet.
+	 *
+	 * @param string $html Rendered response body.
+	 *
+	 * @return bool
+	 */
+	private function looks_like_html_response( $html ) {
+		$body_start = ltrim( substr( $html, 0, 1024 ) );
+
+		return 0 === stripos( $body_start, '<!doctype html' )
+			|| 0 === stripos( $body_start, '<html' )
+			|| false !== stripos( $body_start, '<html' );
+	}
+
+	/**
 	 * Normalize current request URL.
 	 *
 	 * @return string
@@ -1040,11 +1094,17 @@ class PageCache implements ModuleInterface {
 	 * @param string                     $key Cache key.
 	 * @param array<string, int|string> $meta Metadata.
 	 *
-	 * @return void
+	 * @return bool
 	 */
 	private function write_cache_meta( $key, $meta ) {
-		$path = $this->get_meta_file_path( $key );
-		file_put_contents( $path, wp_json_encode( $meta ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$path     = $this->get_meta_file_path( $key );
+		$contents = wp_json_encode( $meta );
+
+		if ( ! is_string( $contents ) ) {
+			return false;
+		}
+
+		return $this->write_file_atomically( $path, $contents );
 	}
 
 	/**
@@ -1053,11 +1113,41 @@ class PageCache implements ModuleInterface {
 	 * @param string $key Cache key.
 	 * @param string $body Body.
 	 *
-	 * @return void
+	 * @return bool
 	 */
 	private function write_cache_body( $key, $body ) {
 		$path = $this->get_body_file_path( $key );
-		file_put_contents( $path, $body ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		return $this->write_file_atomically( $path, $body );
+	}
+
+	/**
+	 * Write cache file through a same-directory temp file and atomic rename.
+	 *
+	 * @param string $path Target file path.
+	 * @param string $contents File contents.
+	 *
+	 * @return bool
+	 */
+	private function write_file_atomically( $path, $contents ) {
+		$directory = dirname( $path );
+		if ( ! is_dir( $directory ) || ! is_writable( $directory ) ) {
+			return false;
+		}
+
+		$tmp_path = $path . '.' . uniqid( 'tmp-', true );
+		$written  = file_put_contents( $tmp_path, $contents, LOCK_EX ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+		if ( false === $written ) {
+			wp_delete_file( $tmp_path );
+			return false;
+		}
+
+		if ( ! rename( $tmp_path, $path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
+			wp_delete_file( $tmp_path );
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/Modules/Cache/StatsStore.php
+++ b/src/Modules/Cache/StatsStore.php
@@ -36,6 +36,18 @@ final class StatsStore {
 	private $dirty = false;
 
 	/**
+	 * High-traffic counters that should be sampled instead of persisted per request.
+	 *
+	 * @var array<string, bool>
+	 */
+	private $sampled_counter_keys = [
+		'hits'       => true,
+		'stale_hits' => true,
+		'bypasses'   => true,
+		'lock_waits' => true,
+	];
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -51,8 +63,35 @@ final class StatsStore {
 	 * @return void
 	 */
 	public function increment( $key ) {
-		$this->stats[ $key ] = isset( $this->stats[ $key ] ) ? ( (int) $this->stats[ $key ] + 1 ) : 1;
+		$increment = $this->get_increment_sample_size( $key );
+		if ( 0 === $increment ) {
+			return;
+		}
+
+		$this->stats[ $key ] = isset( $this->stats[ $key ] ) ? ( (int) $this->stats[ $key ] + $increment ) : $increment;
 		$this->dirty = true;
+	}
+
+	/**
+	 * Get sampled increment size for hot cache counters.
+	 *
+	 * @param string $key Stat key.
+	 *
+	 * @return int
+	 */
+	private function get_increment_sample_size( $key ) {
+		if ( empty( $this->sampled_counter_keys[ $key ] ) ) {
+			return 1;
+		}
+
+		$sample_rate = (int) apply_filters( 'perform_cache_stats_sample_rate', 20, $key );
+		$sample_rate = max( 1, $sample_rate );
+
+		if ( 1 === $sample_rate ) {
+			return 1;
+		}
+
+		return 1 === wp_rand( 1, $sample_rate ) ? $sample_rate : 0;
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -18,7 +18,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
  */
 function perform_handle_plugin_uninstall() {
 
-	$setting_types = array(
+	$option_keys = array(
 		'perform_settings',
 		'perform_common',
 		'perform_ssl',
@@ -27,6 +27,9 @@ function perform_handle_plugin_uninstall() {
 		'perform_advanced',
 		'perform_import_export',
 		'perform_support',
+		'perform_assets_manager_options',
+		'perform_cache_preload_queue',
+		'perform_cache_stats',
 	);
 
 	$remove_data_on_uninstall = false;
@@ -45,18 +48,15 @@ function perform_handle_plugin_uninstall() {
 
 			if ( ! empty( $sites ) ) {
 				foreach ( $sites as $site ) {
-					foreach ( $setting_types as $option ) {
+					foreach ( $option_keys as $option ) {
 						delete_blog_option( (int) $site->blog_id, $option );
 					}
-					}
 				}
+			}
 		} else {
-			foreach ( $setting_types as $option ) {
+			foreach ( $option_keys as $option ) {
 				delete_option( $option );
 			}
-			delete_option( 'perform_assets_manager_options' );
-			delete_option( 'perform_cache_preload_queue' );
-			delete_option( 'perform_cache_stats' );
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Writes page-cache body and metadata files through same-directory temporary files and atomic renames.
- Writes the cache body before metadata so fresh metadata never points at a missing or partial body file.
- Restricts page-cache persistence to cacheable HTML responses: HTTP 200, no `Location`, no `Set-Cookie`, and HTML content/body checks.
- Samples high-traffic cache counters (`hits`, `stale_hits`, `bypasses`, `lock_waits`) so hot cache traffic no longer persists `perform_cache_stats` on every request.
- Uses one uninstall option list for single-site and multisite cleanup, including cache/runtime options.

## Validation
- `php -l src/Modules/Cache/PageCache.php && php -l src/Modules/Cache/StatsStore.php && php -l uninstall.php`
- `git diff --check`
- Studio reflection smoke: atomic body/meta writes created `sample.html` and `sample.meta.json`; HTML response accepted; JSON and redirect responses rejected.
- Studio stats smoke: sample rate `1` persisted a hit; large sample rate skipped repeated hit increments without creating `perform_cache_stats`.

## Notes
- `composer check-cs -- src/Modules/Cache/PageCache.php src/Modules/Cache/StatsStore.php uninstall.php` is still blocked by pre-existing whole-file PHPCS violations in these files, mostly the repo's conflicting short-array rules and legacy formatting. I did not mass-format unrelated release code in this PR.

Closes #82.
Closes #83.
Closes #84.
Closes #85.
