### PR TITLE
Add page cache exclusion controls

### DIFF
--- a/src/Admin/Settings/ClientPayload.php
+++ b/src/Admin/Settings/ClientPayload.php
@@ -38,6 +38,8 @@ final class ClientPayload {
 	 * @return array<string, mixed>
 	 */
 	public static function sanitize_for_client( array $settings ) {
+		$settings = self::normalize_textarea_values_for_client( $settings );
+
 		foreach ( self::get_sensitive_keys() as $key ) {
 			if ( ! array_key_exists( $key, $settings ) ) {
 				continue;
@@ -53,6 +55,70 @@ final class ClientPayload {
 		}
 
 		return $settings;
+	}
+
+	/**
+	 * Normalize stored textarea arrays to strings for React textarea controls.
+	 *
+	 * @param array<string, mixed> $settings Stored settings.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function normalize_textarea_values_for_client( array $settings ) {
+		$textarea_keys = self::get_textarea_field_keys();
+
+		foreach ( $textarea_keys as $key ) {
+			if ( empty( $settings[ $key ] ) || ! is_array( $settings[ $key ] ) ) {
+				continue;
+			}
+
+			$settings[ $key ] = implode(
+				"\n",
+				array_filter(
+					array_map(
+						static function ( $value ) {
+							return is_scalar( $value ) ? (string) $value : '';
+						},
+						$settings[ $key ]
+					),
+					static function ( $value ) {
+						return '' !== $value;
+					}
+				)
+			);
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * Get field ids for textarea controls.
+	 *
+	 * @return array<int, string>
+	 */
+	private static function get_textarea_field_keys() {
+		$keys   = [];
+		$fields = \Perform\Includes\Helpers::get_settings_fields();
+
+		foreach ( $fields as $cards ) {
+			if ( ! is_array( $cards ) ) {
+				continue;
+			}
+
+			foreach ( $cards as $card ) {
+				if ( empty( $card['fields'] ) || ! is_array( $card['fields'] ) ) {
+					continue;
+				}
+
+				foreach ( $card['fields'] as $field ) {
+					if ( isset( $field['id'], $field['type'] ) && 'textarea' === $field['type'] ) {
+						$keys[] = (string) $field['id'];
+					}
+				}
+			}
+		}
+
+		return array_values( array_unique( $keys ) );
 	}
 
 	/**

--- a/src/Admin/Settings/Menu.php
+++ b/src/Admin/Settings/Menu.php
@@ -185,6 +185,10 @@ class Menu {
 		$new_settings['dns_prefetch'] = $this->normalize_multiline_setting( $new_settings['dns_prefetch'] ?? '' );
 		$new_settings['preconnect']   = $this->normalize_multiline_setting( $new_settings['preconnect'] ?? '' );
 
+		foreach ( $this->get_cache_bypass_list_setting_keys() as $setting_key ) {
+			$new_settings[ $setting_key ] = $this->normalize_rule_list_setting( $new_settings[ $setting_key ] ?? '' );
+		}
+
 		$is_saved = update_option( 'perform_settings', $new_settings, false );
 		if ( ! $is_saved && get_option( 'perform_settings' ) === $new_settings ) {
 			$is_saved = true;
@@ -236,5 +240,58 @@ class Menu {
 		);
 
 		return array_values( $lines );
+	}
+
+	/**
+	 * Normalize a cache exclusion list setting to clean unique tokens.
+	 *
+	 * @param mixed $value List value.
+	 *
+	 * @return array<int, string>
+	 */
+	private function normalize_rule_list_setting( $value ) {
+		if ( is_array( $value ) ) {
+			$items = $value;
+		} elseif ( is_scalar( $value ) && '' !== (string) $value ) {
+			$items = preg_split( '/[\r\n,]+/', (string) $value );
+		} else {
+			return [];
+		}
+
+		$items = array_filter(
+			array_map(
+				static function ( $item ) {
+					return is_scalar( $item ) ? sanitize_text_field( wp_unslash( $item ) ) : '';
+				},
+				$items
+			),
+			static function ( $item ) {
+				return '' !== trim( (string) $item );
+			}
+		);
+
+		$items = array_map(
+			static function ( $item ) {
+				return trim( (string) $item );
+			},
+			$items
+		);
+
+		return array_values( array_unique( $items ) );
+	}
+
+	/**
+	 * Get cache bypass setting keys that store newline/comma lists.
+	 *
+	 * @return array<int, string>
+	 */
+	private function get_cache_bypass_list_setting_keys() {
+		return [
+			'cache_bypass_exact_paths',
+			'cache_bypass_path_prefixes',
+			'cache_bypass_query_params',
+			'cache_bypass_cookie_names',
+			'cache_bypass_cookie_prefixes',
+		];
 	}
 }

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -791,6 +791,76 @@ class Helpers {
 								)
 							),
 						],
