### PR TITLE
Harden CDN rewrite load gating

### DIFF
--- a/src/Modules/CDN/CDNManager.php
+++ b/src/Modules/CDN/CDNManager.php
@@ -12,7 +12,7 @@
 namespace Perform\Modules\CDN;
 
 use Perform\Includes\Helpers;
-use Perform\Modules\ModuleInterface;
+use Perform\Modules\AbstractModule;
 
 // Bail out, if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -24,7 +24,20 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 1.0.0
  */
-class CDNManager implements ModuleInterface {
+class CDNManager extends AbstractModule {
+	/**
+	 * Toggle setting used to activate the module.
+	 *
+	 * @var string
+	 */
+	protected static $option_key = 'enable_cdn';
+
+	/**
+	 * Normalized request-local CDN settings.
+	 *
+	 * @var array<string, mixed>|null
+	 */
+	private $normalized_settings = null;
 
 	/**
 	 * Determine whether this module should be loaded.
@@ -32,7 +45,9 @@ class CDNManager implements ModuleInterface {
 	 * @return bool
 	 */
 	public function should_load(): bool {
-		return Helpers::get_option( 'enable_cdn', 'perform_settings', false );
+		$settings = $this->get_normalized_settings();
+
+		return $settings['enabled'] && '' !== $settings['cdn_url'];
 	}
 
 	/**
@@ -77,17 +92,17 @@ class CDNManager implements ModuleInterface {
 			return $html;
 		}
 
-		$site_url        = quotemeta( get_option( 'home' ) );
-		$url_regex       = '(https?:|)' . substr( $site_url, strpos( $site_url, '//' ) );
-		$directories     = 'wp\-content|wp\-includes';
-		$cdn_directories = Helpers::get_option( 'cdn_directories', 'perform_settings' );
-
-		if ( ! empty( $cdn_directories ) ) {
-			$directory_list = array_map( 'trim', explode( ',', $cdn_directories ) );
-			if ( count( $directory_list ) > 0 ) {
-				$directories = implode( '|', array_map( 'quotemeta', array_filter( $directory_list ) ) );
-			}
+		$settings = $this->get_normalized_settings();
+		if ( '' === $settings['cdn_url'] ) {
+			return $html;
 		}
+
+		$site_url    = quotemeta( get_option( 'home' ) );
+		$url_regex   = '(https?:|)' . substr( $site_url, strpos( $site_url, '//' ) );
+		$directories = implode(
+			'|',
+			array_map( 'quotemeta', $settings['directories'] )
+		);
 
 		$regex         = '#(?<=[(\"\'])(?:' . $url_regex . ')?/(?:((?:' . $directories . ')[^\"\')]+)|([^/\"\']+\.[^/\"\')]+))(?=[\"\')])#';
 		$html_with_cdn = preg_replace_callback( $regex, [ $this, 'rewrited_cdn_url' ], $html );
@@ -106,22 +121,14 @@ class CDNManager implements ModuleInterface {
 	 * @return string
 	 */
 	public function rewrited_cdn_url( $url ) {
-		$cdn_url = Helpers::get_option( 'cdn_url', 'perform_settings' );
+		$settings = $this->get_normalized_settings();
+		$cdn_url  = $settings['cdn_url'];
 
-		if ( ! empty( $cdn_url ) ) {
-			$cdn_exclusions = Helpers::get_option( 'cdn_exclusions', 'perform_settings' );
-
+		if ( '' !== $cdn_url ) {
 			// Don't Rewrite URL, if Excluded.
-			if ( ! empty( $cdn_exclusions ) ) {
-				$exclusions = array_map( 'trim', explode( ',', $cdn_exclusions ) );
-
-				foreach ( $exclusions as $exclusion ) {
-					if (
-						! empty( $exclusion ) &&
-						false !== stristr( $url[0], $exclusion )
-					) {
-						return $url[0];
-					}
+			foreach ( $settings['exclusions'] as $exclusion ) {
+				if ( false !== stristr( $url[0], $exclusion ) ) {
+					return $url[0];
 				}
 			}
 
@@ -152,5 +159,102 @@ class CDNManager implements ModuleInterface {
 		}
 
 		return $url[0];
+	}
+
+	/**
+	 * Read a CDN-related setting from injected settings first.
+	 *
+	 * @param string $key            Setting key.
+	 * @param mixed  $fallback_value Default value when the setting is missing.
+	 *
+	 * @return mixed
+	 */
+	private function read_setting( string $key, $fallback_value = '' ) {
+		if ( is_array( $this->settings ) && array_key_exists( $key, $this->settings ) ) {
+			return $this->settings[ $key ];
+		}
+
+		return Helpers::get_option( $key, 'perform_settings', $fallback_value );
+	}
+
+	/**
+	 * Get normalized settings used by load checks and rewrites.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_normalized_settings(): array {
+		if ( is_array( $this->normalized_settings ) ) {
+			return $this->normalized_settings;
+		}
+
+		$this->normalized_settings = [
+			'enabled'     => ! empty( $this->read_setting( 'enable_cdn', false ) ),
+			'cdn_url'     => $this->normalize_cdn_url( $this->read_setting( 'cdn_url', '' ) ),
+			'directories' => $this->normalize_csv_setting( $this->read_setting( 'cdn_directories', '' ), [ 'wp-content', 'wp-includes' ] ),
+			'exclusions'  => $this->normalize_csv_setting( $this->read_setting( 'cdn_exclusions', '' ) ),
+		];
+
+		return $this->normalized_settings;
+	}
+
+	/**
+	 * Normalize a comma-separated list setting.
+	 *
+	 * @param mixed    $value    Raw setting value.
+	 * @param string[] $fallback Default values when the setting is empty.
+	 *
+	 * @return string[]
+	 */
+	private function normalize_csv_setting( $value, array $fallback = [] ): array {
+		if ( is_array( $value ) ) {
+			$items = $value;
+		} elseif ( is_scalar( $value ) && '' !== trim( (string) $value ) ) {
+			$items = explode( ',', (string) $value );
+		} else {
+			return $fallback;
+		}
+
+		$items = array_values(
+			array_filter(
+				array_map(
+					static function ( $item ): string {
+						return trim( (string) $item );
+					},
+					$items
+				),
+				static function ( string $item ): bool {
+					return '' !== $item;
+				}
+			)
+		);
+
+		return ! empty( $items ) ? $items : $fallback;
+	}
+
+	/**
+	 * Normalize the configured CDN URL for safe runtime checks.
+	 *
+	 * @param mixed $cdn_url Raw CDN URL setting.
+	 *
+	 * @return string
+	 */
+	private function normalize_cdn_url( $cdn_url ): string {
+		if ( ! is_scalar( $cdn_url ) ) {
+			return '';
+		}
+
+		$cdn_url = trim( (string) $cdn_url );
+		if ( '' === $cdn_url ) {
+			return '';
+		}
+
+		$scheme = strtolower( (string) wp_parse_url( $cdn_url, PHP_URL_SCHEME ) );
+		$host   = (string) wp_parse_url( $cdn_url, PHP_URL_HOST );
+
+		if ( ! in_array( $scheme, [ 'http', 'https' ], true ) || '' === $host ) {
+			return '';
+		}
+
+		return $cdn_url;
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -56,6 +56,17 @@ if ( ! function_exists( 'delete_transient' ) ) {
 
 if ( ! function_exists( 'add_action' ) ) {
 	function add_action( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
+		if ( ! isset( $GLOBALS['perform_test_actions'] ) || ! is_array( $GLOBALS['perform_test_actions'] ) ) {
+			$GLOBALS['perform_test_actions'] = [];
+		}
+
+		$GLOBALS['perform_test_actions'][] = [
+			'hook'          => $hook_name,
+			'callback'      => $callback,
+			'priority'      => $priority,
+			'accepted_args' => $accepted_args,
+		];
+
 		return true;
 	}
 }
@@ -160,6 +171,12 @@ if ( ! function_exists( 'is_admin' ) ) {
 if ( ! function_exists( 'is_user_logged_in' ) ) {
 	function is_user_logged_in() {
 		return ! empty( $GLOBALS['perform_test_is_user_logged_in'] );
+	}
+}
+
+if ( ! function_exists( 'is_admin_bar_showing' ) ) {
+	function is_admin_bar_showing() {
+		return ! empty( $GLOBALS['perform_test_is_admin_bar_showing'] );
 	}
 }
 

--- a/tests/unit-tests/tests-cdn-manager.php
+++ b/tests/unit-tests/tests-cdn-manager.php
@@ -1,0 +1,86 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Perform\Modules\CDN\CDNManager;
+use Perform\Modules\Loader;
+
+final class Tests_CDN_Manager extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['perform_test_actions'] = [];
+		$GLOBALS['perform_test_options'] = [
+			'home' => 'https://example.com',
+		];
+	}
+
+	protected function tearDown(): void {
+		unset( $GLOBALS['perform_test_actions'], $GLOBALS['perform_test_options'] );
+	}
+
+	public function test_should_load_requires_a_valid_cdn_url() {
+		$disabled = new CDNManager(
+			[
+				'enable_cdn' => 1,
+				'cdn_url'    => '',
+			]
+		);
+		$this->assertFalse( $disabled->should_load() );
+
+		$invalid = new CDNManager(
+			[
+				'enable_cdn' => 1,
+				'cdn_url'    => 'cdn.example.com',
+			]
+		);
+		$this->assertFalse( $invalid->should_load() );
+
+		$valid = new CDNManager(
+			[
+				'enable_cdn' => 1,
+				'cdn_url'    => 'https://cdn.example.com',
+			]
+		);
+		$this->assertTrue( $valid->should_load() );
+	}
+
+	public function test_loader_only_registers_the_module_for_valid_settings() {
+		$loader = new Loader(
+			[
+				'enable_cdn' => 1,
+				'cdn_url'    => '',
+			]
+		);
+		$loader->register_modules( [ CDNManager::class ] );
+
+		$this->assertSame( [], $GLOBALS['perform_test_actions'] );
+
+		$GLOBALS['perform_test_actions'] = [];
+
+		$loader = new Loader(
+			[
+				'enable_cdn' => 1,
+				'cdn_url'    => 'https://cdn.example.com',
+			]
+		);
+		$loader->register_modules( [ CDNManager::class ] );
+
+		$this->assertCount( 1, $GLOBALS['perform_test_actions'] );
+		$this->assertSame( 'template_redirect', $GLOBALS['perform_test_actions'][0]['hook'] );
+	}
+
+	public function test_rewrite_with_cdn_url_preserves_exclusions() {
+		$manager = new CDNManager(
+			[
+				'enable_cdn'      => 1,
+				'cdn_url'         => 'https://cdn.example.com',
+				'cdn_exclusions'  => '.php,skip-me',
+				'cdn_directories' => 'wp-content,wp-includes',
+			]
+		);
+
+		$html      = '<script src="https://example.com/wp-content/skip-me.js"></script><img src="https://example.com/wp-content/uploads/image.jpg" />';
+		$rewritten = $manager->rewrite_with_cdn_url( $html );
+
+		$this->assertStringContainsString( 'https://example.com/wp-content/skip-me.js', $rewritten );
+		$this->assertStringContainsString( 'https://cdn.example.com/wp-content/uploads/image.jpg', $rewritten );
+	}
+}


### PR DESCRIPTION
## Summary
- require a valid HTTP(S) CDN URL before the CDN module loads or starts frontend output buffering
- normalize CDN URL, included directories, and exclusions once per request while preserving valid rewrite behavior
- add focused PHPUnit coverage for invalid config gating, module registration, and exclusion-aware rewrites

Closes #107.

## Base branch evidence
- Issue #107 is assigned to milestone `1.7.0`.
- The matching integration branch `release/1.7.0` exists on origin, so this PR targets that release branch explicitly.

## Scope
- [`src/Modules/CDN/CDNManager.php`](/Users/mehulgohil/Studio/development/wp-content/plugins/perform/src/Modules/CDN/CDNManager.php): move CDN settings normalization ahead of module load/registration checks and reuse normalized per-request config during rewrites.
- [`tests/unit-tests/tests-cdn-manager.php`](/Users/mehulgohil/Studio/development/wp-content/plugins/perform/tests/unit-tests/tests-cdn-manager.php): cover invalid/valid load gating, loader registration, and exclusion-aware rewrite behavior.
- [`tests/bootstrap.php`](/Users/mehulgohil/Studio/development/wp-content/plugins/perform/tests/bootstrap.php): extend the lightweight test harness to capture hook registration and admin-bar state used by the new unit coverage.

## Intentionally excluded
- no settings schema changes, migrations, or legacy option-key changes
- no UI copy/docs changes because this is internal runtime hardening only
- no broader CDN rewrite refactor beyond the load-gating and normalization path in #107

## Validation run
- `php -l src/Modules/CDN/CDNManager.php`
- `php -l tests/bootstrap.php`
- `php -l tests/unit-tests/tests-cdn-manager.php`
- `./vendor/bin/phpunit --filter Tests_CDN_Manager`
- `composer test`
- `composer lint`
- `composer phpstan`
- `./vendor/bin/phpcs -s src/Modules/CDN/CDNManager.php tests/bootstrap.php tests/unit-tests/tests-cdn-manager.php`

## Validation not run
- frontend smoke test with CDN rewriting enabled/disabled on a live WordPress site was not available in this run
- repo-wide `composer check-cs` still reports pre-existing unrelated PHPCS violations outside this PR scope

## Compatibility / security / privacy
- keeps the existing `perform_settings` contract and valid CDN rewrite behavior intact
- fails safe by skipping the module when the CDN URL is empty or not a usable HTTP(S) URL
- does not introduce new data collection, secrets, or public contract changes

## Rollback / release notes
- rollback is a straight revert of commit `f5d10f5`
- no release-note entry needed beyond issue tracking because this is pre-release runtime hardening for `1.7.0`

## Docs status
- no in-repo docs change required
- no separate performwp.com docs note required because there is no new user-facing feature or setting behavior

## Remaining risk
- live frontend behavior with CDN rewriting enabled still needs browser/runtime smoke verification before release sign-off
