### PR TITLE
docs: refresh Perform AGENTS workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@ Guidance for AI coding agents working on the Perform WordPress plugin.
 - Release-scoped work uses `release/<milestone>` branches. Verify the live branch list each run instead of hardcoding a single active release branch here.
 - If an issue or milestone maps to an existing `release/<milestone>` branch, create the work branch from that release branch and set the PR base explicitly.
 - Verify the current public version and release line from live repo metadata such as `readme.txt`, GitHub releases, and WordPress.org signals rather than relying on a static value in this file.
+- Release-readiness checks are project-specific: evaluate minor releases on a 30-day cadence and patch releases on a 7-day cadence within the same minor line.
+- Treat `x.9.x` as the pre-major rollover boundary: if that line is exhausted, the next planned release target should become `(x+1).0.0`.
+- At cadence checkpoints, verify the active milestone due date and latest public release live, then flag owner approval when a patch or minor candidate is justified by security, regression, compatibility, packaging, or high-impact stability/performance needs.
 
 ## Non-Negotiable Compatibility Rules
 - Do not rename existing option/meta keys used by released versions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,16 @@ Guidance for AI coding agents working on the Perform WordPress plugin.
 
 ## Project Snapshot
 - Plugin: `Perform`
-- Current public line: `1.5.1`
-- Active release branch in this workspace: `release/1.6.0`
 - Stack:
   - PHP (WordPress plugin, PSR-4 autoload `Perform\\` -> `src/`)
   - JS/CSS via `@wordpress/scripts` + webpack output in `assets/dist`
   - Freemius SDK via Composer
+
+## Branch And Release Workflow
+- `develop` is the default integration branch for workflow-policy and documentation changes unless current release evidence proves a different base.
+- Release-scoped work uses `release/<milestone>` branches. Verify the live branch list each run instead of hardcoding a single active release branch here.
+- If an issue or milestone maps to an existing `release/<milestone>` branch, create the work branch from that release branch and set the PR base explicitly.
+- Verify the current public version and release line from live repo metadata such as `readme.txt`, GitHub releases, and WordPress.org signals rather than relying on a static value in this file.
 
 ## Non-Negotiable Compatibility Rules
 - Do not rename existing option/meta keys used by released versions.


### PR DESCRIPTION
@mehul0810

## Learning type
Supersede stale AGENTS snapshot fields and add durable release-cadence workflow guidance.

## Evidence
- `gh repo view performwp/perform --json nameWithOwner,defaultBranchRef,url` shows the default branch is `develop`.
- `git branch --format='%(refname:short)'` in the local checkout shows active release branches `release/1.6.0`, `release/1.6.1`, and `release/1.7.0`, so a single hardcoded release branch in `AGENTS.md` is stale.
- `rg -n '^Stable tag:' readme.txt` returns `Stable tag: 1.6.0`, which contradicted the old `Current public line: 1.5.1` snapshot.
- `gh run list --repo performwp/perform --limit 8` shows current CI activity on `release/1.7.0` and on this docs PR, reinforcing that branch and release state changes over time.
- `rg -n '30 days|7 days|x\\.9\\.x|cadence checkpoints' /Users/mehulgohil/.codex/automations/perform-daily-issue-triage/automation.toml /Users/mehulgohil/.codex/automations/perform-daily-issue-triage/memory.md` shows the active Perform automation already uses explicit 30-day minor, 7-day patch, and major-rollover cadence rules that were not yet preserved in repo docs.

## Scope
- Remove the time-sensitive `Current public line` and `Active release branch in this workspace` bullets from `AGENTS.md`.
- Keep the durable branch and release verification guidance for future agents.
- Add repo-specific cadence rules for minor releases, patch releases, pre-major rollover, and live checkpoint verification.

## Why AGENTS.md is the durable home
- This is repo-specific branch, release, and cadence workflow policy that future automations need before choosing bases or trusting release timing.
- Leaving it only in automation prompts or memory would allow the same drift to repeat.

## What future agents should do differently
- Start workflow-policy and docs PRs from `develop` unless live release evidence proves a different base.
- Verify `release/<milestone>` branches, `readme.txt`, GitHub releases, and WordPress.org state live each run.
- Evaluate release readiness against the 30-day minor cadence, 7-day patch cadence, and pre-major rollover rule, while pulling the active milestone due date live instead of hardcoding dates in `AGENTS.md`.
- Set PR bases explicitly instead of inheriting GitHub defaults.

## Base branch
- Base: `develop`
- Why: this PR changes durable workflow guidance only, and live repo metadata shows `develop` is the current integration/default branch.

## Validation
- Reviewed the docs-only diff with `git diff -- AGENTS.md`.
- Ran `git diff --check` after the AGENTS update.

## Rollback or removal notes
- If the repo adopts a different branch model or cadence later, update this section again with live evidence instead of reintroducing fixed snapshot values.
