### PR TITLE
Expand PR validation template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,62 @@
-## Description
-<!-- Please describe your changes -->
+## Linked issue
+<!-- Link the issue this PR closes or explain why there is no issue. -->
 
-## How Has This Been Tested?
-<!-- Please describe in detail how you tested your changes. -->
-<!-- Include details of your testing environment, tests ran to see how -->
-<!-- your change affects other areas of the code, etc. -->
+Closes #
 
-## Screenshots (jpeg or gifs if applicable):
+## Target branch
+<!-- Confirm the intended base branch, such as develop or release/1.7.0. -->
 
-## Types of changes
-<!-- What types of changes does your code introduce?  -->
-<!-- Bug fix (non-breaking change which fixes an issue) -->
-<!-- New feature (non-breaking change which adds functionality) -->
-<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
+- [ ] I confirmed this PR targets the correct base branch.
 
-## Checklist:
-- [ ] My code is tested.
-- [ ] My code follows the WordPress code style.
-- [ ] My code follows has proper inline documentation.
+## Scope
+<!-- Summarize the change and keep the boundary clear. -->
+
+### Summary
+
+### Non-goals
+<!-- List related work intentionally left out, or write "Not applicable". -->
+
+### User-facing impact
+<!-- Describe visible behavior/UI/docs changes, or write "Not applicable". -->
+
+## Validation
+<!-- Check every gate you ran. Mark irrelevant gates as "Not applicable - reason". -->
+
+- [ ] PHPCS / code style:
+- [ ] PHP lint:
+- [ ] PHPStan:
+- [ ] PHPUnit:
+- [ ] Frontend lint/build:
+- [ ] Playwright / browser proof:
+- [ ] WordPress smoke tests:
+- [ ] Manual testing:
+
+## Screenshots or video
+<!-- Required for UI/workflow changes. For non-UI changes, explain why proof is not applicable. -->
+
+## Compatibility
+<!-- Mark items as "Not applicable - reason" when they are unrelated to this PR. -->
+
+- Settings/options/backward compatibility:
+- Public hooks or public PHP API:
+- Migrations and existing installs:
+- Multisite:
+- Supported PHP and WordPress versions:
+- Security/privacy-sensitive behavior:
+- Documentation/readme/changelog/release notes:
+
+## Contributor PR handling
+<!-- Fill this out when this PR replaces, salvages, or follows up on a human contributor PR. Otherwise write "Not applicable". -->
+
+- Contributor PR:
+- What was preserved from the contributor work:
+- Credit note:
+- Why a maintainer replacement is needed:
+
+## Checklist
+
+- [ ] The PR has a clear linked issue, scope, and non-goals.
+- [ ] I avoided unrelated formatting, lockfile, or generated-file churn.
+- [ ] I documented skipped validation gates with a concrete reason.
+- [ ] UI changes include screenshot/video proof or a reason proof is not applicable.
+- [ ] Contributor credit is preserved where applicable.


### PR DESCRIPTION
## Summary
- Expands the PR template with linked issue, target branch, scope, non-goals, and user-facing impact prompts.
- Adds validation gates for PHPCS, PHP lint, PHPStan, PHPUnit, frontend lint/build, Playwright, WordPress smoke, and manual testing.
- Adds compatibility and contributor PR handling sections so replacement/salvage PRs preserve credit and explain why maintainer follow-up is needed.

Closes #158.

## Validation
- `git diff --check`
- Compared against recent UI PR #155: the new template would require screenshot/video proof or an explicit proof-not-applicable reason.
- Compared against tooling/docs PR #160: the new template supports linked issue, narrow scope, no product-code changes, and skipped validation gates without excessive noise.
- Confirmed changed files are limited to `.github/PULL_REQUEST_TEMPLATE.md`; no product code changes are included.

## Compatibility
- Settings/options/backward compatibility: Not applicable - PR template only.
- Public hooks or public PHP API: Not applicable - PR template only.
- Migrations and existing installs: Not applicable - PR template only.
- Multisite: Not applicable - PR template only.
- Supported PHP and WordPress versions: Not applicable - PR template only.
- Security/privacy-sensitive behavior: Not applicable - PR template only.
- Documentation/readme/changelog/release notes: GitHub PR template updated.

## Screenshots or video
Not applicable - GitHub PR template text only.

## Contributor PR handling
Not applicable - this PR does not replace a human contributor PR.