### PR TITLE
Align public metadata surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@
 
 👉 Not a developer? Running WordPress? [Download PerformWP](https://wordpress.org/plugins/perform/) on WordPress.org.
 
-![WordPress version](https://img.shields.io/wordpress/plugin/v/perform.svg) ![WordPress Rating](https://img.shields.io/wordpress/plugin/r/perform.svg) ![WordPress Downloads](https://img.shields.io/wordpress/plugin/dt/perform.svg) [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://github.com/mehul0810/perform-for-wp/blob/master/license.txt) 
+![WordPress version](https://img.shields.io/wordpress/plugin/v/perform.svg) ![WordPress Rating](https://img.shields.io/wordpress/plugin/r/perform.svg) ![WordPress Downloads](https://img.shields.io/wordpress/plugin/dt/perform.svg) [![License](https://img.shields.io/badge/license-GPL--3.0%2B-green.svg)](https://github.com/performwp/perform/blob/develop/license.txt)
 
 Welcome to the Perform GitHub repository. This is the code source and the center of active development. Here you can browse the source, look at open issues, and contribute to the project.
  
 ## Getting Started 
 
-If you're looking to contribute or actively develop on Perform then skip ahead to the [Local Development](https://github.com/mehul0810/perform/#local-development) section below. The following is if you're looking to actively use the plugin on your WordPress site.
+If you're looking to contribute or actively develop on Perform then skip ahead to the [Local Development](#local-development) section below. The following is if you're looking to actively use the plugin on your WordPress site.
 
 ### Minimum Requirements
 
-* WordPress 5.1 or greater
-* PHP version 7.0 or greater
+* WordPress 4.8 or greater
+* PHP version 7.4 or greater
 * MySQL version 5.6 or greater
 
 ### Automatic installation
@@ -35,6 +35,7 @@ The manual installation method involves downloading our donation plugin and uplo
 This repository is not suitable for support. Please don't use GitHub issues for support requests. To get support please use the following channels:
 
 * [WP.org Support Forums](https://wordpress.org/support/plugin/perform) - for all users
+* [PerformWP](https://performwp.com/) - product site and release updates
 
 ## Local Development 
 
@@ -57,6 +58,15 @@ To get started developing on the Perform WordPress Plugin you will need to perfo
 8. Activate the plugin in WordPress
 
 That's it. You're now ready to start development.
+
+### Runtime vs Tooling Baselines
+
+The published plugin currently targets WordPress `4.8+`, PHP `7.4+`, and is tested through WordPress `7.0`, matching the public plugin readme and current released plugin metadata.
+
+Local contributor tooling intentionally uses newer runtimes for build and validation work:
+
+* Node.js `24.x` for npm, `@wordpress/scripts`, and Playwright tasks
+* Composer platform PHP `8.1` for local dependency resolution and static analysis consistency
 
 ### NPM Commands
 
@@ -98,4 +108,4 @@ Use these commands before opening a pull request:
     ```
 * Commit the `package.lock` file. Read more about why [here](https://docs.npmjs.com/files/package-lock.json). 
 * Your editor should recognize the `.eslintrc` and `.editorconfig` files within the Repo's root directory. Please only submit PRs following those coding style rulesets. 
-* Read [CONTRIBUTING.md](https://github.com/mehul0810/perform/blob/master/CONTRIBUTING.md) - it contains more about contributing to Perform.
+* Use the [GitHub issue tracker](https://github.com/performwp/perform/issues) for validated bugs and feature proposals, and open pull requests against the current repository when contributing code.

--- a/perform.php
+++ b/perform.php
@@ -26,7 +26,7 @@
  * Domain Path: /languages
  */
 
- namespace Perform;
+namespace Perform;
 
 // Bailout, if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {

--- a/perform.php
+++ b/perform.php
@@ -21,7 +21,7 @@
  * Author: Mehul Gohil
  * Author URI: https://mehulgohil.com/
  * License: GPLv3 or later
- * License URI: http://www.gnu.org/licenses/gpl-2.0.html
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain: perform
  * Domain Path: /languages
  */

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,7 @@ Yes. Perform 1.6.0 preserves existing public option keys and migrates legacy set
 
 == Support ==
 
+Project site and release updates: https://performwp.com/
 For help and troubleshooting, use our WordPress.org support forum: https://wordpress.org/support/plugin/perform
 Contributions and bug reports welcome on GitHub: https://github.com/performwp/perform
 
@@ -120,9 +121,9 @@ Back up your site before changing performance settings on production, then test 
 == Screenshots ==
 
 1. General Settings Screen
-2. Bloat Settings Screen
-3. Assets Settings Screen
-4. CDN Settings Screen
+2. Frontend cleanup and performance toggle settings
+3. Assets Manager scanner and per-page asset controls
+4. CDN and resource hint settings
 
 == Contributors ==
 


### PR DESCRIPTION
Closes #134

## Summary
- align public-facing compatibility and discovery metadata across the repository README, WordPress.org readme, and plugin header
- replace stale repository links that still pointed to the legacy GitHub location
- document the intentional difference between the published plugin runtime requirements and the newer local tooling baseline

## Base Branch
- base: `release/1.7.0`
- evidence: issue #134 is milestoned to `1.7.0`, the matching `release/1.7.0` branch exists, and recent merged milestone work in #129 and #131 also targeted `release/1.7.0`

## Scope
- refreshed stale GitHub/license/support links in `README.md`
- aligned contributor-facing WordPress/PHP requirement wording with the public plugin metadata
- added a short runtime-versus-tooling note for the Node 24 and Composer PHP 8.1 local validation baseline
- corrected the plugin header license URI to match the GPLv3 license file and public metadata
- updated public screenshot captions in `readme.txt` to match the current settings experience

## Intentionally Excluded
- no plugin version bump, stable-tag change, or release/tagging work
- no runtime, settings, or feature behavior changes
- no `composer.json` or `package.json` field changes because the existing repo/tooling metadata already reflects the intended contributor-facing surfaces

## Validation
- `git diff --check`
- `php -l perform.php`
- manual metadata consistency review across `README.md`, `readme.txt`, `perform.php`, `package.json`, and `composer.json`

## Compatibility, Security, And Privacy
- compatibility-only metadata cleanup; no public runtime contract changes
- no new dependencies, remote calls, tracking URLs, or data-handling changes

## Rollback And Release Notes
- rollback: revert this PR cleanly if any wording or metadata alignment needs to be deferred
- release notes: none required; this is a metadata/docs cleanup only

## Docs Status
- in-repo docs updated in this PR: `README.md` and `readme.txt`
- performwp.com follow-up: note that GitHub/WordPress.org metadata was aligned for the current 1.6.x public release line; no website docs were published from this job

## Remaining Risk
- WordPress.org plugin-directory rendering was not revalidated live from this branch, so final publish confidence still depends on normal repo/CI review
