### PR TITLE
Add reset button to Assets Manager settings

### DIFF
--- a/assets/src/css/frontend/assets-manager.css
+++ b/assets/src/css/frontend/assets-manager.css
@@ -148,6 +148,18 @@
 	color: var(--perform-am-primary);
 }
 
+.perform-assets-manager-button--reset,
+.perform-assets-manager-button--reset:visited {
+	background: var(--perform-am-white);
+	border-color: var(--perform-am-danger);
+	color: var(--perform-am-danger);
+}
+
+.perform-assets-manager-button--reset:hover {
+	background: var(--perform-am-danger);
+	color: var(--perform-am-white);
+}
+
 .perform-assets-manager-button:focus,
 .perform-assets-manager-header-actions input[type='submit']:focus,
 .perform-assets-manager--controls .components-button:focus,

--- a/src/Modules/Assets/AssetsManager.php
+++ b/src/Modules/Assets/AssetsManager.php
@@ -183,6 +183,7 @@ class AssetsManager implements ModuleInterface {
 					</div>
 					<div class="perform-assets-manager-header-actions">
 						<a class="perform-assets-manager-button perform-assets-manager-button--secondary" href="<?php echo esc_url( remove_query_arg( 'perform' ) ); ?>"><?php esc_html_e( 'Close', 'perform' ); ?></a>
+						<button type="submit" name="perform_assets_manager_reset" class="perform-assets-manager-button perform-assets-manager-button--reset" onclick="return confirm('<?php esc_attr_e( 'This will clear all assets manager settings for this site. Continue?', 'perform' ); ?>')"><?php esc_html_e( 'Reset', 'perform' ); ?></button>
 						<input class="perform-assets-manager-button perform-assets-manager-button--primary" type="submit" name="perform_assets_manager" value="<?php esc_attr_e( 'Save changes', 'perform' ); ?>" />
 					</div>
 				</div>
@@ -869,6 +870,12 @@ class AssetsManager implements ModuleInterface {
 
 		if ( ! is_array( $get_data ) ) {
 			$get_data = [];
+		}
+
+		if ( isset( $post_data['perform_assets_manager_reset'] ) ) {
+			delete_option( 'perform_assets_manager_options' );
+			wp_safe_redirect( esc_url_raw( add_query_arg( 'perform_reset', '1', remove_query_arg( 'perform', wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) ) ) ) );
+			exit;
 		}
 
 		if (

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+if ( ! defined( 'PERFORM_PLUGIN_URL' ) ) {
+	define( 'PERFORM_PLUGIN_URL', 'https://example.com/wp-content/plugins/perform/' );
+}
+
+if ( ! defined( 'PERFORM_VERSION' ) ) {
+	define( 'PERFORM_VERSION', '1.7.0' );
+}
+
 if ( ! function_exists( 'get_option' ) ) {
 	function get_option( $name, $default_value = false ) {
 		$store = isset( $GLOBALS['perform_test_options'] ) && is_array( $GLOBALS['perform_test_options'] ) ? $GLOBALS['perform_test_options'] : [];
@@ -168,6 +176,145 @@ if ( ! function_exists( 'esc_url' ) ) {
 if ( ! function_exists( 'esc_html__' ) ) {
 	function esc_html__( $text, $domain = 'default' ) {
 		return (string) $text;
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = 'default' ) {
+		return (string) $text;
+	}
+}
+
+if ( ! function_exists( 'esc_attr__' ) ) {
+	function esc_attr__( $text, $domain = 'default' ) {
+		return (string) $text;
+	}
+}
+
+if ( ! function_exists( 'esc_attr_e' ) ) {
+	function esc_attr_e( $text, $domain = 'default' ) {
+		echo esc_attr__( $text, $domain );
+	}
+}
+
+if ( ! function_exists( 'get_permalink' ) ) {
+	function get_permalink( $post = 0 ) {
+		return 'https://example.com/sample-page/';
+	}
+}
+
+if ( ! function_exists( 'wp_nonce_field' ) ) {
+	function wp_nonce_field( $action = -1, $name = '_wpnonce', $referer = true, $display = true ) {
+		if ( $display ) {
+			echo '<input type="hidden" name="' . esc_attr( $name ) . '" />';
+		}
+		return '<input type="hidden" name="' . esc_attr( $name ) . '" />';
+	}
+}
+
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'checked' ) ) {
+	function checked( $checked, $current = true, $display = true ) {
+		if ( (string) $checked === (string) $current ) {
+			if ( $display ) {
+				echo 'checked="checked"';
+			}
+			return 'checked="checked"';
+		}
+		return '';
+	}
+}
+
+if ( ! function_exists( 'selected' ) ) {
+	function selected( $selected, $current = true, $display = true ) {
+		if ( (string) $selected === (string) $current ) {
+			if ( $display ) {
+				echo 'selected="selected"';
+			}
+			return 'selected="selected"';
+		}
+		return '';
+	}
+}
+
+if ( ! function_exists( 'esc_html_e' ) ) {
+	function esc_html_e( $text, $domain = 'default' ) {
+		echo esc_html__( $text, $domain );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( '_n' ) ) {
+	function _n( $single, $plural, $number, $domain = 'default' ) {
+		return 1 === (int) $number ? $single : $plural;
+	}
+}
+
+if ( ! function_exists( 'get_post_types' ) ) {
+	function get_post_types( $args = [], $output = 'names', $operator = 'and' ) {
+		return [];
+	}
+}
+
+if ( ! function_exists( 'get_queried_object_id' ) ) {
+	function get_queried_object_id() {
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'get_the_ID' ) ) {
+	function get_the_ID() {
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'wp_get_theme' ) ) {
+	function wp_get_theme( $stylesheet = null, $theme_root = null ) {
+		return new class {
+			public function get( $header ) {
+				return 'Test Theme';
+			}
+		};
+	}
+}
+
+if ( ! function_exists( 'get_plugins' ) ) {
+	function get_plugins( $plugin_folder = '' ) {
+		return [];
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
+	}
+}
+
+if ( ! function_exists( 'wp_kses_post' ) ) {
+	function wp_kses_post( $data ) {
+		return (string) $data;
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+	}
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $url ) {
+		return (string) $url;
 	}
 }
 

--- a/tests/unit-tests/tests-assets-manager.php
+++ b/tests/unit-tests/tests-assets-manager.php
@@ -20,4 +20,19 @@ final class Tests_Assets_Manager extends TestCase {
 		$this->assertTrue( $method->invoke( $manager, 42, [ '42' ] ) );
 		$this->assertFalse( $method->invoke( $manager, 11, [ '42' ] ) );
 	}
+
+	public function test_assets_manager_html_renders_reset_button() {
+		$manager = $this->createPartialMock( AssetsManager::class, [ 'prepare_assets_list' ] );
+		$manager->method( 'prepare_assets_list' )->willReturn( [] );
+
+		$manager->selected_options = [];
+		$manager->loaded_assets    = [];
+
+		ob_start();
+		$manager->assets_manager_html();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'perform_assets_manager_reset', $html, 'Reset button should be rendered in the Assets Manager HTML.' );
+		$this->assertStringContainsString( 'perform-assets-manager-button--reset', $html, 'Reset button should have the --reset CSS class.' );
+	}
 }


### PR DESCRIPTION
## Changes

Adds a "Reset" button to the Assets Manager header UI that clears all saved settings.

### What's included:
- **Reset button** in the header (between Close and Save) with danger styling
- **Reset handler** in `save_assets_manager_settings()` — deletes `perform_assets_manager_options` when reset is triggered
- **CSS styling** using existing `--perform-am-danger` variable
- **JavaScript confirmation** dialog before resetting
- **Unit test** asserting the reset button renders in the Assets Manager HTML

### Security
- Protected by existing `manage_options` capability check
- Protected by existing `perform_assets_manager_nonce` nonce verification
- Uses `delete_option()` which is idempotent and safe

### Testing
- PHPUnit: 26/26 tests passing (2 new assertions for reset button)
- PHPCS: 0 errors on changed files
- PHPStan: 0 errors

### Screenshots
The reset button appears in the header as a danger-styled button between Close and Save changes.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.

Closes #14