### PR TITLE
Add runtime diagnostics panel

### DIFF
--- a/assets/src/css/admin/settings.css
+++ b/assets/src/css/admin/settings.css
@@ -70,3 +70,61 @@
 .perform-help-icon {
 	margin-left: 0;
 }
+
+.perform-diagnostics-panel {
+	margin: 0 20px 24px;
+	border-radius: 0;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.perform-diagnostics-panel__header {
+	align-items: flex-start;
+	flex-direction: column;
+}
+
+.perform-diagnostics-list {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+	gap: 16px;
+}
+
+.perform-diagnostics-item {
+	border-left: 4px solid var(--primary-color);
+	background: #f6f7f7;
+	padding: 12px 14px;
+}
+
+.perform-diagnostics-item[data-status='warning'] {
+	border-left-color: #b26200;
+}
+
+.perform-diagnostics-item[data-status='needs-attention'] {
+	border-left-color: #b32d2e;
+}
+
+.perform-diagnostics-item__heading {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.perform-diagnostics-item p {
+	margin: 8px 0 0;
+}
+
+.perform-diagnostics-item__action {
+	color: #50575e;
+}
+
+.perform-diagnostics-badge {
+	display: inline-flex;
+	align-items: center;
+	min-height: 22px;
+	border-radius: 3px;
+	background: #fff;
+	padding: 2px 8px;
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+}

--- a/assets/src/js/admin/DiagnosticsPanel.jsx
+++ b/assets/src/js/admin/DiagnosticsPanel.jsx
@@ -1,0 +1,50 @@
+import { Card, CardBody, CardHeader } from '@wordpress/components';
+
+const STATUS_LABELS = {
+	ready: 'Ready',
+	warning: 'Warning',
+	'needs-attention': 'Needs attention',
+};
+
+const DiagnosticsPanel = ( { diagnostics } ) => {
+	const items = diagnostics?.items || [];
+
+	if ( ! items.length ) {
+		return null;
+	}
+
+	return (
+		<Card className="perform-diagnostics-panel">
+			<CardHeader className="perform-diagnostics-panel__header">
+				<div>
+					<h3 className="perform-card-title">Runtime Diagnostics</h3>
+					<p className="perform-card-description">
+						Read-only checks for cache, CDN, and optimization prerequisites.
+					</p>
+				</div>
+			</CardHeader>
+			<CardBody>
+				<div className="perform-diagnostics-list">
+					{ items.map( ( item ) => {
+						const status = item.status || 'warning';
+
+						return (
+							<div className="perform-diagnostics-item" data-status={ status } key={ item.label }>
+								<div className="perform-diagnostics-item__heading">
+									<strong>{ item.label }</strong>
+									<span className="perform-diagnostics-badge">
+										{ STATUS_LABELS[ status ] || 'Warning' }
+									</span>
+								</div>
+								<p>{ item.message }</p>
+								<p className="perform-diagnostics-item__action">{ item.action }</p>
+							</div>
+						);
+					} ) }
+				</div>
+			</CardBody>
+		</Card>
+	);
+};
+
+export default DiagnosticsPanel;

--- a/assets/src/js/admin/SettingsApp.jsx
+++ b/assets/src/js/admin/SettingsApp.jsx
@@ -1,12 +1,14 @@
 import SettingsHeader from './SettingsHeader';
 import SettingsNav from './SettingsNav';
 import Footer from './Footer';
+import DiagnosticsPanel from './DiagnosticsPanel';
 import { useState, useEffect, useMemo, useRef } from '@wordpress/element';
 
 const SETTINGS = window.performwpSettings || {};
 const SETTINGS_TABS = SETTINGS.tabs || {};
 const SETTINGS_FIELDS = SETTINGS.fields || {};
 const SAVED_SETTINGS = SETTINGS.saved || {};
+const INITIAL_DIAGNOSTICS = SETTINGS.diagnostics || {};
 
 const SettingsApp = () => {
 	const tabs = SETTINGS_TABS;
@@ -35,6 +37,7 @@ const SettingsApp = () => {
 	const [ fieldValues, setFieldValues ] = useState( initialValues );
 	const [ saving, setSaving ] = useState( false );
 	const [ message, setMessage ] = useState( null );
+	const [ diagnostics, setDiagnostics ] = useState( INITIAL_DIAGNOSTICS );
 	const [ activeTab, setActiveTab ] = useState( Object.keys( tabs )[ 0 ] || '' );
 	const messageTimerRef = useRef( null );
 
@@ -62,6 +65,9 @@ const SettingsApp = () => {
 			const json = await res.json();
 			if ( json && json.success ) {
 				setMessage( { text: json.data?.message || 'Settings saved.', type: 'success' } );
+				if ( json.data?.diagnostics ) {
+					setDiagnostics( json.data.diagnostics );
+				}
 				// update initialValues snapshot
 				// mutate initialValues object won't update memo, so reset by rebuild: setFieldValues equals current, but we need to reset initialValues - simplest approach: set initial snapshot to current by resetting via a state.
 				// We'll set the initialValues by replacing the state used for comparison: emulate by setting all initialValues to current values via a ref - but here we'll just clear dirty by resetting initialValues via resetting fieldValues baseline.
@@ -144,6 +150,7 @@ const SettingsApp = () => {
 				fieldValues={ fieldValues }
 				onFieldChange={ handleFieldChange }
 			/>
+			<DiagnosticsPanel diagnostics={ diagnostics } />
 			<Footer dirty={ isDirty } saving={ saving } message={ message } onSave={ handleSave } />
 		</>
 	);

--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -12,6 +12,7 @@ namespace Perform\Admin;
 
 use Perform\Includes\Helpers;
 use Perform\Admin\Settings\ClientPayload;
+use Perform\Admin\Settings\RuntimeDiagnostics;
 
 // Bailout, if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -64,6 +65,7 @@ class Actions {
 					'logoUrl'           => plugins_url( 'assets/dist/images/logo.png', PERFORM_PLUGIN_FILE ),
 					'nonce'             => wp_create_nonce( 'perform_save_settings' ),
 					'saved'             => ClientPayload::sanitize_for_client( (array) \Perform\Includes\Helpers::get_settings() ),
+					'diagnostics'       => RuntimeDiagnostics::get_results(),
 					'sensitiveKeys'     => ClientPayload::get_sensitive_keys(),
 					'maskedSecretValue' => ClientPayload::MASKED_SECRET,
 					'tabs'              => \Perform\Includes\Helpers::get_settings_tabs(),

--- a/src/Admin/Settings/Menu.php
+++ b/src/Admin/Settings/Menu.php
@@ -197,8 +197,9 @@ class Menu {
 		if ( $is_saved ) {
 			wp_send_json_success(
 				[
-					'type'    => 'success',
-					'message' => esc_html__( 'Settings saved successfully.', 'perform' ),
+					'type'        => 'success',
+					'message'     => esc_html__( 'Settings saved successfully.', 'perform' ),
+					'diagnostics' => RuntimeDiagnostics::get_results(),
 				]
 			);
 		} else {

--- a/src/Admin/Settings/RuntimeDiagnostics.php
+++ b/src/Admin/Settings/RuntimeDiagnostics.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Perform - Runtime Diagnostics.
+ *
+ * @package Perform
+ * @subpackage Admin/Settings
+ */
+
+namespace Perform\Admin\Settings;
+
+use Perform\Includes\Helpers;
+
+// Bailout, if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class RuntimeDiagnostics {
+	/**
+	 * Build read-only diagnostics for the settings UI.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function get_results() {
+		$settings = Helpers::get_settings();
+		$settings = is_array( $settings ) ? $settings : [];
+
+		$items = [
+			self::diagnose_page_cache_storage( $settings ),
+			self::diagnose_page_cache_dropin(),
+			self::diagnose_cache_preload_schedule( $settings ),
+			self::diagnose_dynamic_cache_exclusions( $settings ),
+			self::diagnose_menu_cache_theme_support( $settings ),
+			self::diagnose_cdn_configuration( $settings ),
+		];
+
+		$summary = [
+			'ready'           => 0,
+			'warning'         => 0,
+			'needs-attention' => 0,
+		];
+
+		foreach ( $items as $item ) {
+			$status = isset( $item['status'] ) ? (string) $item['status'] : 'warning';
+			if ( ! isset( $summary[ $status ] ) ) {
+				$status = 'warning';
+			}
+
+			++$summary[ $status ];
+		}
+
+		return [
+			'summary' => $summary,
+			'items'   => $items,
+		];
+	}
+
+	/**
+	 * Check whether page-cache storage appears writable without creating files.
+	 *
+	 * @param array<string, mixed> $settings Settings.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function diagnose_page_cache_storage( array $settings ) {
+		if ( empty( $settings['enable_page_cache'] ) ) {
+			return self::item(
+				'ready',
+				__( 'Page cache storage', 'perform' ),
+				__( 'Page cache is disabled, so no cache storage is required yet.', 'perform' ),
+				__( 'Enable full-page cache when you are ready to test storage prerequisites.', 'perform' )
+			);
+		}
+
+		$cache_dir      = self::get_cache_dir();
+		$cache_parent   = dirname( $cache_dir );
+		$storage_ready  = is_dir( $cache_dir ) ? is_writable( $cache_dir ) : ( is_dir( $cache_parent ) && is_writable( $cache_parent ) );
+		$storage_status = $storage_ready ? 'ready' : 'needs-attention';
+
+		return self::item(
+			$storage_status,
+			__( 'Page cache storage', 'perform' ),
+			$storage_ready
+				? __( 'Perform can use the cache storage location for generated HTML files.', 'perform' )
+				: __( 'Perform cannot confirm writable cache storage for generated HTML files.', 'perform' ),
+			$storage_ready
+				? __( 'No action needed.', 'perform' )
+				: __( 'Ask your host to allow WordPress to write to its cache directory before relying on full-page cache.', 'perform' )
+		);
+	}
+
+	/**
+	 * Check whether another page-cache drop-in is present.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function diagnose_page_cache_dropin() {
+		$dropin_exists = file_exists( trailingslashit( self::get_wp_content_dir() ) . 'advanced-cache.php' );
+
+		return self::item(
+			$dropin_exists ? 'warning' : 'ready',
+			__( 'Page cache drop-in', 'perform' ),
+			$dropin_exists
+				? __( 'A page-cache drop-in is present, so another cache layer may already be active.', 'perform' )
+				: __( 'No page-cache drop-in was detected.', 'perform' ),
+			$dropin_exists
+				? __( 'Review host or plugin-level page caching before enabling overlapping cache behavior.', 'perform' )
+				: __( 'No action needed.', 'perform' )
+		);
+	}
+
+	/**
+	 * Check cache preload scheduling prerequisites.
+	 *
+	 * @param array<string, mixed> $settings Settings.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function diagnose_cache_preload_schedule( array $settings ) {
+		if ( empty( $settings['enable_cache_preload'] ) ) {
+			return self::item(
+				'ready',
+				__( 'Cache preload schedule', 'perform' ),
+				__( 'Adaptive cache preload is disabled.', 'perform' ),
+				__( 'Enable preload only after page cache is working reliably.', 'perform' )
+			);
+		}
+
+		$scheduled = function_exists( 'wp_next_scheduled' ) && wp_next_scheduled( 'perform_cache_preload_event' );
+
+		return self::item(
+			$scheduled ? 'ready' : 'warning',
+			__( 'Cache preload schedule', 'perform' ),
+			$scheduled
+				? __( 'The cache preload event is scheduled.', 'perform' )
+				: __( 'The cache preload event is not scheduled yet.', 'perform' ),
+			$scheduled
+				? __( 'No action needed.', 'perform' )
+				: __( 'Save settings again or confirm WordPress cron is running on this site.', 'perform' )
+		);
+	}
+
+	/**
+	 * Check whether page cache is enabled without site-specific exclusions.
+	 *
+	 * @param array<string, mixed> $settings Settings.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function diagnose_dynamic_cache_exclusions( array $settings ) {
+		if ( empty( $settings['enable_page_cache'] ) ) {
+			return self::item(
+				'ready',
+				__( 'Dynamic request exclusions', 'perform' ),
+				__( 'Page cache is disabled, so dynamic request exclusions are not required yet.', 'perform' ),
+				__( 'Add exclusions before enabling page cache on sites with member areas, custom checkouts, or preview tokens.', 'perform' )
+			);
+		}
+
+		$has_exclusions = ! empty( $settings['cache_bypass_exact_paths'] )
+			|| ! empty( $settings['cache_bypass_path_prefixes'] )
+			|| ! empty( $settings['cache_bypass_query_params'] )
+			|| ! empty( $settings['cache_bypass_cookie_names'] )
+			|| ! empty( $settings['cache_bypass_cookie_prefixes'] );
+
+		return self::item(
+			$has_exclusions ? 'ready' : 'warning',
+			__( 'Dynamic request exclusions', 'perform' ),
+			$has_exclusions
+				? __( 'Site-specific cache bypass rules are configured.', 'perform' )
+				: __( 'No site-specific cache bypass rules are configured.', 'perform' ),
+			$has_exclusions
+				? __( 'Review bypass rules after adding new dynamic workflows.', 'perform' )
+				: __( 'Add path, query, or cookie exclusions for dynamic workflows before broad cache rollout.', 'perform' )
+		);
+	}
+
+	/**
+	 * Check whether menu cache is enabled on a block theme without opt-in support.
+	 *
+	 * @param array<string, mixed> $settings Settings.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function diagnose_menu_cache_theme_support( array $settings ) {
+		if ( empty( $settings['enable_navigation_menu_cache'] ) ) {
+			return self::item(
+				'ready',
+				__( 'Menu cache theme support', 'perform' ),
+				__( 'Menu cache is disabled.', 'perform' ),
+				__( 'Use menu cache primarily with classic themes that render menus through wp_nav_menu().', 'perform' )
+			);
+		}
+
+		$is_block_theme = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
+		$supported      = (bool) apply_filters( 'perform_menu_cache_supports_current_theme', ! $is_block_theme, $is_block_theme );
+
+		return self::item(
+			$supported ? 'ready' : 'warning',
+			__( 'Menu cache theme support', 'perform' ),
+			$supported
+				? __( 'The active theme is eligible for menu cache.', 'perform' )
+				: __( 'The active block theme is not expected to benefit from menu cache by default.', 'perform' ),
+			$supported
+				? __( 'No action needed.', 'perform' )
+				: __( 'Leave menu cache disabled unless custom theme code opts in through the compatibility filter.', 'perform' )
+		);
+	}
+
+	/**
+	 * Check CDN settings required for safe URL rewriting.
+	 *
+	 * @param array<string, mixed> $settings Settings.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function diagnose_cdn_configuration( array $settings ) {
+		if ( empty( $settings['enable_cdn'] ) ) {
+			return self::item(
+				'ready',
+				__( 'CDN configuration', 'perform' ),
+				__( 'CDN rewriting is disabled.', 'perform' ),
+				__( 'Enable CDN rewriting only after confirming the CDN origin URL and included directories.', 'perform' )
+			);
+		}
+
+		$cdn_url = isset( $settings['cdn_url'] ) && is_scalar( $settings['cdn_url'] ) ? trim( (string) $settings['cdn_url'] ) : '';
+		$scheme  = strtolower( (string) wp_parse_url( $cdn_url, PHP_URL_SCHEME ) );
+		$host    = (string) wp_parse_url( $cdn_url, PHP_URL_HOST );
+		$ready   = '' !== $cdn_url && in_array( $scheme, [ 'http', 'https' ], true ) && '' !== $host;
+
+		return self::item(
+			$ready ? 'ready' : 'needs-attention',
+			__( 'CDN configuration', 'perform' ),
+			$ready
+				? __( 'CDN rewriting has a valid CDN URL.', 'perform' )
+				: __( 'CDN rewriting is enabled but the CDN URL is missing or invalid.', 'perform' ),
+			$ready
+				? __( 'Confirm included directories and exclusions before broad rollout.', 'perform' )
+				: __( 'Enter a full CDN URL with http or https before enabling CDN rewriting.', 'perform' )
+		);
+	}
+
+	/**
+	 * Build a diagnostic item.
+	 *
+	 * @param string $status Status.
+	 * @param string $label Label.
+	 * @param string $message Message.
+	 * @param string $action Action.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function item( $status, $label, $message, $action ) {
+		return [
+			'status'  => $status,
+			'label'   => $label,
+			'message' => $message,
+			'action'  => $action,
+		];
+	}
+
+	/**
+	 * Get WordPress content directory.
+	 *
+	 * @return string
+	 */
+	private static function get_wp_content_dir() {
+		return defined( 'WP_CONTENT_DIR' ) ? WP_CONTENT_DIR : dirname( ABSPATH ) . '/wp-content';
+	}
+
+	/**
+	 * Get Perform cache directory.
+	 *
+	 * @return string
+	 */
+	private static function get_cache_dir() {
+		return trailingslashit( self::get_wp_content_dir() ) . 'cache/perform/';
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+	define( 'WP_CONTENT_DIR', sys_get_temp_dir() . '/perform-test-content' );
+}
+
+if ( ! defined( 'PHP_URL_SCHEME' ) ) {
+	define( 'PHP_URL_SCHEME', 0 );
+}
+
+if ( ! defined( 'PHP_URL_HOST' ) ) {
+	define( 'PHP_URL_HOST', 1 );
+}
+
 if ( ! function_exists( 'get_option' ) ) {
 	function get_option( $name, $default_value = false ) {
 		$store = isset( $GLOBALS['perform_test_options'] ) && is_array( $GLOBALS['perform_test_options'] ) ? $GLOBALS['perform_test_options'] : [];
@@ -64,6 +76,12 @@ if ( ! function_exists( 'delete_transient' ) ) {
 	function delete_transient( $transient ) {
 		unset( $GLOBALS['perform_test_transients'][ $transient ] );
 		return true;
+	}
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( $value ) {
+		return rtrim( (string) $value, '/' ) . '/';
 	}
 }
 
@@ -285,6 +303,14 @@ if ( ! function_exists( 'wp_rand' ) ) {
 		}
 
 		return (int) $min;
+	}
+}
+
+if ( ! function_exists( 'wp_next_scheduled' ) ) {
+	function wp_next_scheduled( $hook ) {
+		$scheduled = isset( $GLOBALS['perform_test_scheduled_events'] ) && is_array( $GLOBALS['perform_test_scheduled_events'] ) ? $GLOBALS['perform_test_scheduled_events'] : [];
+
+		return $scheduled[ $hook ] ?? false;
 	}
 }
 

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -15,6 +15,7 @@ test( 'settings save, Assets Manager, and page cache smoke paths work', async ( 
 	await expect( page.locator( '#perform-settings-page' ) ).toBeVisible();
 	await expect( page.getByRole( 'button', { name: 'Save Settings' } ) ).toBeVisible();
 	await expect( page.getByText( 'General Settings' ) ).toBeVisible();
+	await expect( page.getByText( 'Runtime Diagnostics' ) ).toBeVisible();
 
 	await page.getByRole( 'tab', { name: 'Assets' } ).click();
 	await page.getByRole( 'checkbox', { name: 'Enable Assets Manager' } ).check();

--- a/tests/unit-tests/tests-runtime-diagnostics.php
+++ b/tests/unit-tests/tests-runtime-diagnostics.php
@@ -1,0 +1,106 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Perform\Admin\Settings\RuntimeDiagnostics;
+
+final class Tests_Runtime_Diagnostics extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		$GLOBALS['perform_test_options']          = [];
+		$GLOBALS['perform_test_filters']          = [];
+		$GLOBALS['perform_test_scheduled_events'] = [];
+		$GLOBALS['perform_test_is_block_theme']   = false;
+	}
+
+	protected function tearDown(): void {
+		unset(
+			$GLOBALS['perform_test_options'],
+			$GLOBALS['perform_test_filters'],
+			$GLOBALS['perform_test_scheduled_events'],
+			$GLOBALS['perform_test_is_block_theme']
+		);
+
+		parent::tearDown();
+	}
+
+	public function test_reports_invalid_cdn_url_as_needs_attention() {
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings' => [
+				'enable_cdn' => 1,
+				'cdn_url'    => 'not-a-valid-url',
+			],
+		];
+
+		$item = $this->find_item( RuntimeDiagnostics::get_results(), 'CDN configuration' );
+
+		$this->assertSame( 'needs-attention', $item['status'] );
+		$this->assertStringContainsString( 'missing or invalid', $item['message'] );
+	}
+
+	public function test_reports_unscheduled_preload_when_enabled() {
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings' => [
+				'enable_cache_preload' => 1,
+			],
+		];
+
+		$item = $this->find_item( RuntimeDiagnostics::get_results(), 'Cache preload schedule' );
+
+		$this->assertSame( 'warning', $item['status'] );
+		$this->assertStringContainsString( 'not scheduled', $item['message'] );
+	}
+
+	public function test_reports_menu_cache_warning_for_block_theme_without_filter_opt_in() {
+		$GLOBALS['perform_test_options']        = [
+			'perform_settings' => [
+				'enable_navigation_menu_cache' => 1,
+			],
+		];
+		$GLOBALS['perform_test_is_block_theme'] = true;
+
+		$item = $this->find_item( RuntimeDiagnostics::get_results(), 'Menu cache theme support' );
+
+		$this->assertSame( 'warning', $item['status'] );
+		$this->assertStringContainsString( 'block theme', $item['message'] );
+	}
+
+	public function test_reports_dynamic_exclusion_warning_when_page_cache_has_no_rules() {
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings' => [
+				'enable_page_cache' => 1,
+			],
+		];
+
+		$item = $this->find_item( RuntimeDiagnostics::get_results(), 'Dynamic request exclusions' );
+
+		$this->assertSame( 'warning', $item['status'] );
+		$this->assertStringContainsString( 'No site-specific cache bypass rules', $item['message'] );
+	}
+
+	public function test_summary_counts_diagnostic_statuses() {
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings' => [
+				'enable_cdn'           => 1,
+				'cdn_url'              => 'bad-url',
+				'enable_cache_preload' => 1,
+			],
+		];
+
+		$results = RuntimeDiagnostics::get_results();
+
+		$this->assertSame( 1, $results['summary']['needs-attention'] );
+		$this->assertGreaterThanOrEqual( 1, $results['summary']['warning'] );
+		$this->assertCount( 6, $results['items'] );
+	}
+
+	private function find_item( array $results, string $label ): array {
+		foreach ( $results['items'] as $item ) {
+			if ( $label === $item['label'] ) {
+				return $item;
+			}
+		}
+
+		$this->fail( 'Missing diagnostic item: ' . $label );
+	}
+}


