### PR TITLE
Fix WooCommerce module guards

### DIFF
--- a/src/Modules/WooCommerce/WooManager.php
+++ b/src/Modules/WooCommerce/WooManager.php
@@ -32,10 +32,16 @@ class WooManager implements ModuleInterface {
 	 * @return bool
 	 */
 	public function should_load(): bool {
-		return Helpers::get_option( 'disable_woocommerce_assets', 'perform_settings' ) ||
-			   Helpers::get_option( 'disable_woocommerce_cart_fragmentation', 'perform_settings' ) ||
-			   Helpers::get_option( 'disable_woocommerce_status', 'perform_settings' ) ||
-			   Helpers::get_option( 'disable_woocommerce_widgets', 'perform_settings' );
+		if ( ! Helpers::is_woocommerce_active() ) {
+			return false;
+		}
+
+		return (
+			Helpers::get_option( 'disable_woocommerce_assets', 'perform_settings' ) ||
+			Helpers::get_option( 'disable_woocommerce_cart_fragmentation', 'perform_settings' ) ||
+			Helpers::get_option( 'disable_woocommerce_status', 'perform_settings' ) ||
+			Helpers::get_option( 'disable_woocommerce_widgets', 'perform_settings' )
+		);
 	}
 
 	/**
@@ -94,6 +100,10 @@ class WooManager implements ModuleInterface {
 	 * @return void
 	 */
 	public function disable_assets() {
+		if ( ! $this->has_woocommerce_conditionals() ) {
+			return;
+		}
+
 		if (
 			! is_woocommerce() &&
 			! is_cart() &&
@@ -140,6 +150,10 @@ class WooManager implements ModuleInterface {
 	 * @return void
 	 */
 	public function disable_cart_fragmentation() {
+		if ( ! function_exists( 'is_cart' ) || ! function_exists( 'is_checkout' ) ) {
+			return;
+		}
+
 		if ( ! is_cart() && ! is_checkout() ) {
 			wp_dequeue_script( 'wc-cart-fragments' );
 		}
@@ -166,17 +180,46 @@ class WooManager implements ModuleInterface {
 	 * @return void
 	 */
 	public function disable_widgets() {
-		unregister_widget( 'WC_Widget_Products' );
-		unregister_widget( 'WC_Widget_Product_Categories' );
-		unregister_widget( 'WC_Widget_Product_Tag_Cloud' );
-		unregister_widget( 'WC_Widget_Cart' );
-		unregister_widget( 'WC_Widget_Layered_Nav' );
-		unregister_widget( 'WC_Widget_Layered_Nav_Filters' );
-		unregister_widget( 'WC_Widget_Price_Filter' );
-		unregister_widget( 'WC_Widget_Product_Search' );
-		unregister_widget( 'WC_Widget_Recently_Viewed' );
-		unregister_widget( 'WC_Widget_Rating_Filter' );
-		unregister_widget( 'WC_Widget_Top_Rated_Products' );
-		unregister_widget( 'WC_Widget_Recent_Reviews' );
+		$widgets = [
+			'WC_Widget_Products',
+			'WC_Widget_Product_Categories',
+			'WC_Widget_Product_Tag_Cloud',
+			'WC_Widget_Cart',
+			'WC_Widget_Layered_Nav',
+			'WC_Widget_Layered_Nav_Filters',
+			'WC_Widget_Price_Filter',
+			'WC_Widget_Product_Search',
+			'WC_Widget_Recently_Viewed',
+			'WC_Widget_Rating_Filter',
+			'WC_Widget_Top_Rated_Products',
+			'WC_Widget_Recent_Reviews',
+		];
+
+		foreach ( $widgets as $widget ) {
+			if ( class_exists( $widget ) ) {
+				unregister_widget( $widget );
+			}
+		}
+	}
+
+	/**
+	 * Determine whether WooCommerce conditional helpers are available.
+	 *
+	 * @return bool
+	 */
+	private function has_woocommerce_conditionals(): bool {
+		$conditionals = [
+			'is_woocommerce',
+			'is_cart',
+			'is_checkout',
+			'is_account_page',
+			'is_product',
+			'is_product_category',
+			'is_shop',
+		];
+
+		$available_conditionals = array_filter( $conditionals, 'function_exists' );
+
+		return count( $conditionals ) === count( $available_conditionals );
 	}
 }

--- a/tests/unit-tests/tests-woocommerce-manager.php
+++ b/tests/unit-tests/tests-woocommerce-manager.php
@@ -1,0 +1,37 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Perform\Modules\WooCommerce\WooManager;
+
+final class Tests_WooCommerce_Manager extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings' => [
+				'disable_woocommerce_assets'             => true,
+				'disable_woocommerce_cart_fragmentation' => true,
+				'disable_woocommerce_status'             => true,
+				'disable_woocommerce_widgets'            => true,
+			],
+		];
+	}
+
+	protected function tearDown(): void {
+		unset( $GLOBALS['perform_test_options'] );
+	}
+
+	public function test_should_not_load_when_woocommerce_is_inactive_even_if_settings_are_enabled() {
+		$module = new WooManager();
+
+		$this->assertFalse( $module->should_load() );
+	}
+
+	public function test_callbacks_return_when_woocommerce_helpers_are_unavailable() {
+		$module = new WooManager();
+
+		$module->disable_assets();
+		$module->disable_cart_fragmentation();
+		$module->disable_widgets();
+
+		$this->assertTrue( true );
+	}
+}


### PR DESCRIPTION
## Summary

- Prevent the WooCommerce module from loading when WooCommerce is unavailable, even if Perform WooCommerce settings remain enabled from a prior configuration.
- Guard WooCommerce asset/cart-fragment callbacks when WooCommerce conditional helpers are unavailable.
- Guard WooCommerce widget unregistering so only available widget classes are unregistered.
- Add focused unit coverage for the inactive-WooCommerce path.

## Deferred follow-up issues

- #103
- #104
- #105
- #106
- #107
- #108

## Validation

- `php -l src/Modules/WooCommerce/WooManager.php`
- `php -l tests/unit-tests/tests-woocommerce-manager.php`
- `./vendor/bin/phpunit --dont-report-useless-tests --filter Tests_WooCommerce_Manager`
- `./vendor/bin/phpcs -s src/Modules/WooCommerce/WooManager.php tests/unit-tests/tests-woocommerce-manager.php`
- `composer test`
- `composer phpstan`
- `composer lint`
