### PR TITLE
Add Assets Manager reset action

### DIFF
--- a/assets/src/css/frontend/assets-manager.css
+++ b/assets/src/css/frontend/assets-manager.css
@@ -148,6 +148,18 @@
 	color: var(--perform-am-primary);
 }
 
+.perform-assets-manager-button--reset {
+	border-color: var(--perform-am-danger);
+	background: var(--perform-am-white);
+	color: var(--perform-am-danger);
+}
+
+.perform-assets-manager-button--reset:hover,
+.perform-assets-manager-button--reset:focus {
+	background: var(--perform-am-danger);
+	color: var(--perform-am-white);
+}
+
 .perform-assets-manager-button:focus,
 .perform-assets-manager-header-actions input[type='submit']:focus,
 .perform-assets-manager--controls .components-button:focus,

--- a/src/Modules/Assets/AssetsManager.php
+++ b/src/Modules/Assets/AssetsManager.php
@@ -183,6 +183,9 @@ class AssetsManager implements ModuleInterface {
 					</div>
 					<div class="perform-assets-manager-header-actions">
 						<a class="perform-assets-manager-button perform-assets-manager-button--secondary" href="<?php echo esc_url( remove_query_arg( 'perform' ) ); ?>"><?php esc_html_e( 'Close', 'perform' ); ?></a>
+						<button class="perform-assets-manager-button perform-assets-manager-button--reset" type="submit" name="perform_assets_manager_reset" value="1" onclick="return window.confirm('<?php esc_attr_e( 'This will reset all Assets Manager settings for this site. Continue?', 'perform' ); ?>');">
+							<?php esc_html_e( 'Reset', 'perform' ); ?>
+						</button>
 						<input class="perform-assets-manager-button perform-assets-manager-button--primary" type="submit" name="perform_assets_manager" value="<?php esc_attr_e( 'Save changes', 'perform' ); ?>" />
 					</div>
 				</div>
@@ -873,6 +876,14 @@ class AssetsManager implements ModuleInterface {
 
 		if (
 			isset( $get_data['perform'] ) &&
+			! empty( $post_data['perform_assets_manager_reset'] )
+		) {
+			wp_safe_redirect( $this->reset_assets_manager_settings() );
+			exit;
+		}
+
+		if (
+			isset( $get_data['perform'] ) &&
 			! empty( $post_data['perform_assets_manager'] )
 		) {
 
@@ -1084,6 +1095,28 @@ class AssetsManager implements ModuleInterface {
 			// Save assets manager settings to DB.
 			update_option( 'perform_assets_manager_options', $options, false );
 		}
+	}
+
+	/**
+	 * Reset saved Assets Manager options and return the scanner close URL.
+	 *
+	 * @return string Redirect URL.
+	 */
+	private function reset_assets_manager_settings(): string {
+		delete_option( 'perform_assets_manager_options' );
+
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? (string) wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+		if ( '' === $request_uri ) {
+			$request_uri = home_url( add_query_arg( [] ) );
+		}
+
+		return esc_url_raw(
+			add_query_arg(
+				'perform_reset',
+				'1',
+				remove_query_arg( 'perform', $request_uri )
+			)
+		);
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,6 +29,19 @@ if ( ! function_exists( 'update_option' ) ) {
 	}
 }
 
+if ( ! function_exists( 'delete_option' ) ) {
+	function delete_option( $name ) {
+		if ( ! isset( $GLOBALS['perform_test_options'] ) || ! is_array( $GLOBALS['perform_test_options'] ) ) {
+			$GLOBALS['perform_test_options'] = [];
+		}
+
+		$exists = array_key_exists( $name, $GLOBALS['perform_test_options'] );
+		unset( $GLOBALS['perform_test_options'][ $name ] );
+
+		return $exists;
+	}
+}
+
 if ( ! function_exists( 'get_transient' ) ) {
 	function get_transient( $transient ) {
 		$store = isset( $GLOBALS['perform_test_transients'] ) && is_array( $GLOBALS['perform_test_transients'] ) ? $GLOBALS['perform_test_transients'] : [];

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -33,6 +33,7 @@ test( 'settings save, Assets Manager, and page cache smoke paths work', async ( 
 	await page.goto( '/?perform' );
 	await expect( page.locator( '#perform-assets-manager' ) ).toBeVisible();
 	await expect( page.getByRole( 'heading', { name: 'Assets Manager' } ) ).toBeVisible();
+	await expect( page.getByRole( 'button', { name: 'Reset' } ) ).toBeVisible();
 
 	const anonymous = await request.newContext( { baseURL } );
 	await anonymous.get( '/' );

--- a/tests/unit-tests/tests-assets-manager.php
+++ b/tests/unit-tests/tests-assets-manager.php
@@ -20,4 +20,26 @@ final class Tests_Assets_Manager extends TestCase {
 		$this->assertTrue( $method->invoke( $manager, 42, [ '42' ] ) );
 		$this->assertFalse( $method->invoke( $manager, 11, [ '42' ] ) );
 	}
+
+	public function test_reset_assets_manager_settings_deletes_saved_options_and_returns_clean_url() {
+		$GLOBALS['perform_test_options'] = [
+			'perform_assets_manager_options' => [
+				'disabled' => [
+					'js' => [
+						'example' => [
+							'everywhere' => 1,
+						],
+					],
+				],
+			],
+		];
+		$_SERVER['REQUEST_URI']          = '/sample-page/?perform=1&keep=1';
+
+		$manager = new AssetsManager();
+		$method  = new ReflectionMethod( $manager, 'reset_assets_manager_settings' );
+		$method->setAccessible( true );
+
+		$this->assertSame( '/sample-page/?keep=1&perform_reset=1', $method->invoke( $manager ) );
+		$this->assertArrayNotHasKey( 'perform_assets_manager_options', $GLOBALS['perform_test_options'] );
+	}
 }


### PR DESCRIPTION
## Summary
- Add a Reset button to the Assets Manager toolbar with a confirmation prompt.
- Delete saved Assets Manager options and redirect back to the current page without the scanner query flag.
- Add focused unit coverage for the reset helper and extend the Playwright smoke path to assert the Reset control is visible.

## Validation
- `php -l src/Modules/Assets/AssetsManager.php && php -l tests/bootstrap.php && php -l tests/unit-tests/tests-assets-manager.php`
- `./vendor/bin/phpunit --filter Tests_Assets_Manager`
- `composer test`
- `composer phpstan`
- `./vendor/bin/phpcs -s src/Modules/Assets/AssetsManager.php tests/bootstrap.php tests/unit-tests/tests-assets-manager.php`
- `npm run lint:css`
- `npm run lint:js`
- `npm run build`
- `git diff --check`

## Proof Gap
- `npm run test:e2e:ci` is blocked locally because `docker` is not available in this shell (`spawn docker ENOENT`). CI should still run the smoke assertion added here.
- Screenshot proof for the Assets Manager toolbar remains pending for reviewer/CI environment because no local WordPress HTTP endpoint is reachable in this shell.

Refs #14
Supersedes #149 if accepted.