### PR DESCRIPTION
## Summary
- Add a read-only runtime diagnostics service for cache, CDN, menu cache, and dynamic cache exclusion prerequisites.
- Surface diagnostics in the Perform settings UI with ready, warning, and needs-attention states.
- Refresh diagnostics after settings save so users immediately see updated prerequisite status.
- Add unit coverage for the main warning/needs-attention states and extend the WordPress smoke path to assert the diagnostics panel renders.

## Validation
- `php -l src/Admin/Settings/RuntimeDiagnostics.php && php -l src/Admin/Settings/Menu.php && php -l src/Admin/Actions.php && php -l tests/bootstrap.php && php -l tests/unit-tests/tests-runtime-diagnostics.php`
- `composer test` (39 tests, 75 assertions)
- `composer phpstan`
- `./vendor/bin/phpcs -s src/Admin/Settings/RuntimeDiagnostics.php src/Admin/Settings/Menu.php src/Admin/Actions.php tests/bootstrap.php tests/unit-tests/tests-runtime-diagnostics.php`
- `node --check tests/e2e/perform-smoke.spec.js`
- `npm run lint:js`
- `npm run lint:css`
- `npm run build`
- `git diff --check`

## Proof Gap
- Local `npm run test:e2e:ci` is blocked because Docker is unavailable in this shell (`spawn docker ENOENT`). The PR includes a smoke assertion for the Runtime Diagnostics panel so GitHub CI can provide the browser/UI signal.

Closes #126
