### PR TITLE
Bound sitemap preload traversal

### DIFF
--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -75,6 +75,20 @@ class PageCache implements ModuleInterface {
 	private $url_normalizer = null;
 
 	/**
+	 * Maximum number of child sitemap documents to fetch per seed run.
+	 *
+	 * @var int
+	 */
+	private $preload_sitemap_child_limit = 20;
+
+	/**
+	 * Maximum number of unique sitemap URLs to collect per seed run.
+	 *
+	 * @var int
+	 */
+	private $preload_sitemap_url_cap = 500;
+
+	/**
 	 * Determine whether this module should be loaded.
 	 *
 	 * @return bool
@@ -656,9 +670,17 @@ class PageCache implements ModuleInterface {
 			return [];
 		}
 
-		$urls = [];
+		$urls                   = [];
+		$url_cap                = max( 1, (int) $this->preload_sitemap_url_cap );
+		$child_sitemap_limit    = max( 1, (int) $this->preload_sitemap_child_limit );
+		$child_sitemaps_fetched = 0;
+
 		if ( isset( $index->sitemap ) ) {
 			foreach ( $index->sitemap as $sitemap ) {
+				if ( count( $urls ) >= $url_cap || $child_sitemaps_fetched >= $child_sitemap_limit ) {
+					break;
+				}
+
 				if ( empty( $sitemap->loc ) ) {
 					continue;
 				}
@@ -668,6 +690,7 @@ class PageCache implements ModuleInterface {
 					continue;
 				}
 
+				++$child_sitemaps_fetched;
 				$child_response = wp_remote_get( $child_sitemap_url, [ 'timeout' => 8 ] );
 				if ( is_wp_error( $child_response ) ) {
 					continue;
@@ -684,17 +707,21 @@ class PageCache implements ModuleInterface {
 				}
 
 				foreach ( $child->url as $item ) {
+					if ( count( $urls ) >= $url_cap ) {
+						break;
+					}
+
 					if ( ! empty( $item->loc ) ) {
 						$item_url = esc_url_raw( (string) $item->loc );
 						if ( $this->is_site_url( $item_url ) ) {
-							$urls[] = $item_url;
+							$urls[ $item_url ] = true;
 						}
 					}
 				}
 			}
 		}
 
-		return array_slice( array_values( array_unique( array_filter( $urls ) ) ), 0, 500 );
+		return array_keys( $urls );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -143,6 +143,22 @@ if ( ! function_exists( 'admin_url' ) ) {
 	}
 }
 
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '' ) {
+		$base = isset( $GLOBALS['perform_test_home_url'] ) ? (string) $GLOBALS['perform_test_home_url'] : 'https://example.com';
+
+		if ( '' === $path ) {
+			return $base;
+		}
+
+		if ( 0 === strpos( (string) $path, 'http://' ) || 0 === strpos( (string) $path, 'https://' ) ) {
+			return (string) $path;
+		}
+
+		return rtrim( $base, '/' ) . '/' . ltrim( (string) $path, '/' );
+	}
+}
+
 if ( ! function_exists( 'esc_url' ) ) {
 	function esc_url( $url ) {
 		return (string) $url;
@@ -220,6 +236,71 @@ if ( ! function_exists( 'wp_parse_url' ) ) {
 if ( ! function_exists( 'esc_url_raw' ) ) {
 	function esc_url_raw( $url ) {
 		return (string) $url;
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		/**
+		 * Error code.
+		 *
+		 * @var string
+		 */
+		public $code = '';
+
+		/**
+		 * Error message.
+		 *
+		 * @var string
+		 */
+		public $message = '';
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string $code Error code.
+		 * @param string $message Error message.
+		 */
+		public function __construct( $code = '', $message = '' ) {
+			$this->code    = (string) $code;
+			$this->message = (string) $message;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'wp_remote_get' ) ) {
+	function wp_remote_get( $url, $args = [] ) {
+		if ( ! isset( $GLOBALS['perform_test_remote_get_calls'] ) || ! is_array( $GLOBALS['perform_test_remote_get_calls'] ) ) {
+			$GLOBALS['perform_test_remote_get_calls'] = [];
+		}
+
+		$GLOBALS['perform_test_remote_get_calls'][] = [
+			'url'  => $url,
+			'args' => $args,
+		];
+
+		$responses = isset( $GLOBALS['perform_test_remote_get_map'] ) && is_array( $GLOBALS['perform_test_remote_get_map'] ) ? $GLOBALS['perform_test_remote_get_map'] : [];
+		if ( array_key_exists( $url, $responses ) ) {
+			return $responses[ $url ];
+		}
+
+		return new WP_Error( 'missing_mock', 'No mocked response registered.' );
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
+	function wp_remote_retrieve_body( $response ) {
+		if ( is_array( $response ) && isset( $response['body'] ) ) {
+			return (string) $response['body'];
+		}
+
+		return '';
 	}
 }
 

--- a/tests/unit-tests/tests-page-cache.php
+++ b/tests/unit-tests/tests-page-cache.php
@@ -5,14 +5,27 @@ use Perform\Modules\Cache\PageCache;
 
 final class Tests_Page_Cache extends TestCase {
 	protected function setUp(): void {
-		$GLOBALS['perform_test_transients'] = [
+		$GLOBALS['perform_test_transients']       = [
 			'perform_cache_lock_test' => 'expected-token',
 		];
+		$GLOBALS['perform_test_options']          = [];
+		$GLOBALS['perform_test_filters']          = [];
+		$GLOBALS['perform_test_home_url']         = 'https://example.com';
+		$GLOBALS['perform_test_remote_get_map']   = [];
+		$GLOBALS['perform_test_remote_get_calls'] = [];
 		unset( $_SERVER['HTTP_X_PERFORM_CACHE_REGEN'] );
 	}
 
 	protected function tearDown(): void {
-		unset( $GLOBALS['perform_test_transients'], $_SERVER['HTTP_X_PERFORM_CACHE_REGEN'] );
+		unset(
+			$GLOBALS['perform_test_filters'],
+			$GLOBALS['perform_test_home_url'],
+			$GLOBALS['perform_test_options'],
+			$GLOBALS['perform_test_remote_get_calls'],
+			$GLOBALS['perform_test_remote_get_map'],
+			$GLOBALS['perform_test_transients'],
+			$_SERVER['HTTP_X_PERFORM_CACHE_REGEN']
+		);
 	}
 
 	public function test_internal_regeneration_requires_matching_lock_token() {
@@ -30,5 +43,131 @@ final class Tests_Page_Cache extends TestCase {
 
 		$_SERVER['HTTP_X_PERFORM_CACHE_REGEN'] = 'expected-token';
 		$this->assertTrue( $is_internal_regen_request->invoke( $page_cache ) );
+	}
+
+	public function test_fetch_urls_from_sitemap_limits_child_sitemap_requests_per_run() {
+		$page_cache = new PageCache();
+
+		$this->set_private_property( $page_cache, 'preload_sitemap_child_limit', 3 );
+		$this->set_private_property( $page_cache, 'preload_sitemap_url_cap', 20 );
+
+		$GLOBALS['perform_test_remote_get_map'] = [
+			'https://example.com/wp-sitemap.xml' => [ 'body' => $this->build_sitemap_index_xml( 5 ) ],
+			'https://example.com/sitemap-1.xml'  => [ 'body' => $this->build_urlset_xml( '/page-1', '/page-2' ) ],
+			'https://example.com/sitemap-2.xml'  => [ 'body' => $this->build_urlset_xml( '/page-3', '/page-4' ) ],
+			'https://example.com/sitemap-3.xml'  => [ 'body' => $this->build_urlset_xml( '/page-5', '/page-6' ) ],
+			'https://example.com/sitemap-4.xml'  => [ 'body' => $this->build_urlset_xml( '/page-7', '/page-8' ) ],
+			'https://example.com/sitemap-5.xml'  => [ 'body' => $this->build_urlset_xml( '/page-9', '/page-10' ) ],
+		];
+
+		$method = new ReflectionMethod( $page_cache, 'fetch_urls_from_sitemap' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			[
+				'https://example.com/page-1',
+				'https://example.com/page-2',
+				'https://example.com/page-3',
+				'https://example.com/page-4',
+				'https://example.com/page-5',
+				'https://example.com/page-6',
+			],
+			$method->invoke( $page_cache )
+		);
+
+		$this->assertSame(
+			[
+				'https://example.com/wp-sitemap.xml',
+				'https://example.com/sitemap-1.xml',
+				'https://example.com/sitemap-2.xml',
+				'https://example.com/sitemap-3.xml',
+			],
+			array_column( $GLOBALS['perform_test_remote_get_calls'], 'url' )
+		);
+	}
+
+	public function test_fetch_urls_from_sitemap_stops_after_reaching_url_cap() {
+		$page_cache = new PageCache();
+
+		$this->set_private_property( $page_cache, 'preload_sitemap_child_limit', 5 );
+		$this->set_private_property( $page_cache, 'preload_sitemap_url_cap', 3 );
+
+		$GLOBALS['perform_test_remote_get_map'] = [
+			'https://example.com/wp-sitemap.xml' => [ 'body' => $this->build_sitemap_index_xml( 2 ) ],
+			'https://example.com/sitemap-1.xml'  => [ 'body' => $this->build_urlset_xml( '/page-1', '/page-2', '/page-2', '/page-3', '/page-4' ) ],
+			'https://example.com/sitemap-2.xml'  => [ 'body' => $this->build_urlset_xml( '/page-5' ) ],
+		];
+
+		$method = new ReflectionMethod( $page_cache, 'fetch_urls_from_sitemap' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			[
+				'https://example.com/page-1',
+				'https://example.com/page-2',
+				'https://example.com/page-3',
+			],
+			$method->invoke( $page_cache )
+		);
+
+		$this->assertSame(
+			[
+				'https://example.com/wp-sitemap.xml',
+				'https://example.com/sitemap-1.xml',
+			],
+			array_column( $GLOBALS['perform_test_remote_get_calls'], 'url' )
+		);
+	}
+
+	public function test_seed_preload_queue_keeps_existing_queue_when_sitemap_fetch_fails() {
+		$GLOBALS['perform_test_options']        = [
+			'perform_settings'            => [
+				'enable_cache_preload' => true,
+			],
+			'perform_cache_preload_queue' => [
+				'https://example.com/existing-page',
+			],
+		];
+		$GLOBALS['perform_test_remote_get_map'] = [
+			'https://example.com/wp-sitemap.xml' => new WP_Error( 'http_request_failed', 'Timeout' ),
+		];
+
+		$page_cache = new PageCache();
+		$page_cache->seed_preload_queue_from_sitemap_and_logs();
+
+		$this->assertSame(
+			[ 'https://example.com/existing-page' ],
+			$GLOBALS['perform_test_options']['perform_cache_preload_queue']
+		);
+		$this->assertSame(
+			[ 'https://example.com/wp-sitemap.xml' ],
+			array_column( $GLOBALS['perform_test_remote_get_calls'], 'url' )
+		);
+	}
+
+	private function set_private_property( PageCache $page_cache, string $property_name, int $value ): void {
+		$property = new ReflectionProperty( $page_cache, $property_name );
+		$property->setAccessible( true );
+		$property->setValue( $page_cache, $value );
+	}
+
+	private function build_sitemap_index_xml( int $child_count ): string {
+		$items = [];
+
+		for ( $index = 1; $index <= $child_count; $index++ ) {
+			$items[] = sprintf( '<sitemap><loc>https://example.com/sitemap-%d.xml</loc></sitemap>', $index );
+		}
+
+		return '<?xml version="1.0" encoding="UTF-8"?><sitemapindex>' . implode( '', $items ) . '</sitemapindex>';
+	}
+
+	private function build_urlset_xml( string ...$paths ): string {
+		$items = [];
+
+		foreach ( $paths as $path ) {
+			$items[] = '<url><loc>https://example.com' . $path . '</loc></url>';
+		}
+
+		return '<?xml version="1.0" encoding="UTF-8"?><urlset>' . implode( '', $items ) . '</urlset>';
 	}
 }


### PR DESCRIPTION
## Summary

Closes #104.

Bound page-cache sitemap preload traversal so one seed run stops after a limited number of child sitemap fetches and after the existing URL cap is filled, instead of fetching every child sitemap first and trimming later.

## Base Branch Evidence

- Issue #104 is assigned to milestone `1.7.0`.
- The matching release branch `release/1.7.0` exists on origin.
- `origin/release/1.7.0` is the active release line for this milestone and is already ahead of `develop` with release-scoped cache work merged in PR #129, so this fix branches from and targets `release/1.7.0`.

## Scope

- Add bounded child-sitemap traversal to `PageCache::fetch_urls_from_sitemap()`.
- Stop fetching child sitemaps once the per-run URL cap is satisfied.
- Deduplicate sitemap URLs during collection instead of only after all child fetches complete.
- Add unit-test bootstrap HTTP helpers plus regression coverage for traversal limits, early URL-cap exits, and fetch-failure queue preservation.

## Intentionally Excluded

- No cursor/checkpoint persistence across multiple sitemap seed runs.
- No settings or UI changes for preload tuning.
- No queue option schema changes or migration work.

## Validation

- `php -l src/Modules/Cache/PageCache.php`
- `php -l tests/bootstrap.php`
- `php -l tests/unit-tests/tests-page-cache.php`
- `./vendor/bin/phpunit --filter Tests_Page_Cache`
- `composer test`
- `composer lint`
- `./vendor/bin/phpstan analyse --memory-limit=2048M --debug`

## Compatibility, Security, Privacy

- Keeps the existing preload queue option contract intact.
- Continues to accept only same-site HTTP(S) sitemap URLs.
- Network failures still short-circuit safely without clearing the existing preload queue.
- No new user data, secrets, telemetry, or public API surface introduced.

## Rollback and Release Notes

- Rollback is a straight revert of this PR's commit.
- No version bump, migration, or release artifact change is required.
- Release impact is limited to safer preload seeding behavior on larger sites.

## Docs Status

- No `AGENTS.md` update needed for this code-only runtime fix.
- No in-repo docs or performwp.com docs change is required because this does not add a new setting, hook, or user-facing workflow.

## Remaining Risk

- I did not run a live cron/preload smoke test against a WordPress site from this worktree, so runtime proof is limited to unit/static validation.

@mehul0810 for release-line visibility.
