### PR TITLE
Add Perform dashboard overview

### DIFF
--- a/assets/src/css/admin/settings.css
+++ b/assets/src/css/admin/settings.css
@@ -128,3 +128,101 @@
 	font-weight: 600;
 	text-transform: uppercase;
 }
+
+.perform-dashboard {
+	display: grid;
+	gap: 20px;
+}
+
+.perform-dashboard-hero {
+	border-radius: 0;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.perform-dashboard-hero__header {
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 20px;
+}
+
+.perform-dashboard-hero h2 {
+	margin: 0 0 8px;
+	font-size: 24px;
+	line-height: 1.25;
+}
+
+.perform-dashboard-hero p {
+	max-width: 720px;
+	margin: 0;
+	color: #50575e;
+}
+
+.perform-dashboard-eyebrow {
+	margin: 0 0 6px !important;
+	color: var(--primary-color) !important;
+	font-size: 12px;
+	font-weight: 700;
+	text-transform: uppercase;
+}
+
+.perform-dashboard-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.perform-dashboard-grid,
+.perform-dashboard-stats,
+.perform-dashboard-metrics {
+	display: grid;
+	gap: 16px;
+}
+
+.perform-dashboard-grid {
+	grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.perform-dashboard-stats {
+	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.perform-dashboard-metrics {
+	grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+	margin-bottom: 16px;
+}
+
+.perform-dashboard-stat {
+	min-height: 84px;
+	border-left: 4px solid var(--primary-color);
+	background: #f6f7f7;
+	padding: 12px 14px;
+}
+
+.perform-dashboard-stat span {
+	display: block;
+	color: #50575e;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
+.perform-dashboard-stat strong {
+	display: block;
+	margin-top: 6px;
+	font-size: 24px;
+	line-height: 1.2;
+}
+
+.perform-dashboard-stat p,
+.perform-dashboard-empty {
+	margin: 8px 0 0;
+	color: #50575e;
+}
+
+.perform-dashboard-list {
+	margin: 0 0 16px 18px;
+}
+
+.perform-dashboard-list li {
+	margin-bottom: 8px;
+}

--- a/assets/src/js/admin/DashboardPanel.jsx
+++ b/assets/src/js/admin/DashboardPanel.jsx
@@ -1,0 +1,158 @@
+import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
+
+const StatCard = ( { label, value, description } ) => (
+	<div className="perform-dashboard-stat">
+		<span>{ label }</span>
+		<strong>{ value }</strong>
+		{ description && <p>{ description }</p> }
+	</div>
+);
+
+const DashboardPanel = ( { dashboard, diagnostics } ) => {
+	const data = dashboard || {};
+	const links = data.links || {};
+	const cache = data.cache || {};
+	const assets = data.assetsManager || {};
+	const diagnosticSummary = diagnostics?.summary || {};
+	const changelog = data.changelog || [];
+
+	return (
+		<div className="perform-dashboard">
+			<Card className="perform-dashboard-hero">
+				<CardHeader className="perform-dashboard-hero__header">
+					<div>
+						<p className="perform-dashboard-eyebrow">Dashboard</p>
+						<h2>Perform overview</h2>
+						<p>
+							Review current plugin health, cache activity, and configured optimization rule coverage
+							before changing production settings.
+						</p>
+					</div>
+					<div className="perform-dashboard-actions">
+						<Button variant="primary" href={ links.docs || '#' } target="_blank" rel="noopener noreferrer">
+							View docs
+						</Button>
+						<Button
+							variant="secondary"
+							href={ links.support || '#' }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Support
+						</Button>
+					</div>
+				</CardHeader>
+				<CardBody>
+					<div className="perform-dashboard-stats">
+						<StatCard
+							label="Plugin version"
+							value={ data.version || 'Unknown' }
+							description="Bundled version loaded in this WordPress admin."
+						/>
+						<StatCard
+							label="Ready checks"
+							value={ diagnosticSummary.ready ?? 0 }
+							description="Runtime diagnostics currently marked ready."
+						/>
+						<StatCard
+							label="Warnings"
+							value={
+								( diagnosticSummary.warning ?? 0 ) + ( diagnosticSummary[ 'needs-attention' ] ?? 0 )
+							}
+							description="Review these before broad cache or CDN rollout."
+						/>
+					</div>
+				</CardBody>
+			</Card>
+
+			<div className="perform-dashboard-grid">
+				<Card>
+					<CardHeader>
+						<div>
+							<h3 className="perform-card-title">Cache summary</h3>
+							<p className="perform-card-description">Existing page cache stats from this site.</p>
+						</div>
+					</CardHeader>
+					<CardBody>
+						{ cache.hasStats ? (
+							<div className="perform-dashboard-metrics">
+								<StatCard label="Hit ratio" value={ `${ cache.hitRatio ?? 0 }%` } />
+								<StatCard label="Hits" value={ cache.hits ?? 0 } />
+								<StatCard label="Misses" value={ cache.misses ?? 0 } />
+								<StatCard label="Stale hits" value={ cache.staleHits ?? 0 } />
+								<StatCard label="Bypasses" value={ cache.bypasses ?? 0 } />
+								<StatCard label="Preload queue" value={ cache.preloadQueueSize ?? 0 } />
+							</div>
+						) : (
+							<p className="perform-dashboard-empty">
+								No cache stats have been recorded yet. Enable page cache and revisit after traffic or
+								preload runs.
+							</p>
+						) }
+						<a
+							className="perform-help-link"
+							href={ links.cache || '#' }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Read cache docs <span className="perform-help-icon">→</span>
+						</a>
+					</CardBody>
+				</Card>
+
+				<Card>
+					<CardHeader>
+						<div>
+							<h3 className="perform-card-title">Assets Manager rule coverage</h3>
+							<p className="perform-card-description">
+								Configured rules only. Perform does not store historical byte savings yet.
+							</p>
+						</div>
+					</CardHeader>
+					<CardBody>
+						<div className="perform-dashboard-metrics">
+							<StatCard label="Disabled JS handles" value={ assets.disabledJsHandles ?? 0 } />
+							<StatCard label="Disabled CSS handles" value={ assets.disabledCssHandles ?? 0 } />
+							<StatCard label="Group rules" value={ assets.groupDisabledRules ?? 0 } />
+							<StatCard label="Current URL exceptions" value={ assets.currentPageExceptions ?? 0 } />
+						</div>
+						<a
+							className="perform-help-link"
+							href={ links.assetsManager || '#' }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Read Assets Manager docs <span className="perform-help-icon">→</span>
+						</a>
+					</CardBody>
+				</Card>
+			</div>
+
+			<Card>
+				<CardHeader>
+					<div>
+						<h3 className="perform-card-title">Release notes</h3>
+						<p className="perform-card-description">Local release-candidate notes for owner review.</p>
+					</div>
+				</CardHeader>
+				<CardBody>
+					<ul className="perform-dashboard-list">
+						{ changelog.map( ( item ) => (
+							<li key={ item }>{ item }</li>
+						) ) }
+					</ul>
+					<a
+						className="perform-help-link"
+						href={ links.releaseNotes || '#' }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						View release updates <span className="perform-help-icon">→</span>
+					</a>
+				</CardBody>
+			</Card>
+		</div>
+	);
+};
+
+export default DashboardPanel;

--- a/assets/src/js/admin/SettingsApp.jsx
+++ b/assets/src/js/admin/SettingsApp.jsx
@@ -9,6 +9,7 @@ const SETTINGS_TABS = SETTINGS.tabs || {};
 const SETTINGS_FIELDS = SETTINGS.fields || {};
 const SAVED_SETTINGS = SETTINGS.saved || {};
 const INITIAL_DIAGNOSTICS = SETTINGS.diagnostics || {};
+const DASHBOARD = SETTINGS.dashboard || {};
 
 const SettingsApp = () => {
 	const tabs = SETTINGS_TABS;
@@ -38,7 +39,7 @@ const SettingsApp = () => {
 	const [ saving, setSaving ] = useState( false );
 	const [ message, setMessage ] = useState( null );
 	const [ diagnostics, setDiagnostics ] = useState( INITIAL_DIAGNOSTICS );
-	const [ activeTab, setActiveTab ] = useState( Object.keys( tabs )[ 0 ] || '' );
+	const [ activeTab, setActiveTab ] = useState( 'dashboard' );
 	const messageTimerRef = useRef( null );
 
 	// dirty detection
@@ -145,12 +146,14 @@ const SettingsApp = () => {
 			<SettingsNav
 				fields={ fields }
 				tabs={ tabs }
+				dashboard={ DASHBOARD }
+				diagnostics={ diagnostics }
 				activeTab={ activeTab }
 				onTabChange={ setActiveTab }
 				fieldValues={ fieldValues }
 				onFieldChange={ handleFieldChange }
 			/>
-			<DiagnosticsPanel diagnostics={ diagnostics } />
+			{ 'dashboard' !== activeTab && <DiagnosticsPanel diagnostics={ diagnostics } /> }
 			<Footer dirty={ isDirty } saving={ saving } message={ message } onSave={ handleSave } />
 		</>
 	);

--- a/assets/src/js/admin/SettingsNav.jsx
+++ b/assets/src/js/admin/SettingsNav.jsx
@@ -9,6 +9,7 @@ import {
 	TextareaControl,
 } from '@wordpress/components';
 import { useState, useMemo } from '@wordpress/element';
+import DashboardPanel from './DashboardPanel';
 
 const FIELD_COMPONENTS = {
 	toggle: ToggleControl,
@@ -160,6 +161,8 @@ const renderField = ( field, value, onChange ) => {
 const SettingsNav = ( {
 	tabs: propTabs,
 	fields: propFields,
+	dashboard,
+	diagnostics,
 	activeTab: propActiveTab,
 	onTabChange: propOnTabChange,
 	fieldValues: propFieldValues,
@@ -167,7 +170,7 @@ const SettingsNav = ( {
 } ) => {
 	const tabs = useMemo( () => propTabs || SETTINGS.tabs || {}, [ propTabs ] );
 	const fields = useMemo( () => propFields || SETTINGS.fields || {}, [ propFields ] );
-	const tabKeys = useMemo( () => Object.keys( tabs ), [ tabs ] );
+	const tabKeys = useMemo( () => [ 'dashboard', ...Object.keys( tabs ) ], [ tabs ] );
 
 	const [ internalActiveTab, setInternalActiveTab ] = useState( tabKeys[ 0 ] || '' );
 	const activeTab = propActiveTab ?? internalActiveTab;
@@ -182,7 +185,7 @@ const SettingsNav = ( {
 		() =>
 			tabKeys.map( ( slug ) => ( {
 				name: slug,
-				title: tabs[ slug ],
+				title: 'dashboard' === slug ? 'Dashboard' : tabs[ slug ],
 			} ) ),
 		[ tabKeys, tabs ]
 	);
@@ -204,32 +207,42 @@ const SettingsNav = ( {
 				>
 					{ () => null }
 				</TabPanel>
-				<div className="perform-settings-cards">
-					{ cards.map( ( card, idx ) => (
-						<Card
-							key={ idx }
-							style={ {
-								marginBottom: '24px',
-								boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
-								borderRadius: 0,
-							} }
-						>
-							<CardHeader style={ { alignItems: 'flex-start', flexDirection: 'column' } }>
-								<h3 className="perform-card-title">{ card.title }</h3>
-								{ card.description && <p className="perform-card-description">{ card.description }</p> }
-							</CardHeader>
-							{ card.fields && card.fields.length > 0 && (
-								<CardBody>
-									{ card.fields.map( ( field ) => (
-										<div key={ field.id } className="perform-field" style={ { marginBottom: 16 } }>
-											{ renderField( field, fieldValues[ field.id ], onFieldChange ) }
-										</div>
-									) ) }
-								</CardBody>
-							) }
-						</Card>
-					) ) }
-				</div>
+				{ 'dashboard' === activeTab ? (
+					<DashboardPanel dashboard={ dashboard } diagnostics={ diagnostics } />
+				) : (
+					<div className="perform-settings-cards">
+						{ cards.map( ( card, idx ) => (
+							<Card
+								key={ idx }
+								style={ {
+									marginBottom: '24px',
+									boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
+									borderRadius: 0,
+								} }
+							>
+								<CardHeader style={ { alignItems: 'flex-start', flexDirection: 'column' } }>
+									<h3 className="perform-card-title">{ card.title }</h3>
+									{ card.description && (
+										<p className="perform-card-description">{ card.description }</p>
+									) }
+								</CardHeader>
+								{ card.fields && card.fields.length > 0 && (
+									<CardBody>
+										{ card.fields.map( ( field ) => (
+											<div
+												key={ field.id }
+												className="perform-field"
+												style={ { marginBottom: 16 } }
+											>
+												{ renderField( field, fieldValues[ field.id ], onFieldChange ) }
+											</div>
+										) ) }
+									</CardBody>
+								) }
+							</Card>
+						) ) }
+					</div>
+				) }
 			</div>
 		</>
 	);

--- a/languages/perform.pot
+++ b/languages/perform.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: PerformWP <hello@performwp.com>\n"
-"POT-Creation-Date: 2026-05-25 11:35+0000\n"
+"POT-Creation-Date: 2026-07-02 10:16+0000\n"
 "Report-Msgid-Bugs-To: https://github.com/performwp/perform/issues/new\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
@@ -16,19 +16,19 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/Admin/Actions.php:98
+#: src/Admin/Actions.php:102
 msgid "Close Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:95, src/Modules/Assets/AssetsManager.php:195
+#: src/Admin/Actions.php:99, src/Modules/Assets/AssetsManager.php:258
 msgid "Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:105, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:178
+#: src/Admin/Actions.php:109, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:238
 msgid "Perform"
 msgstr ""
 
-#: src/Admin/Actions.php:125
+#: src/Admin/Actions.php:129
 msgid "Support Forum"
 msgstr ""
 
@@ -485,114 +485,154 @@ msgid "Comma-separated query keys that should generate separate cache entries. T
 msgstr ""
 
 #: src/Includes/Helpers.php:797
-msgid "Preload and Observability"
+msgid "Bypass Exact Paths"
 msgstr ""
 
 #: src/Includes/Helpers.php:798
-msgid "Warm cache from sitemaps and monitor cache effectiveness."
+msgid "One URL path per line that should bypass full-page cache exactly, such as /account/dashboard."
 msgstr ""
 
-#: src/Includes/Helpers.php:803
-msgid "Enable Adaptive Preloader"
+#: src/Includes/Helpers.php:811
+msgid "Bypass Path Prefixes"
 msgstr ""
 
-#: src/Includes/Helpers.php:804
-msgid "Preloads cache from sitemap and high-miss URLs using adaptive request rate."
+#: src/Includes/Helpers.php:812
+msgid "One URL path prefix per line that should bypass full-page cache, such as /checkout or /private."
 msgstr ""
 
-#: src/Includes/Helpers.php:815
-msgid "Slow Request Threshold"
+#: src/Includes/Helpers.php:825
+msgid "Bypass Query Keys"
 msgstr ""
 
-#: src/Includes/Helpers.php:817
-msgid "500ms"
-msgstr ""
-
-#: src/Includes/Helpers.php:818
-msgid "800ms"
-msgstr ""
-
-#: src/Includes/Helpers.php:819
-msgid "1200ms"
-msgstr ""
-
-#: src/Includes/Helpers.php:820
-msgid "2000ms"
-msgstr ""
-
-#: src/Includes/Helpers.php:822
-msgid "Tracks uncached requests slower than this value in observability stats."
-msgstr ""
-
-#: src/Includes/Helpers.php:833
-msgid "Cloudflare"
-msgstr ""
-
-#: src/Includes/Helpers.php:834
-msgid "Sync local cache purge events to Cloudflare (free-tier friendly)."
+#: src/Includes/Helpers.php:826
+msgid "Query keys that should bypass cache reads and writes entirely. This is separate from query keys that create separate cache entries."
 msgstr ""
 
 #: src/Includes/Helpers.php:839
-msgid "Enable Cloudflare Cache Sync"
+msgid "Bypass Cookie Names"
 msgstr ""
 
 #: src/Includes/Helpers.php:840
-msgid "Purge Cloudflare URLs when Perform purges local cache."
+msgid "Cookie names that should bypass cache reads and writes. Cookie values are never needed for matching."
 msgstr ""
 
-#: src/Includes/Helpers.php:851
-msgid "Cloudflare Zone ID"
+#: src/Includes/Helpers.php:853
+msgid "Bypass Cookie Prefixes"
 msgstr ""
 
-#: src/Includes/Helpers.php:852
-msgid "Your Cloudflare Zone ID."
+#: src/Includes/Helpers.php:854
+msgid "Cookie name prefixes that should bypass cache reads and writes, such as wp-postpass_ or custom_session_."
 msgstr ""
 
-#: src/Includes/Helpers.php:863
-msgid "Cloudflare API Token"
+#: src/Includes/Helpers.php:867
+msgid "Preload and Observability"
 msgstr ""
 
-#: src/Includes/Helpers.php:864
-msgid "API token with Zone:Cache Purge permission."
+#: src/Includes/Helpers.php:868
+msgid "Warm cache from sitemaps and monitor cache effectiveness."
 msgstr ""
 
-#: src/Includes/Helpers.php:877
-msgid "Advanced Settings"
+#: src/Includes/Helpers.php:873
+msgid "Enable Adaptive Preloader"
 msgstr ""
 
-#: src/Includes/Helpers.php:878
-msgid "Settings for advanced configurations."
+#: src/Includes/Helpers.php:874
+msgid "Preloads cache from sitemap and high-miss URLs using adaptive request rate."
 msgstr ""
 
-#: src/Includes/Helpers.php:883
-msgid "Remove Data on Uninstall"
+#: src/Includes/Helpers.php:885
+msgid "Slow Request Threshold"
 msgstr ""
 
-#: src/Includes/Helpers.php:884
-msgid "Enabling this will remove all plugin data upon uninstallation."
+#: src/Includes/Helpers.php:887
+msgid "500ms"
 msgstr ""
 
-#: src/Includes/Helpers.php:897
-msgid "WooCommerce Settings"
+#: src/Includes/Helpers.php:888
+msgid "800ms"
 msgstr ""
 
-#: src/Includes/Helpers.php:898
-msgid "Settings specific to WooCommerce."
+#: src/Includes/Helpers.php:889
+msgid "1200ms"
+msgstr ""
+
+#: src/Includes/Helpers.php:890
+msgid "2000ms"
+msgstr ""
+
+#: src/Includes/Helpers.php:892
+msgid "Tracks uncached requests slower than this value in observability stats."
 msgstr ""
 
 #: src/Includes/Helpers.php:903
-msgid "Enable WooCommerce Manager"
+msgid "Cloudflare"
 msgstr ""
 
 #: src/Includes/Helpers.php:904
+msgid "Sync local cache purge events to Cloudflare (free-tier friendly)."
+msgstr ""
+
+#: src/Includes/Helpers.php:909
+msgid "Enable Cloudflare Cache Sync"
+msgstr ""
+
+#: src/Includes/Helpers.php:910
+msgid "Purge Cloudflare URLs when Perform purges local cache."
+msgstr ""
+
+#: src/Includes/Helpers.php:921
+msgid "Cloudflare Zone ID"
+msgstr ""
+
+#: src/Includes/Helpers.php:922
+msgid "Your Cloudflare Zone ID."
+msgstr ""
+
+#: src/Includes/Helpers.php:933
+msgid "Cloudflare API Token"
+msgstr ""
+
+#: src/Includes/Helpers.php:934
+msgid "API token with Zone:Cache Purge permission."
+msgstr ""
+
+#: src/Includes/Helpers.php:947
+msgid "Advanced Settings"
+msgstr ""
+
+#: src/Includes/Helpers.php:948
+msgid "Settings for advanced configurations."
+msgstr ""
+
+#: src/Includes/Helpers.php:953
+msgid "Remove Data on Uninstall"
+msgstr ""
+
+#: src/Includes/Helpers.php:954
+msgid "Enabling this will remove all plugin data upon uninstallation."
+msgstr ""
+
+#: src/Includes/Helpers.php:967
+msgid "WooCommerce Settings"
+msgstr ""
+
+#: src/Includes/Helpers.php:968
+msgid "Settings specific to WooCommerce."
+msgstr ""
+
+#: src/Includes/Helpers.php:973
+msgid "Enable WooCommerce Manager"
+msgstr ""
+
+#: src/Includes/Helpers.php:974
 msgid "Enabling this will allow you to manage WooCommerce specific settings."
 msgstr ""
 
-#: src/Includes/Helpers.php:915
+#: src/Includes/Helpers.php:985
 msgid "Enable WooCommerce Cache"
 msgstr ""
 
-#: src/Includes/Helpers.php:916
+#: src/Includes/Helpers.php:986
 msgid "Enabling this will cache WooCommerce pages for better performance."
 msgstr ""
 
@@ -608,6 +648,18 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
+#: src/Admin/Settings/DashboardPayload.php:105
+msgid "Dashboard, diagnostics, cache, and Assets Manager work in 1.7.0 remains release-candidate content until the owner approves publication."
+msgstr ""
+
+#: src/Admin/Settings/DashboardPayload.php:106
+msgid "Runtime diagnostics summarize cache, CDN, menu cache, and dynamic request prerequisites without writing new tracking data."
+msgstr ""
+
+#: src/Admin/Settings/DashboardPayload.php:107
+msgid "Assets Manager summary reports configured rule coverage, not historical byte savings."
+msgstr ""
+
 #: src/Admin/Settings/Menu.php:82
 msgid "Insufficient permissions."
 msgstr ""
@@ -616,170 +668,326 @@ msgstr ""
 msgid "Security check failed."
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:204
+#: src/Admin/Settings/Menu.php:209
 msgid "Unable to save the settings. Please try again."
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:197
+#: src/Admin/Settings/Menu.php:201
 msgid "Settings saved successfully."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:157
-msgid "Search detected assets"
+#: src/Admin/Settings/RuntimeDiagnostics.php:69, src/Admin/Settings/RuntimeDiagnostics.php:82
+msgid "Page cache storage"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:158
-msgid "Search by handle, source, or file URL"
+#: src/Admin/Settings/RuntimeDiagnostics.php:70
+msgid "Page cache is disabled, so no cache storage is required yet."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:159
-msgid "Filter detected assets"
+#: src/Admin/Settings/RuntimeDiagnostics.php:71
+msgid "Enable full-page cache when you are ready to test storage prerequisites."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:160
-msgid "All"
+#: src/Admin/Settings/RuntimeDiagnostics.php:84
+msgid "Perform can use the cache storage location for generated HTML files."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:161
-msgid "Plugins"
+#: src/Admin/Settings/RuntimeDiagnostics.php:85
+msgid "Perform cannot confirm writable cache storage for generated HTML files."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:162
-msgid "Themes"
+#: src/Admin/Settings/RuntimeDiagnostics.php:87, src/Admin/Settings/RuntimeDiagnostics.php:108, src/Admin/Settings/RuntimeDiagnostics.php:138, src/Admin/Settings/RuntimeDiagnostics.php:205
+msgid "No action needed."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:163, src/Modules/Assets/AssetsManager.php:547
-msgid "Other"
+#: src/Admin/Settings/RuntimeDiagnostics.php:88
+msgid "Ask your host to allow WordPress to write to its cache directory before relying on full-page cache."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:164
-msgid "JS"
+#: src/Admin/Settings/RuntimeDiagnostics.php:102
+msgid "Page cache drop-in"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:165, src/Modules/Assets/AssetsManager.php:213
-msgid "CSS"
+#: src/Admin/Settings/RuntimeDiagnostics.php:104
+msgid "A page-cache drop-in is present, so another cache layer may already be active."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:166
-msgid "Disabled"
+#: src/Admin/Settings/RuntimeDiagnostics.php:105
+msgid "No page-cache drop-in was detected."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:180
-msgid "Page asset scanner"
+#: src/Admin/Settings/RuntimeDiagnostics.php:107
+msgid "Review host or plugin-level page caching before enabling overlapping cache behavior."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:181
-msgid "Perform Assets Manager"
+#: src/Admin/Settings/RuntimeDiagnostics.php:123, src/Admin/Settings/RuntimeDiagnostics.php:133
+msgid "Cache preload schedule"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:185
-msgid "Close"
+#: src/Admin/Settings/RuntimeDiagnostics.php:124
+msgid "Adaptive cache preload is disabled."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:186
-msgid "Save changes"
+#: src/Admin/Settings/RuntimeDiagnostics.php:125
+msgid "Enable preload only after page cache is working reliably."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:192
-msgid "Current page"
+#: src/Admin/Settings/RuntimeDiagnostics.php:135
+msgid "The cache preload event is scheduled."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:198
-msgid "Review scripts and styles detected on this page, then disable only the assets you have verified are not needed."
+#: src/Admin/Settings/RuntimeDiagnostics.php:136
+msgid "The cache preload event is not scheduled yet."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:202
-msgid "Asset scan summary"
+#: src/Admin/Settings/RuntimeDiagnostics.php:139
+msgid "Save settings again or confirm WordPress cron is running on this site."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:205
-msgid "Detected assets"
+#: src/Admin/Settings/RuntimeDiagnostics.php:154, src/Admin/Settings/RuntimeDiagnostics.php:168
+msgid "Dynamic request exclusions"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:209
-msgid "JavaScript"
+#: src/Admin/Settings/RuntimeDiagnostics.php:155
+msgid "Page cache is disabled, so dynamic request exclusions are not required yet."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:156
+msgid "Add exclusions before enabling page cache on sites with member areas, custom checkouts, or preview tokens."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:170
+msgid "Site-specific cache bypass rules are configured."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:171
+msgid "No site-specific cache bypass rules are configured."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:173
+msgid "Review bypass rules after adding new dynamic workflows."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:174
+msgid "Add path, query, or cookie exclusions for dynamic workflows before broad cache rollout."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:189, src/Admin/Settings/RuntimeDiagnostics.php:200
+msgid "Menu cache theme support"
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:190
+msgid "Menu cache is disabled."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:191
+msgid "Use menu cache primarily with classic themes that render menus through wp_nav_menu()."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:202
+msgid "The active theme is eligible for menu cache."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:203
+msgid "The active block theme is not expected to benefit from menu cache by default."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:206
+msgid "Leave menu cache disabled unless custom theme code opts in through the compatibility filter."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:221, src/Admin/Settings/RuntimeDiagnostics.php:234
+msgid "CDN configuration"
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:222
+msgid "CDN rewriting is disabled."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:223
+msgid "Enable CDN rewriting only after confirming the CDN origin URL and included directories."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:236
+msgid "CDN rewriting has a valid CDN URL."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:237
+msgid "CDN rewriting is enabled but the CDN URL is missing or invalid."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:239
+msgid "Confirm included directories and exclusions before broad rollout."
+msgstr ""
+
+#: src/Admin/Settings/RuntimeDiagnostics.php:240
+msgid "Enter a full CDN URL with http or https before enabling CDN rewriting."
 msgstr ""
 
 #: src/Modules/Assets/AssetsManager.php:217
-msgid "Disabled rules"
+msgid "Search detected assets"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:218
+msgid "Search by handle, source, or file URL"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:219
+msgid "Filter detected assets"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:220
+msgid "All"
 msgstr ""
 
 #: src/Modules/Assets/AssetsManager.php:221
+msgid "Plugins"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:222
+msgid "Themes"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:223, src/Modules/Assets/AssetsManager.php:641
+msgid "Other"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:224
+msgid "JS"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:225, src/Modules/Assets/AssetsManager.php:276
+msgid "CSS"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:226
+msgid "Disabled"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:240
+msgid "Page asset scanner"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:241
+msgid "Perform Assets Manager"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:245
+msgid "Close"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:246
+msgid "This will reset all Assets Manager settings for this site. Continue?"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:247
+msgid "Reset"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:249
+msgid "Save changes"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:255
+msgid "Current page"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:261
+msgid "Review scripts and styles detected on this page, then disable only the assets you have verified are not needed."
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:265
+msgid "Asset scan summary"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:268
+msgid "Detected assets"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:272
+msgid "JavaScript"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:280
+msgid "Disabled rules"
+msgstr ""
+
+#: src/Modules/Assets/AssetsManager.php:284
 msgid "Known file size"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:258
+#: src/Modules/Assets/AssetsManager.php:321
 msgid "No assets match the current scan filter."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:548
+#: src/Modules/Assets/AssetsManager.php:642
 msgid "WordPress core, CDN, and uncategorized assets"
 msgstr ""
 
 #. translators: %d: number of assets.
-#: src/Modules/Assets/AssetsManager.php:553, src/Modules/Assets/AssetsManager.php:532
+#: src/Modules/Assets/AssetsManager.php:647, src/Modules/Assets/AssetsManager.php:626
 msgid "%d detected asset"
 msgid_plural "%d detected assets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Modules/Assets/AssetsManager.php:567
+#: src/Modules/Assets/AssetsManager.php:661
 msgid "Handle"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:570
+#: src/Modules/Assets/AssetsManager.php:664
 msgid "Type"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:573
+#: src/Modules/Assets/AssetsManager.php:667
 msgid "Size"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:576
+#: src/Modules/Assets/AssetsManager.php:670
 msgid "Status"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:579
+#: src/Modules/Assets/AssetsManager.php:673
 msgid "Actions"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:637
+#: src/Modules/Assets/AssetsManager.php:731
 msgid "External"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:645
+#: src/Modules/Assets/AssetsManager.php:739
 msgid "View File"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:692
+#: src/Modules/Assets/AssetsManager.php:786
 msgid "All assets in this group have been disabled. Enable the group again to manage individual assets."
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:713, src/Modules/Assets/AssetsManager.php:807
+#: src/Modules/Assets/AssetsManager.php:807, src/Modules/Assets/AssetsManager.php:901
 msgid "Current URL"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:714
+#: src/Modules/Assets/AssetsManager.php:808
 msgid "Everywhere"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:719
+#: src/Modules/Assets/AssetsManager.php:813
 msgid "Disable on"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:769
+#: src/Modules/Assets/AssetsManager.php:863
 msgid "Asset loading status"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:771
+#: src/Modules/Assets/AssetsManager.php:865
 msgid "ON"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:774
+#: src/Modules/Assets/AssetsManager.php:868
 msgid "OFF"
 msgstr ""
 
-#: src/Modules/Assets/AssetsManager.php:800
+#: src/Modules/Assets/AssetsManager.php:894
 msgid "Exceptions"
 msgstr ""
 
@@ -787,70 +995,78 @@ msgstr ""
 msgid "No feed available, please visit the homepage!"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:127
+#: src/Modules/Cache/PageCache.php:148
 msgid "Every 5 minutes (Perform Cache)"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:456, src/Modules/Cache/PageCache.php:485
+#: src/Modules/Cache/PageCache.php:480, src/Modules/Cache/PageCache.php:510
 msgid "Perform Cache Observability"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:457
+#: src/Modules/Cache/PageCache.php:481
 msgid "Perform Cache Stats"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:486
+#: src/Modules/Cache/PageCache.php:511
 msgid "Live cache effectiveness and warmup health metrics."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:490
+#: src/Modules/Cache/PageCache.php:515
 msgid "Cache Hit Ratio"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:491
+#: src/Modules/Cache/PageCache.php:516
 msgid "Hits"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:492
+#: src/Modules/Cache/PageCache.php:517
 msgid "Stale Hits"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:493, src/Modules/Cache/PageCache.php:502
+#: src/Modules/Cache/PageCache.php:518, src/Modules/Cache/PageCache.php:527
 msgid "Misses"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:494
+#: src/Modules/Cache/PageCache.php:519, src/Modules/Cache/PageCache.php:530
 msgid "Bypasses"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:495
+#: src/Modules/Cache/PageCache.php:520
 msgid "Lock Waits"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:496
+#: src/Modules/Cache/PageCache.php:521
 msgid "Preload Queue Size"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:497
+#: src/Modules/Cache/PageCache.php:522
 msgid "Preload Requests"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:501
+#: src/Modules/Cache/PageCache.php:526
 msgid "Top Missed URLs"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:504
+#: src/Modules/Cache/PageCache.php:529
+msgid "Bypass Reasons"
+msgstr ""
+
+#: src/Modules/Cache/PageCache.php:530
+msgid "Reason"
+msgstr ""
+
+#: src/Modules/Cache/PageCache.php:532
 msgid "Slow Uncached URLs (ms)"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:505
+#: src/Modules/Cache/PageCache.php:533
 msgid "Render Time (ms)"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:520
+#: src/Modules/Cache/PageCache.php:549
 msgid "No data yet."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:527
+#: src/Modules/Cache/PageCache.php:554
 msgid "URL"
 msgstr ""

--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -12,6 +12,7 @@ namespace Perform\Admin;
 
 use Perform\Includes\Helpers;
 use Perform\Admin\Settings\ClientPayload;
+use Perform\Admin\Settings\DashboardPayload;
 use Perform\Admin\Settings\RuntimeDiagnostics;
 
 // Bailout, if accessed directly.
@@ -65,6 +66,7 @@ class Actions {
 					'logoUrl'           => plugins_url( 'assets/dist/images/logo.png', PERFORM_PLUGIN_FILE ),
 					'nonce'             => wp_create_nonce( 'perform_save_settings' ),
 					'saved'             => ClientPayload::sanitize_for_client( (array) \Perform\Includes\Helpers::get_settings() ),
+					'dashboard'         => DashboardPayload::get_data(),
 					'diagnostics'       => RuntimeDiagnostics::get_results(),
 					'sensitiveKeys'     => ClientPayload::get_sensitive_keys(),
 					'maskedSecretValue' => ClientPayload::MASKED_SECRET,

--- a/src/Admin/Settings/DashboardPayload.php
+++ b/src/Admin/Settings/DashboardPayload.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Perform - Admin Dashboard Payload.
+ *
+ * @package Perform
+ * @subpackage Admin/Settings
+ */
+
+namespace Perform\Admin\Settings;
+
+// Bailout, if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class DashboardPayload {
+	/**
+	 * Build the read-only dashboard payload for the admin app.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function get_data() {
+		return [
+			'version'       => defined( 'PERFORM_VERSION' ) ? PERFORM_VERSION : '',
+			'links'         => self::get_links(),
+			'cache'         => self::get_cache_summary(),
+			'assetsManager' => self::get_assets_manager_summary(),
+			'changelog'     => self::get_changelog_items(),
+		];
+	}
+
+	/**
+	 * Get dashboard links.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function get_links() {
+		$docs_url = defined( 'PERFORM_PLUGIN_DOCS_URL' ) ? PERFORM_PLUGIN_DOCS_URL : 'https://performwp.com/docs/';
+
+		return [
+			'docs'          => esc_url( $docs_url ),
+			'support'       => esc_url( 'https://wordpress.org/support/plugin/perform/' ),
+			'assetsManager' => esc_url( $docs_url . 'assets-manager/' ),
+			'cache'         => esc_url( $docs_url . 'page-cache/' ),
+			'releaseNotes'  => esc_url( 'https://performwp.com/' ),
+		];
+	}
+
+	/**
+	 * Build cache statistics summary from the existing stats option.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function get_cache_summary() {
+		$stats = get_option( 'perform_cache_stats', [] );
+		$stats = is_array( $stats ) ? $stats : [];
+
+		$hits       = self::get_int( $stats, 'hits' );
+		$misses     = self::get_int( $stats, 'misses' );
+		$stale_hits = self::get_int( $stats, 'stale_hits' );
+		$bypasses   = self::get_int( $stats, 'bypasses' );
+		$requests   = $hits + $misses + $stale_hits;
+		$hit_ratio  = 0 < $requests ? round( ( ( $hits + $stale_hits ) / $requests ) * 100, 1 ) : 0.0;
+
+		return [
+			'hasStats'          => ! empty( $stats ),
+			'hitRatio'          => $hit_ratio,
+			'hits'              => $hits,
+			'misses'            => $misses,
+			'staleHits'         => $stale_hits,
+			'bypasses'          => $bypasses,
+			'preloadQueueSize'  => self::get_int( $stats, 'preload_queue_size' ),
+			'preloadRequests'   => self::get_int( $stats, 'preload_requests' ),
+			'slowUncachedCount' => isset( $stats['slow_uncached'] ) && is_array( $stats['slow_uncached'] ) ? count( $stats['slow_uncached'] ) : 0,
+		];
+	}
+
+	/**
+	 * Build Assets Manager rule coverage summary from existing options.
+	 *
+	 * @return array<string, int>
+	 */
+	private static function get_assets_manager_summary() {
+		$options  = get_option( 'perform_assets_manager_options', [] );
+		$options  = is_array( $options ) ? $options : [];
+		$disabled = isset( $options['disabled'] ) && is_array( $options['disabled'] ) ? $options['disabled'] : [];
+		$enabled  = isset( $options['enabled'] ) && is_array( $options['enabled'] ) ? $options['enabled'] : [];
+
+		return [
+			'disabledJsHandles'        => self::count_handle_rules( $disabled, 'js' ),
+			'disabledCssHandles'       => self::count_handle_rules( $disabled, 'css' ),
+			'groupDisabledRules'       => self::count_group_rules( $disabled ),
+			'currentPageExceptions'    => self::count_current_page_exceptions( $enabled ),
+			'currentPageDisabledRules' => self::count_current_page_exceptions( $disabled ),
+		];
+	}
+
+	/**
+	 * Get local release notes for the current bundled line.
+	 *
+	 * @return array<int, string>
+	 */
+	private static function get_changelog_items() {
+		return [
+			__( 'Dashboard, diagnostics, cache, and Assets Manager work in 1.7.0 remains release-candidate content until the owner approves publication.', 'perform' ),
+			__( 'Runtime diagnostics summarize cache, CDN, menu cache, and dynamic request prerequisites without writing new tracking data.', 'perform' ),
+			__( 'Assets Manager summary reports configured rule coverage, not historical byte savings.', 'perform' ),
+		];
+	}
+
+	/**
+	 * Count disabled or enabled handle rule groups for one asset type.
+	 *
+	 * @param array<string, mixed> $rules Rules.
+	 * @param string              $type Asset type.
+	 *
+	 * @return int
+	 */
+	private static function count_handle_rules( array $rules, $type ) {
+		if ( empty( $rules[ $type ] ) || ! is_array( $rules[ $type ] ) ) {
+			return 0;
+		}
+
+		return count(
+			array_filter(
+				$rules[ $type ],
+				static function ( $rule ) {
+					return is_array( $rule ) && ! empty( $rule );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Count group-level disabled rules.
+	 *
+	 * @param array<string, mixed> $disabled Disabled rules.
+	 *
+	 * @return int
+	 */
+	private static function count_group_rules( array $disabled ) {
+		$count = 0;
+
+		foreach ( $disabled as $category => $groups ) {
+			if ( in_array( $category, [ 'js', 'css' ], true ) || ! is_array( $groups ) ) {
+				continue;
+			}
+
+			foreach ( $groups as $group_rule ) {
+				if ( is_array( $group_rule ) && ! empty( $group_rule ) ) {
+					++$count;
+				}
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Count current-page rule entries across JS/CSS maps.
+	 *
+	 * @param array<string, mixed> $rules Rules.
+	 *
+	 * @return int
+	 */
+	private static function count_current_page_exceptions( array $rules ) {
+		$count = 0;
+
+		foreach ( [ 'js', 'css' ] as $type ) {
+			if ( empty( $rules[ $type ] ) || ! is_array( $rules[ $type ] ) ) {
+				continue;
+			}
+
+			foreach ( $rules[ $type ] as $rule ) {
+				if ( isset( $rule['current'] ) && is_array( $rule['current'] ) ) {
+					$count += count( array_filter( $rule['current'], 'is_scalar' ) );
+				}
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Get an integer stat from an array.
+	 *
+	 * @param array<string, mixed> $stats Stats.
+	 * @param string              $key Key.
+	 *
+	 * @return int
+	 */
+	private static function get_int( array $stats, $key ) {
+		return isset( $stats[ $key ] ) && is_numeric( $stats[ $key ] ) ? max( 0, (int) $stats[ $key ] ) : 0;
+	}
+}

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -14,6 +14,11 @@ test( 'settings save, Assets Manager, and page cache smoke paths work', async ( 
 	await page.goto( '/wp-admin/options-general.php?page=perform_settings' );
 	await expect( page.locator( '#perform-settings-page' ) ).toBeVisible();
 	await expect( page.getByRole( 'button', { name: 'Save Settings' } ) ).toBeVisible();
+	await expect( page.getByRole( 'tab', { name: 'Dashboard' } ) ).toBeVisible();
+	await expect( page.getByRole( 'heading', { name: 'Perform overview' } ) ).toBeVisible();
+	await expect( page.getByText( 'Runtime diagnostics currently marked ready.' ) ).toBeVisible();
+
+	await page.getByRole( 'tab', { name: 'General' } ).click();
 	await expect( page.getByText( 'General Settings' ) ).toBeVisible();
 	await expect( page.getByText( 'Runtime Diagnostics' ) ).toBeVisible();
 

--- a/tests/unit-tests/tests-dashboard-payload.php
+++ b/tests/unit-tests/tests-dashboard-payload.php
@@ -1,0 +1,95 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Perform\Admin\Settings\DashboardPayload;
+
+final class Tests_Dashboard_Payload extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['perform_test_options'] = [];
+	}
+
+	protected function tearDown(): void {
+		unset( $GLOBALS['perform_test_options'] );
+	}
+
+	public function test_cache_summary_uses_existing_stats_without_writes() {
+		$GLOBALS['perform_test_options']['perform_cache_stats'] = [
+			'hits'               => 80,
+			'misses'             => 15,
+			'stale_hits'         => 5,
+			'bypasses'           => 7,
+			'preload_queue_size' => 3,
+			'preload_requests'   => 11,
+			'slow_uncached'      => [
+				'/slow' => 1200,
+			],
+		];
+
+		$payload = DashboardPayload::get_data();
+
+		$this->assertTrue( $payload['cache']['hasStats'] );
+		$this->assertSame( 85.0, $payload['cache']['hitRatio'] );
+		$this->assertSame( 80, $payload['cache']['hits'] );
+		$this->assertSame( 15, $payload['cache']['misses'] );
+		$this->assertSame( 5, $payload['cache']['staleHits'] );
+		$this->assertSame( 7, $payload['cache']['bypasses'] );
+		$this->assertSame( 3, $payload['cache']['preloadQueueSize'] );
+		$this->assertSame( 11, $payload['cache']['preloadRequests'] );
+		$this->assertSame( 1, $payload['cache']['slowUncachedCount'] );
+	}
+
+	public function test_assets_manager_summary_counts_rule_coverage_not_bytes_saved() {
+		$GLOBALS['perform_test_options']['perform_assets_manager_options'] = [
+			'disabled' => [
+				'js'      => [
+					'first-script'  => [
+						'everywhere' => 1,
+					],
+					'second-script' => [
+						'current' => [ 42 ],
+					],
+				],
+				'css'     => [
+					'theme-style' => [
+						'everywhere' => 1,
+					],
+				],
+				'plugins' => [
+					'example-plugin' => [
+						'everywhere' => 1,
+					],
+				],
+			],
+			'enabled'  => [
+				'js'  => [
+					'first-script' => [
+						'current' => [ 42, 43 ],
+					],
+				],
+				'css' => [
+					'theme-style' => [
+						'current' => [ 42 ],
+					],
+				],
+			],
+		];
+
+		$payload = DashboardPayload::get_data();
+
+		$this->assertSame( 2, $payload['assetsManager']['disabledJsHandles'] );
+		$this->assertSame( 1, $payload['assetsManager']['disabledCssHandles'] );
+		$this->assertSame( 1, $payload['assetsManager']['groupDisabledRules'] );
+		$this->assertSame( 3, $payload['assetsManager']['currentPageExceptions'] );
+		$this->assertSame( 1, $payload['assetsManager']['currentPageDisabledRules'] );
+	}
+
+	public function test_empty_dashboard_payload_has_safe_defaults() {
+		$payload = DashboardPayload::get_data();
+
+		$this->assertFalse( $payload['cache']['hasStats'] );
+		$this->assertSame( 0.0, $payload['cache']['hitRatio'] );
+		$this->assertSame( 0, $payload['assetsManager']['disabledJsHandles'] );
+		$this->assertSame( 0, $payload['assetsManager']['disabledCssHandles'] );
+		$this->assertNotEmpty( $payload['changelog'] );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a read-only Dashboard tab as the first screen in the existing Perform admin app.
- Surfaces plugin version, docs/support links, runtime diagnostic counts, cache activity, Assets Manager rule coverage, and local release-candidate notes.
- Uses existing local options only; no remote calls, no tracking, no writes, and no historical byte-savings claims.

## Validation
- `./vendor/bin/phpcs -s src/Admin/Actions.php src/Admin/Settings/DashboardPayload.php tests/unit-tests/tests-dashboard-payload.php`
- `composer phpstan`
- `composer test` (45 tests, 99 assertions)
- `PATH="/Users/mehulgohil/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run lint:js`
- `PATH="/Users/mehulgohil/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run lint:css`
- `PATH="/Users/mehulgohil/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run build`
- `git diff --check`

## Proof Gap
- Browser screenshot proof was not captured locally because Docker/wp-env is unavailable in this environment (`docker: command not found`). The dashboard is implemented through the existing bundled admin app and compiled successfully.

Closes #7