+						[
+							'id'          => 'cache_bypass_exact_paths',
+							'type'        => 'textarea',
+							'name'        => esc_html__( 'Bypass Exact Paths', 'perform' ),
+							'desc'        => esc_html__( 'One URL path per line that should bypass full-page cache exactly, such as /account/dashboard.', 'perform' ),
+							'placeholder' => "/account/dashboard\n/members-only",
+							'rows'        => 4,
+							'help_link'   => esc_url(
+								add_query_arg(
+									$utm_args,
+									'https://performwp.com/docs/page-cache-exclusions'
+								)
+							),
+						],
+						[
+							'id'          => 'cache_bypass_path_prefixes',
+							'type'        => 'textarea',
+							'name'        => esc_html__( 'Bypass Path Prefixes', 'perform' ),
+							'desc'        => esc_html__( 'One URL path prefix per line that should bypass full-page cache, such as /checkout or /private.', 'perform' ),
+							'placeholder' => "/checkout\n/private",
+							'rows'        => 4,
+							'help_link'   => esc_url(
+								add_query_arg(
+									$utm_args,
+									'https://performwp.com/docs/page-cache-exclusions'
+								)
+							),
+						],
+						[
+							'id'          => 'cache_bypass_query_params',
+							'type'        => 'textarea',
+							'name'        => esc_html__( 'Bypass Query Keys', 'perform' ),
+							'desc'        => esc_html__( 'Query keys that should bypass cache reads and writes entirely. This is separate from query keys that create separate cache entries.', 'perform' ),
+							'placeholder' => "preview_token\nab_variant",
+							'rows'        => 4,
+							'help_link'   => esc_url(
+								add_query_arg(
+									$utm_args,
+									'https://performwp.com/docs/page-cache-exclusions'
+								)
+							),
+						],
+						[
+							'id'          => 'cache_bypass_cookie_names',
+							'type'        => 'textarea',
+							'name'        => esc_html__( 'Bypass Cookie Names', 'perform' ),
+							'desc'        => esc_html__( 'Cookie names that should bypass cache reads and writes. Cookie values are never needed for matching.', 'perform' ),
+							'placeholder' => "membership_session\nexperiment_override",
+							'rows'        => 4,
+							'help_link'   => esc_url(
+								add_query_arg(
+									$utm_args,
+									'https://performwp.com/docs/page-cache-exclusions'
+								)
+							),
+						],
+						[
+							'id'          => 'cache_bypass_cookie_prefixes',
+							'type'        => 'textarea',
+							'name'        => esc_html__( 'Bypass Cookie Prefixes', 'perform' ),
+							'desc'        => esc_html__( 'Cookie name prefixes that should bypass cache reads and writes, such as wp-postpass_ or custom_session_.', 'perform' ),
+							'placeholder' => "wp-postpass_\ncustom_session_",
+							'rows'        => 4,
+							'help_link'   => esc_url(
+								add_query_arg(
+									$utm_args,
+									'https://performwp.com/docs/page-cache-exclusions'
+								)
+							),
+						],
 					],
 				],
 				[

--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -47,6 +47,13 @@ class PageCache implements ModuleInterface {
 	private $should_write_cache = false;
 
 	/**
+	 * Current cache bypass reason for the request.
+	 *
+	 * @var string
+	 */
+	private $current_bypass_reason = '';
+
+	/**
 	 * Request start time.
 	 *
 	 * @var float
@@ -179,7 +186,10 @@ class PageCache implements ModuleInterface {
 		$this->request_start = microtime( true );
 
 		if ( ! $this->is_cacheable_request() ) {
-			$this->increment_stat( 'bypasses' );
+			$bypass_increment = $this->increment_stat( 'bypasses' );
+			if ( 0 < $bypass_increment ) {
+				$this->record_bypass_reason( $this->current_bypass_reason, $bypass_increment );
+			}
 			return;
 		}
 
@@ -492,8 +502,9 @@ class PageCache implements ModuleInterface {
 		$total      = max( 1, ( $hits + $stale_hits + $misses ) );
 		$hit_ratio  = round( ( ( $hits + $stale_hits ) / $total ) * 100, 2 );
 
-		$top_misses    = $stats['top_misses'] ?? [];
-		$slow_uncached = $stats['slow_uncached'] ?? [];
+		$top_misses     = $stats['top_misses'] ?? [];
+		$bypass_reasons = $stats['bypass_reasons'] ?? [];
+		$slow_uncached  = $stats['slow_uncached'] ?? [];
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Perform Cache Observability', 'perform' ); ?></h1>
@@ -515,6 +526,9 @@ class PageCache implements ModuleInterface {
 			<h2><?php esc_html_e( 'Top Missed URLs', 'perform' ); ?></h2>
 			<?php $this->render_stat_map_table( $top_misses, esc_html__( 'Misses', 'perform' ) ); ?>
 
+			<h2><?php esc_html_e( 'Bypass Reasons', 'perform' ); ?></h2>
+			<?php $this->render_stat_map_table( $bypass_reasons, esc_html__( 'Bypasses', 'perform' ), esc_html__( 'Reason', 'perform' ) ); ?>
+
 			<h2><?php esc_html_e( 'Slow Uncached URLs (ms)', 'perform' ); ?></h2>
 			<?php $this->render_stat_map_table( $slow_uncached, esc_html__( 'Render Time (ms)', 'perform' ) ); ?>
 		</div>
@@ -526,19 +540,24 @@ class PageCache implements ModuleInterface {
 	 *
 	 * @param array<string, int|float> $map Stat map.
 	 * @param string                    $value_header Value header label.
+	 * @param string                    $key_header Key header label.
 	 *
 	 * @return void
 	 */
-	private function render_stat_map_table( $map, $value_header ) {
+	private function render_stat_map_table( $map, $value_header, $key_header = '' ) {
 		if ( ! is_array( $map ) || empty( $map ) ) {
 			echo '<p>' . esc_html__( 'No data yet.', 'perform' ) . '</p>';
 			return;
+		}
+
+		if ( '' === $key_header ) {
+			$key_header = esc_html__( 'URL', 'perform' );
 		}
 		?>
 		<table class="widefat striped" style="max-width:1200px;">
 			<thead>
 				<tr>
-					<th><?php esc_html_e( 'URL', 'perform' ); ?></th>
+					<th><?php echo esc_html( $key_header ); ?></th>
 					<th><?php echo esc_html( $value_header ); ?></th>
 				</tr>
 			</thead>
@@ -882,27 +901,38 @@ class PageCache implements ModuleInterface {
 	 * @return bool
 	 */
 	private function is_cacheable_request() {
+		$this->current_bypass_reason = $this->get_cache_bypass_reason();
+
+		return '' === $this->current_bypass_reason;
+	}
+
+	/**
+	 * Get the reason the current request should bypass page cache.
+	 *
+	 * @return string Empty string when cacheable.
+	 */
+	private function get_cache_bypass_reason() {
 		if ( is_admin() || wp_doing_ajax() || wp_doing_cron() ) {
-			return false;
+			return 'runtime_context';
 		}
 
 		if ( ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
-			return false;
+			return 'runtime_context';
 		}
 
 		if ( is_user_logged_in() || is_preview() || is_feed() || is_trackback() || is_robots() || is_search() ) {
-			return false;
+			return 'wordpress_context';
 		}
 
 		$method = isset( $_SERVER['REQUEST_METHOD'] ) ? strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) ) : 'GET';
 		if ( ! in_array( $method, [ 'GET', 'HEAD' ], true ) ) {
-			return false;
+			return 'http_method';
 		}
 
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 		$path        = '' !== $request_uri ? wp_parse_url( $request_uri, PHP_URL_PATH ) : '';
 		if ( is_string( $path ) ) {
-			$path          = untrailingslashit( strtolower( $path ) );
+			$path          = $this->normalize_request_path( $path );
 			$blocked_paths = [
 				'/cart',
 				'/checkout',
@@ -911,13 +941,25 @@ class PageCache implements ModuleInterface {
 			];
 			foreach ( $blocked_paths as $blocked_path ) {
 				if ( 0 === strpos( $path, $blocked_path ) ) {
-					return false;
+					return 'default_path';
 				}
+			}
+
+			if ( $this->path_matches_exact_bypass_rule( $path ) ) {
+				return 'path_exact';
+			}
+
+			if ( $this->path_matches_prefix_bypass_rule( $path ) ) {
+				return 'path_prefix';
 			}
 		}
 
 		if ( isset( $_GET['add-to-cart'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only cache bypass signal.
-			return false;
+			return 'default_query';
+		}
+
+		if ( $this->request_has_bypass_query_key() ) {
+			return 'query_key';
 		}
 
 		$cookies        = $_COOKIE; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -932,12 +974,262 @@ class PageCache implements ModuleInterface {
 		foreach ( $cookies as $cookie_name => $cookie_value ) {
 			foreach ( $bypass_cookies as $prefix ) {
 				if ( 0 === strpos( (string) $cookie_name, $prefix ) ) {
-					return false;
+					return 'default_cookie';
 				}
 			}
 		}
 
-		return true;
+		if ( $this->request_has_bypass_cookie_name() ) {
+			return 'cookie_name';
+		}
+
+		if ( $this->request_has_bypass_cookie_prefix() ) {
+			return 'cookie_prefix';
+		}
+
+		$custom_reason = $this->get_custom_bypass_reason(
+			[
+				'method'       => $method,
+				'path'         => is_string( $path ) ? $path : '',
+				'query_keys'   => $this->get_request_query_keys(),
+				'cookie_names' => $this->get_request_cookie_names(),
+				'request_uri'  => $request_uri,
+			]
+		);
+
+		return $custom_reason;
+	}
+
+	/**
+	 * Normalize a request path for case-insensitive matching.
+	 *
+	 * @param string $path Request path.
+	 *
+	 * @return string
+	 */
+	private function normalize_request_path( $path ) {
+		$path = '/' . ltrim( strtolower( rawurldecode( (string) $path ) ), '/' );
+		$path = rtrim( $path, '/' );
+
+		return '' === $path ? '/' : $path;
+	}
+
+	/**
+	 * Determine if the request path matches an exact exclusion rule.
+	 *
+	 * @param string $path Normalized request path.
+	 *
+	 * @return bool
+	 */
+	private function path_matches_exact_bypass_rule( $path ) {
+		$rules = $this->get_cache_bypass_rules( 'cache_bypass_exact_paths' );
+		foreach ( $rules as $rule ) {
+			if ( $path === $this->normalize_request_path( $rule ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determine if the request path matches a prefix exclusion rule.
+	 *
+	 * @param string $path Normalized request path.
+	 *
+	 * @return bool
+	 */
+	private function path_matches_prefix_bypass_rule( $path ) {
+		$rules = $this->get_cache_bypass_rules( 'cache_bypass_path_prefixes' );
+		foreach ( $rules as $rule ) {
+			$prefix = $this->normalize_request_path( $rule );
+			if ( '/' === $prefix || 0 === strpos( $path, $prefix ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determine if any configured query key should bypass cache.
+	 *
+	 * @return bool
+	 */
+	private function request_has_bypass_query_key() {
+		$bypass_keys = $this->get_cache_bypass_rules( 'cache_bypass_query_params' );
+		if ( empty( $bypass_keys ) ) {
+			return false;
+		}
+
+		$bypass_keys = array_fill_keys( array_map( [ $this, 'normalize_rule_token' ], $bypass_keys ), true );
+		foreach ( $this->get_request_query_keys() as $query_key ) {
+			if ( isset( $bypass_keys[ $this->normalize_rule_token( $query_key ) ] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determine if any configured cookie name should bypass cache.
+	 *
+	 * @return bool
+	 */
+	private function request_has_bypass_cookie_name() {
+		$bypass_names = $this->get_cache_bypass_rules( 'cache_bypass_cookie_names' );
+		if ( empty( $bypass_names ) ) {
+			return false;
+		}
+
+		$bypass_names = array_fill_keys( array_map( [ $this, 'normalize_rule_token' ], $bypass_names ), true );
+		foreach ( $this->get_request_cookie_names() as $cookie_name ) {
+			if ( isset( $bypass_names[ $this->normalize_rule_token( $cookie_name ) ] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determine if any configured cookie prefix should bypass cache.
+	 *
+	 * @return bool
+	 */
+	private function request_has_bypass_cookie_prefix() {
+		$prefixes = $this->get_cache_bypass_rules( 'cache_bypass_cookie_prefixes' );
+		if ( empty( $prefixes ) ) {
+			return false;
+		}
+
+		$prefixes = array_map( [ $this, 'normalize_rule_token' ], $prefixes );
+		foreach ( $this->get_request_cookie_names() as $cookie_name ) {
+			$cookie_name = $this->normalize_rule_token( $cookie_name );
+			foreach ( $prefixes as $prefix ) {
+				if ( '' !== $prefix && 0 === strpos( $cookie_name, $prefix ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get normalized configured bypass rules from settings.
+	 *
+	 * @param string $option Settings key.
+	 *
+	 * @return array<int, string>
+	 */
+	private function get_cache_bypass_rules( $option ) {
+		$value = Helpers::get_option( $option, 'perform_settings', [] );
+		if ( is_string( $value ) ) {
+			$value = preg_split( '/[\r\n,]+/', $value );
+		}
+
+		if ( ! is_array( $value ) ) {
+			return [];
+		}
+
+		$rules = [];
+		foreach ( $value as $rule ) {
+			if ( ! is_scalar( $rule ) ) {
+				continue;
+			}
+
+			$rule = trim( (string) $rule );
+			if ( '' === $rule ) {
+				continue;
+			}
+
+			$rules[] = $rule;
+		}
+
+		return array_values( array_unique( $rules ) );
+	}
+
+	/**
+	 * Get request query keys without query values.
+	 *
+	 * @return array<int, string>
+	 */
+	private function get_request_query_keys() {
+		return array_map( 'strval', array_keys( $_GET ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only cache bypass signal.
+	}
+
+	/**
+	 * Get request cookie names without cookie values.
+	 *
+	 * @return array<int, string>
+	 */
+	private function get_request_cookie_names() {
+		return array_map( 'strval', array_keys( $_COOKIE ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Names only.
+	}
+
+	/**
+	 * Normalize a query or cookie rule token for case-insensitive matching.
+	 *
+	 * @param string $token Rule token.
+	 *
+	 * @return string
+	 */
+	private function normalize_rule_token( $token ) {
+		return strtolower( trim( rawurldecode( (string) $token ) ) );
+	}
+
+	/**
+	 * Get optional custom bypass reason from advanced filter logic.
+	 *
+	 * @param array<string, mixed> $context Request context without raw query or cookie values.
+	 *
+	 * @return string Empty string when cacheable.
+	 */
+	private function get_custom_bypass_reason( array $context ) {
+		$reason = apply_filters( 'perform_page_cache_bypass_reason', '', $context );
+
+		if ( true === $reason ) {
+			return 'custom_filter';
+		}
+
+		if ( is_scalar( $reason ) && '' !== trim( (string) $reason ) ) {
+			return $this->normalize_stat_key( (string) $reason );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Record aggregate bypass reason stats.
+	 *
+	 * @param string $reason Bypass reason.
+	 * @param int    $increment Increment amount.
+	 *
+	 * @return void
+	 */
+	private function record_bypass_reason( $reason, $increment ) {
+		$reason = '' !== $reason ? $reason : 'unknown';
+		$reason = $this->normalize_stat_key( $reason );
+
+		$reasons            = $this->get_stat_map( 'bypass_reasons' );
+		$reasons[ $reason ] = ( $reasons[ $reason ] ?? 0 ) + $increment;
+		$this->set_stat_map( 'bypass_reasons', $reasons );
+	}
+
+	/**
+	 * Normalize a string for use as a stats-map key.
+	 *
+	 * @param string $key Stats key.
+	 *
+	 * @return string
+	 */
+	private function normalize_stat_key( $key ) {
+		$key = strtolower( sanitize_text_field( $key ) );
+		$key = preg_replace( '/[^a-z0-9_\-]+/', '_', $key );
+
+		return is_string( $key ) && '' !== trim( $key, '_' ) ? trim( $key, '_' ) : 'custom_filter';
 	}
 
 	/**

--- a/src/Modules/Cache/StatsStore.php
+++ b/src/Modules/Cache/StatsStore.php
@@ -82,7 +82,8 @@ final class StatsStore {
 	 * @var array<string, bool>
 	 */
 	private $additive_map_keys = [
-		'top_misses' => true,
+		'bypass_reasons' => true,
+		'top_misses'     => true,
 	];
 
 	/**
@@ -91,8 +92,9 @@ final class StatsStore {
 	 * @var array<string, int>
 	 */
 	private $map_limits = [
-		'top_misses'    => 50,
-		'slow_uncached' => 30,
+		'bypass_reasons' => 20,
+		'top_misses'     => 50,
+		'slow_uncached'  => 30,
 	];
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -184,6 +184,12 @@ if ( ! function_exists( 'esc_html__' ) ) {
 	}
 }
 
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = 'default' ) {
+		return (string) $text;
+	}
+}
+
 if ( ! function_exists( 'current_user_can' ) ) {
 	function current_user_can( $capability ) {
 		$capabilities = isset( $GLOBALS['perform_test_current_user_can'] ) && is_array( $GLOBALS['perform_test_current_user_can'] ) ? $GLOBALS['perform_test_current_user_can'] : [];
@@ -197,9 +203,51 @@ if ( ! function_exists( 'is_admin' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_doing_ajax' ) ) {
+	function wp_doing_ajax() {
+		return ! empty( $GLOBALS['perform_test_wp_doing_ajax'] );
+	}
+}
+
+if ( ! function_exists( 'wp_doing_cron' ) ) {
+	function wp_doing_cron() {
+		return ! empty( $GLOBALS['perform_test_wp_doing_cron'] );
+	}
+}
+
 if ( ! function_exists( 'is_user_logged_in' ) ) {
 	function is_user_logged_in() {
 		return ! empty( $GLOBALS['perform_test_is_user_logged_in'] );
+	}
+}
+
+if ( ! function_exists( 'is_preview' ) ) {
+	function is_preview() {
+		return ! empty( $GLOBALS['perform_test_is_preview'] );
+	}
+}
+
+if ( ! function_exists( 'is_feed' ) ) {
+	function is_feed() {
+		return ! empty( $GLOBALS['perform_test_is_feed'] );
+	}
+}
+
+if ( ! function_exists( 'is_trackback' ) ) {
+	function is_trackback() {
+		return ! empty( $GLOBALS['perform_test_is_trackback'] );
+	}
+}
+
+if ( ! function_exists( 'is_robots' ) ) {
+	function is_robots() {
+		return ! empty( $GLOBALS['perform_test_is_robots'] );
+	}
+}
+
+if ( ! function_exists( 'is_search' ) ) {
+	function is_search() {
+		return ! empty( $GLOBALS['perform_test_is_search'] );
 	}
 }
 

--- a/tests/unit-tests/tests-client-payload.php
+++ b/tests/unit-tests/tests-client-payload.php
@@ -20,4 +20,17 @@ final class Tests_Client_Payload extends TestCase {
 		$this->assertTrue( ClientPayload::is_masked_secret( ClientPayload::MASKED_SECRET ) );
 		$this->assertFalse( ClientPayload::is_masked_secret( 'plain-value' ) );
 	}
+
+	public function test_textarea_array_values_are_normalized_for_client_payload() {
+		$payload = ClientPayload::sanitize_for_client(
+			[
+				'cache_bypass_exact_paths' => [
+					'/members',
+					'/account/dashboard',
+				],
+			]
+		);
+
+		$this->assertSame( "/members\n/account/dashboard", $payload['cache_bypass_exact_paths'] );
+	}
 }

--- a/tests/unit-tests/tests-page-cache.php
+++ b/tests/unit-tests/tests-page-cache.php
@@ -13,6 +13,10 @@ final class Tests_Page_Cache extends TestCase {
 		$GLOBALS['perform_test_home_url']         = 'https://example.com';
 		$GLOBALS['perform_test_remote_get_map']   = [];
 		$GLOBALS['perform_test_remote_get_calls'] = [];
+		$_COOKIE                                  = [];
+		$_GET                                     = [];
+		$_SERVER['REQUEST_METHOD']                = 'GET';
+		$_SERVER['REQUEST_URI']                   = '/';
 		unset( $_SERVER['HTTP_X_PERFORM_CACHE_REGEN'] );
 	}
 
@@ -24,8 +28,12 @@ final class Tests_Page_Cache extends TestCase {
 			$GLOBALS['perform_test_remote_get_calls'],
 			$GLOBALS['perform_test_remote_get_map'],
 			$GLOBALS['perform_test_transients'],
+			$_SERVER['REQUEST_METHOD'],
+			$_SERVER['REQUEST_URI'],
 			$_SERVER['HTTP_X_PERFORM_CACHE_REGEN']
 		);
+		$_COOKIE = [];
+		$_GET    = [];
 	}
 
 	public function test_internal_regeneration_requires_matching_lock_token() {
@@ -145,10 +153,122 @@ final class Tests_Page_Cache extends TestCase {
 		);
 	}
 
+	public function test_configured_exact_path_bypasses_cache_without_writes() {
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings' => [
+				'cache_bypass_exact_paths' => [ '/members/dashboard' ],
+			],
+		];
+		$_SERVER['REQUEST_URI']          = '/members/dashboard?lang=en';
+
+		$page_cache = new PageCache();
+
+		$this->assertFalse( $this->invoke_is_cacheable_request( $page_cache ) );
+		$this->assertSame( 'path_exact', $this->get_private_property( $page_cache, 'current_bypass_reason' ) );
+	}
+
+	public function test_configured_path_prefix_bypasses_cache_without_changing_exact_behavior() {
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings' => [
+				'cache_bypass_path_prefixes' => [ '/private' ],
+			],
+		];
+		$_SERVER['REQUEST_URI']          = '/private/report';
+
+		$page_cache = new PageCache();
+
+		$this->assertFalse( $this->invoke_is_cacheable_request( $page_cache ) );
+		$this->assertSame( 'path_prefix', $this->get_private_property( $page_cache, 'current_bypass_reason' ) );
+
+		$_SERVER['REQUEST_URI'] = '/public/report';
+		$this->assertTrue( $this->invoke_is_cacheable_request( $page_cache ) );
+	}
+
+	public function test_configured_query_bypass_is_distinct_from_query_variation() {
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings' => [
+				'cache_separate_query_params' => 'lang',
+				'cache_bypass_query_params'   => [ 'preview_token' ],
+			],
+		];
+		$_GET                            = [
+			'lang' => 'en',
+		];
+
+		$page_cache = new PageCache();
+		$this->assertTrue( $this->invoke_is_cacheable_request( $page_cache ) );
+
+		$_GET['preview_token'] = 'abc123';
+		$this->assertFalse( $this->invoke_is_cacheable_request( $page_cache ) );
+		$this->assertSame( 'query_key', $this->get_private_property( $page_cache, 'current_bypass_reason' ) );
+	}
+
+	public function test_configured_cookie_name_and_prefix_bypass_cache() {
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings' => [
+				'cache_bypass_cookie_names'    => [ 'membership_session' ],
+				'cache_bypass_cookie_prefixes' => [ 'experiment_' ],
+			],
+		];
+
+		$page_cache = new PageCache();
+
+		$_COOKIE = [ 'membership_session' => 'secret-value' ];
+		$this->assertFalse( $this->invoke_is_cacheable_request( $page_cache ) );
+		$this->assertSame( 'cookie_name', $this->get_private_property( $page_cache, 'current_bypass_reason' ) );
+
+		$_COOKIE = [ 'experiment_variant' => 'b' ];
+		$this->assertFalse( $this->invoke_is_cacheable_request( $page_cache ) );
+		$this->assertSame( 'cookie_prefix', $this->get_private_property( $page_cache, 'current_bypass_reason' ) );
+	}
+
+	public function test_custom_filter_can_bypass_cache_with_named_reason() {
+		$GLOBALS['perform_test_filters']['perform_page_cache_bypass_reason'] = static function ( $reason, $context ) {
+			return '/dynamic' === $context['path'] ? 'partner area' : $reason;
+		};
+		$_SERVER['REQUEST_URI'] = '/dynamic';
+
+		$page_cache = new PageCache();
+
+		$this->assertFalse( $this->invoke_is_cacheable_request( $page_cache ) );
+		$this->assertSame( 'partner_area', $this->get_private_property( $page_cache, 'current_bypass_reason' ) );
+	}
+
+	public function test_bypass_reasons_are_aggregated_in_stats() {
+		$GLOBALS['perform_test_options']                                    = [
+			'perform_settings' => [
+				'cache_bypass_query_params' => [ 'preview_token' ],
+			],
+		];
+		$GLOBALS['perform_test_filters']['perform_cache_stats_sample_rate'] = 1;
+		$_GET['preview_token'] = 'abc123';
+
+		$page_cache = new PageCache();
+		$page_cache->maybe_serve_cache();
+		$page_cache->flush_stats();
+
+		$this->assertSame( 1, $GLOBALS['perform_test_options']['perform_cache_stats']['bypasses'] );
+		$this->assertSame( 1, $GLOBALS['perform_test_options']['perform_cache_stats']['bypass_reasons']['query_key'] );
+	}
+
 	private function set_private_property( PageCache $page_cache, string $property_name, int $value ): void {
 		$property = new ReflectionProperty( $page_cache, $property_name );
 		$property->setAccessible( true );
 		$property->setValue( $page_cache, $value );
+	}
+
+	private function get_private_property( PageCache $page_cache, string $property_name ) {
+		$property = new ReflectionProperty( $page_cache, $property_name );
+		$property->setAccessible( true );
+
+		return $property->getValue( $page_cache );
+	}
+
+	private function invoke_is_cacheable_request( PageCache $page_cache ): bool {
+		$method = new ReflectionMethod( $page_cache, 'is_cacheable_request' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $page_cache );
 	}
 
 	private function build_sitemap_index_xml( int $child_count ): string {

--- a/tests/unit-tests/tests-settings-menu.php
+++ b/tests/unit-tests/tests-settings-menu.php
@@ -31,4 +31,19 @@ final class Tests_Settings_Menu extends TestCase {
 			$method->invoke( $menu, [ 'https://fonts.example.com', '', 'https://cdn.example.com' ] )
 		);
 	}
+
+	public function test_cache_bypass_rule_lists_are_sanitized_and_deduplicated() {
+		$menu   = new Menu();
+		$method = new ReflectionMethod( $menu, 'normalize_rule_list_setting' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			[
+				'/private',
+				'/members',
+				'preview_token',
+			],
+			$method->invoke( $menu, " /private \n/members,preview_token\n/private" )
+		);
+	}
 }


### PR DESCRIPTION
## Summary
- Add explicit full-page cache bypass settings for exact paths, path prefixes, query keys, cookie names, and cookie prefixes.
- Keep query-key bypass separate from existing query-key cache variation.
- Record cache bypass reasons in observability stats and add an advanced `perform_page_cache_bypass_reason` filter for custom bypass logic.
- Normalize textarea list values for settings storage and client payload hydration.

## Validation
- `php -l src/Admin/Settings/ClientPayload.php && php -l src/Admin/Settings/Menu.php && php -l src/Includes/Helpers.php && php -l src/Modules/Cache/PageCache.php && php -l src/Modules/Cache/StatsStore.php && php -l tests/bootstrap.php && php -l tests/unit-tests/tests-page-cache.php`
- `composer test` (34 tests, 63 assertions)
- `composer phpstan`
- `./vendor/bin/phpcs -s src/Admin/Settings/ClientPayload.php src/Admin/Settings/Menu.php src/Includes/Helpers.php src/Modules/Cache/PageCache.php src/Modules/Cache/StatsStore.php tests/bootstrap.php tests/unit-tests/tests-client-payload.php tests/unit-tests/tests-page-cache.php tests/unit-tests/tests-settings-menu.php`
- `git diff --check`

## Proof Gap
- This adds settings UI fields and cache runtime behavior. Local wp-env/browser proof was not rerun here because the local shell does not expose Docker; GitHub CI should provide the WordPress smoke signal.

Closes #127
