### PR TITLE
Fix REST API docs help link

### DIFF
--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -469,7 +469,7 @@ class Helpers {
 							'help_link' => esc_url(
 								add_query_arg(
 									$utm_args,
-									'https://performwp.com/docs/remove-rest-api-links'
+									'https://performwp.com/docs/disable-wordpress-rest-api/'
 								)
 							),
 						],


### PR DESCRIPTION
## Summary
- Updates the Remove REST API Links help link to the live Perform documentation URL.
- Leaves the existing UTM handling and settings metadata shape unchanged.

## Validation
- Verified the old URL returns HTTP 404 and the replacement URL returns HTTP 200.
- php -l src/Includes/Helpers.php
- git diff --check

## Notes
- composer check-cs -- src/Includes/Helpers.php still fails on pre-existing whole-file style violations unrelated to this one-line URL change.

Closes #25.