### PR TITLE
Cache Assets Manager request state

### DIFF
--- a/src/Modules/Assets/AssetsManager.php
+++ b/src/Modules/Assets/AssetsManager.php
@@ -52,6 +52,27 @@ class AssetsManager implements ModuleInterface {
 	public $selected_options;
 
 	/**
+	 * Cleaned query data for the current request.
+	 *
+	 * @var array<string, mixed>|null
+	 */
+	private $request_query_data = null;
+
+	/**
+	 * Cached current object ID for this request.
+	 *
+	 * @var int|null
+	 */
+	private $current_object_id = null;
+
+	/**
+	 * Parsed source group cache keyed by asset source URL.
+	 *
+	 * @var array<string, array{category:string, group:string}>
+	 */
+	private $asset_source_groups = [];
+
+	/**
 	 * Constructor
 	 *
 	 * @since  1.1.0
@@ -75,7 +96,7 @@ class AssetsManager implements ModuleInterface {
 	 * @return void
 	 */
 	public function register(): void {
-		$this->selected_options = get_option( 'perform_assets_manager_options' );
+		$this->selected_options = $this->get_assets_manager_options();
 
 		add_action( 'template_redirect', [ $this, 'save_assets_manager_settings' ], 10, 2 );
 
@@ -94,13 +115,52 @@ class AssetsManager implements ModuleInterface {
 	 * @return int
 	 */
 	private function get_current_object_id() {
+		if ( null !== $this->current_object_id ) {
+			return $this->current_object_id;
+		}
+
 		$current_id = (int) get_queried_object_id();
 
 		if ( 0 >= $current_id ) {
 			$current_id = (int) get_the_ID();
 		}
 
-		return max( 0, $current_id );
+		$this->current_object_id = max( 0, $current_id );
+
+		return $this->current_object_id;
+	}
+
+	/**
+	 * Get selected Assets Manager options once per request.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_assets_manager_options() {
+		if ( is_array( $this->selected_options ) ) {
+			return $this->selected_options;
+		}
+
+		$options                = get_option( 'perform_assets_manager_options' );
+		$this->selected_options = is_array( $options ) ? $options : [];
+
+		return $this->selected_options;
+	}
+
+	/**
+	 * Get cleaned query data once per request.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_request_query_data() {
+		if ( null !== $this->request_query_data ) {
+			return $this->request_query_data;
+		}
+
+		$query_data               = filter_input_array( INPUT_GET );
+		$query_data               = is_array( $query_data ) ? Helpers::clean( $query_data ) : [];
+		$this->request_query_data = is_array( $query_data ) ? $query_data : [];
+
+		return $this->request_query_data;
 	}
 
 	/**
@@ -501,8 +561,39 @@ class AssetsManager implements ModuleInterface {
 	 * @return bool
 	 */
 	private function is_rule_disabled( $type, $handle ) {
-		return ! empty( $this->selected_options['disabled'][ $type ][ $handle ] )
-			&& is_array( $this->selected_options['disabled'][ $type ][ $handle ] );
+		$options = $this->get_assets_manager_options();
+
+		return ! empty( $options['disabled'][ $type ][ $handle ] )
+			&& is_array( $options['disabled'][ $type ][ $handle ] );
+	}
+
+	/**
+	 * Parse category and group from a registered asset source.
+	 *
+	 * @param string $src Asset source URL.
+	 *
+	 * @return array{category:string, group:string}
+	 */
+	private function get_asset_source_group( $src ) {
+		if ( isset( $this->asset_source_groups[ $src ] ) ) {
+			return $this->asset_source_groups[ $src ];
+		}
+
+		$source_group    = [
+			'category' => '',
+			'group'    => '',
+		];
+		$content_dirname = preg_quote( Helpers::get_content_dir_name(), '/' );
+
+		if ( preg_match( "/\/{$content_dirname}\/(.*?\/.*?)\//", (string) $src, $match ) && ! empty( $match[1] ) ) {
+			$parts                    = explode( '/', $match[1] );
+			$source_group['category'] = isset( $parts[0] ) ? (string) $parts[0] : '';
+			$source_group['group']    = isset( $parts[1] ) ? (string) $parts[1] : '';
+		}
+
+		$this->asset_source_groups[ $src ] = $source_group;
+
+		return $source_group;
 	}
 
 	/**
@@ -1136,24 +1227,17 @@ class AssetsManager implements ModuleInterface {
 			return $src;
 		}
 
-		$get_data = Helpers::clean( filter_input_array( INPUT_GET ) );
+		$get_data = $this->get_request_query_data();
 
 		// Get assets type.
 		$type = current_filter() === 'script_loader_src' ? 'js' : 'css';
 
 		// Load Assets Manager settings.
-		$options         = get_option( 'perform_assets_manager_options' );
+		$options         = $this->get_assets_manager_options();
 		$current_id      = $this->get_current_object_id();
-		$content_dirname = Helpers::get_content_dir_name();
-
-		// Get category + group from src.
-		preg_match( "/\/{$content_dirname}\/(.*?\/.*?)\//", $src, $match );
-
-		if ( ! empty( $match[1] ) ) {
-			$match    = explode( '/', $match[1] );
-			$category = $match[0];
-			$group    = $match[1];
-		}
+		$source_group    = $this->get_asset_source_group( (string) $src );
+		$category        = $source_group['category'];
+		$group           = $source_group['group'];
 
 		// Check for group disable settings and override.
 		if ( ! empty( $category ) && ! empty( $group ) && isset( $options['disabled'][ $category ][ $group ] ) ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,6 +21,12 @@ if ( ! defined( 'PHP_URL_HOST' ) ) {
 
 if ( ! function_exists( 'get_option' ) ) {
 	function get_option( $name, $default_value = false ) {
+		if ( ! isset( $GLOBALS['perform_test_get_option_counts'] ) || ! is_array( $GLOBALS['perform_test_get_option_counts'] ) ) {
+			$GLOBALS['perform_test_get_option_counts'] = [];
+		}
+
+		$GLOBALS['perform_test_get_option_counts'][ $name ] = isset( $GLOBALS['perform_test_get_option_counts'][ $name ] ) ? $GLOBALS['perform_test_get_option_counts'][ $name ] + 1 : 1;
+
 		$store = isset( $GLOBALS['perform_test_options'] ) && is_array( $GLOBALS['perform_test_options'] ) ? $GLOBALS['perform_test_options'] : [];
 		return array_key_exists( $name, $store ) ? $store[ $name ] : $default_value;
 	}
@@ -218,6 +224,43 @@ if ( ! function_exists( 'current_user_can' ) ) {
 if ( ! function_exists( 'is_admin' ) ) {
 	function is_admin() {
 		return ! empty( $GLOBALS['perform_test_is_admin'] );
+	}
+}
+
+if ( ! function_exists( 'current_filter' ) ) {
+	function current_filter() {
+		return isset( $GLOBALS['perform_test_current_filter'] ) ? (string) $GLOBALS['perform_test_current_filter'] : '';
+	}
+}
+
+if ( ! function_exists( 'get_queried_object_id' ) ) {
+	function get_queried_object_id() {
+		return isset( $GLOBALS['perform_test_queried_object_id'] ) ? (int) $GLOBALS['perform_test_queried_object_id'] : 0;
+	}
+}
+
+if ( ! function_exists( 'get_the_ID' ) ) {
+	// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid -- WordPress core compatibility shim.
+	function get_the_ID() {
+		return isset( $GLOBALS['perform_test_the_id'] ) ? (int) $GLOBALS['perform_test_the_id'] : 0;
+	}
+}
+
+if ( ! function_exists( 'is_front_page' ) ) {
+	function is_front_page() {
+		return ! empty( $GLOBALS['perform_test_is_front_page'] );
+	}
+}
+
+if ( ! function_exists( 'is_home' ) ) {
+	function is_home() {
+		return ! empty( $GLOBALS['perform_test_is_home'] );
+	}
+}
+
+if ( ! function_exists( 'get_post_type' ) ) {
+	function get_post_type() {
+		return isset( $GLOBALS['perform_test_post_type'] ) ? (string) $GLOBALS['perform_test_post_type'] : 'post';
 	}
 }
 

--- a/tests/unit-tests/tests-assets-manager.php
+++ b/tests/unit-tests/tests-assets-manager.php
@@ -4,6 +4,32 @@ use PHPUnit\Framework\TestCase;
 use Perform\Modules\Assets\AssetsManager;
 
 final class Tests_Assets_Manager extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		$GLOBALS['perform_test_get_option_counts'] = [];
+		$GLOBALS['perform_test_options']           = [];
+		$GLOBALS['perform_test_current_filter']    = 'script_loader_src';
+		$GLOBALS['perform_test_queried_object_id'] = 42;
+		$GLOBALS['perform_test_the_id']            = 0;
+		$GLOBALS['perform_test_post_type']         = 'post';
+	}
+
+	protected function tearDown(): void {
+		unset(
+			$GLOBALS['perform_test_get_option_counts'],
+			$GLOBALS['perform_test_options'],
+			$GLOBALS['perform_test_current_filter'],
+			$GLOBALS['perform_test_queried_object_id'],
+			$GLOBALS['perform_test_the_id'],
+			$GLOBALS['perform_test_post_type'],
+			$GLOBALS['perform_test_is_front_page'],
+			$GLOBALS['perform_test_is_home']
+		);
+
+		parent::tearDown();
+	}
+
 	public function test_current_object_id_lists_are_normalized_for_strict_comparisons() {
 		$manager = new AssetsManager();
 		$method  = new ReflectionMethod( $manager, 'normalize_object_id_list' );
@@ -41,5 +67,69 @@ final class Tests_Assets_Manager extends TestCase {
 
 		$this->assertSame( '/sample-page/?keep=1&perform_reset=1', $method->invoke( $manager ) );
 		$this->assertArrayNotHasKey( 'perform_assets_manager_options', $GLOBALS['perform_test_options'] );
+	}
+
+	public function test_current_page_disabled_asset_uses_cached_options() {
+		$GLOBALS['perform_test_options'] = [
+			'perform_assets_manager_options' => [
+				'disabled' => [
+					'js' => [
+						'example-handle' => [
+							'current' => [ 42 ],
+						],
+					],
+				],
+			],
+		];
+
+		$manager = new AssetsManager();
+
+		$this->assertFalse( $manager->dequeue_assets( 'https://example.com/wp-content/plugins/example/app.js', 'example-handle' ) );
+		$this->assertFalse( $manager->dequeue_assets( 'https://example.com/wp-content/plugins/example/app.js', 'example-handle' ) );
+		$this->assertSame( 1, $GLOBALS['perform_test_get_option_counts']['perform_assets_manager_options'] );
+	}
+
+	public function test_current_page_enabled_exception_preserves_asset() {
+		$GLOBALS['perform_test_options'] = [
+			'perform_assets_manager_options' => [
+				'disabled' => [
+					'js' => [
+						'example-handle' => [
+							'everywhere' => 1,
+						],
+					],
+				],
+				'enabled'  => [
+					'js' => [
+						'example-handle' => [
+							'current' => [ 42 ],
+						],
+					],
+				],
+			],
+		];
+
+		$manager = new AssetsManager();
+		$src     = 'https://example.com/wp-content/plugins/example/app.js';
+
+		$this->assertSame( $src, $manager->dequeue_assets( $src, 'example-handle' ) );
+	}
+
+	public function test_group_disabled_rule_matches_asset_source_group() {
+		$GLOBALS['perform_test_options'] = [
+			'perform_assets_manager_options' => [
+				'disabled' => [
+					'plugins' => [
+						'example' => [
+							'everywhere' => 1,
+						],
+					],
+				],
+			],
+		];
+
+		$manager = new AssetsManager();
+
+		$this->assertFalse( $manager->dequeue_assets( 'https://example.com/wp-content/plugins/example/app.js', 'example-handle' ) );
 	}
 }


### PR DESCRIPTION
## Summary
- Cache selected Assets Manager options, cleaned query data, current object ID, and parsed asset source groups per request.
- Preserve the existing stored option shape and frontend asset enable/disable decisions.
- Add regression coverage for current-page disabled rules, current-page enabled exceptions, group-level source matching, and option-read reuse.

## Validation
- `php -l src/Modules/Assets/AssetsManager.php && php -l tests/bootstrap.php && php -l tests/unit-tests/tests-assets-manager.php`
- `./vendor/bin/phpcs -s src/Modules/Assets/AssetsManager.php tests/bootstrap.php tests/unit-tests/tests-assets-manager.php`
- `composer phpstan`
- `composer test` - 42 tests, 80 assertions
- `git diff --check`

## Notes
- No UI source changed. Local browser/e2e smoke was not rerun in this environment because prior wp-env attempts are blocked by missing Docker (`spawn docker ENOENT`); GitHub CI remains the release-branch validation path for hosted smoke coverage.

Closes #105