### PR TITLE
Update GitHub Actions Node runtime pins

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/composer-diff.yml
+++ b/.github/workflows/composer-diff.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0 # Required to make it possible to compare with PR base branch
 
@@ -20,7 +20,7 @@ jobs:
         id: composer_diff # To reference the output in comment
         uses: IonBazan/composer-diff-action@v1
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@v3.0.4
         # An empty diff result will break this action.
         if: ${{ steps.composer_diff.outputs.composer_diff_exit_code != 0 }}
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -64,7 +64,7 @@ jobs:
           composer-options: '--no-dev --prefer-dist --optimize-autoloader'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: npm

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -52,7 +52,7 @@ jobs:
           tools: composer
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: npm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Install PHP for the composer install
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: mshick/add-pr-comment@v2
+      - uses: mshick/add-pr-comment@v3.12.0
         with:
           message: |
             **Test on Playground**

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -27,7 +27,7 @@ jobs:
           composer-options: '--no-dev --prefer-dist --optimize-autoloader'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: npm
@@ -44,6 +44,6 @@ jobs:
           zip -r "${GITHUB_WORKSPACE}/perform.zip" .
 
       - name: Upload release asset
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.1
         with:
           files: ${{ github.workspace }}/perform.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -27,7 +27,7 @@ jobs:
           composer-options: '--no-dev --prefer-dist --optimize-autoloader'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: npm
@@ -48,6 +48,6 @@ jobs:
           SLUG: perform
 
       - name: Upload release asset
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.1
         with:
           files: ${{ github.workspace }}/perform.zip

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       # This action checks the `composer.lock` file against known security vulnerabilities in the dependencies.
       # https://github.com/marketplace/actions/the-php-security-checker


### PR DESCRIPTION
## Summary
- Update JavaScript GitHub Actions to versions whose action metadata uses the Node 24 runtime.
- Cover checkout, setup-node, sticky PR comments, PR playground comments, and release asset upload workflows.
- Leave composite and Docker-based actions unchanged because they are not Node action-runtime warning sources.

## Node 24 metadata verified
- `actions/checkout@v7.0.0` -> `using: node24`
- `actions/setup-node@v6.4.0` -> `using: node24`
- `marocchino/sticky-pull-request-comment@v3.0.4` -> `using: node24`
- `mshick/add-pr-comment@v3.12.0` -> `using: node24`
- `softprops/action-gh-release@v3.0.1` -> `using: node24`
- Existing `shivammathur/setup-php@v2` already reports `using: node24`

## Validation
- Parsed all `.github/workflows/*.yml` files with Ruby YAML.
- `git diff --check`
- Confirmed no remaining `actions/checkout@v4`, `actions/setup-node@v4`, `marocchino/sticky-pull-request-comment@v2`, `mshick/add-pr-comment@v2`, or `softprops/action-gh-release@v2` references.
- `actionlint` is not installed locally; hosted workflow execution is the final validation for action compatibility.

Closes #101