### PR TITLE
Prepare 1.7.0 release metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perform",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perform",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perform",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Web Performance Optimization Plugin for WordPress",
   "homepage": "https://github.com/performwp/perform#readme",
   "license": "GPL-3.0-or-later",

--- a/perform.php
+++ b/perform.php
@@ -17,7 +17,7 @@
  * Plugin Name: Perform - Optimize Performance
  * Plugin URI: https://performwp.com/
  * Description: This plugin adds toolset for performance and speed improvements to your WordPress sites.
- * Version: 1.6.0
+ * Version: 1.7.0
  * Author: Mehul Gohil
  * Author URI: https://mehulgohil.com/
  * License: GPLv3 or later

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.buymeacoffee.com/mehulgohil
 Requires at least: 4.8
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 1.6.0
+Stable tag: 1.7.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -15,7 +15,7 @@ Optimize WordPress performance with asset controls, page caching, CDN rewriting,
 
 Perform helps site owners reduce unnecessary frontend work in WordPress. It combines asset controls, cache features, CDN rewriting, and small cleanup modules in one settings area.
 
-Version 1.6.0 focuses on safer controls for real sites: a redesigned Assets Manager, full-page cache settings, classic theme menu caching, compatibility-safe settings migration, and improved release validation.
+Version 1.7.0 focuses on safer controls for real sites: a dashboard overview, runtime diagnostics, page cache exclusion controls, an Assets Manager reset action, and refreshed release metadata.
 
 Key capabilities:
 
@@ -56,8 +56,8 @@ Menu Cache is designed for classic themes that render menus through `wp_nav_menu
 = Does Assets Manager scan the whole site? =
 Assets Manager scans the current frontend page while you are logged in as an administrator. Use it page by page for safer asset decisions, then test important templates before applying broad changes.
 
-= Are settings preserved when updating to 1.6.0? =
-Yes. Perform 1.6.0 preserves existing public option keys and migrates legacy settings into the current settings shape where needed.
+= Are settings preserved when updating to 1.7.0? =
+Yes. Perform 1.7.0 preserves existing public option keys and migrates legacy settings into the current settings shape where needed.
 
 == Support ==
 
@@ -66,6 +66,14 @@ For help and troubleshooting, use our WordPress.org support forum: https://wordp
 Contributions and bug reports welcome on GitHub: https://github.com/performwp/perform
 
 == Changelog ==
+
+= 1.7.0 - 2026-07-06 =
+- Added a dashboard overview for faster at-a-glance site status.
+- Added a runtime diagnostics panel for environment and plugin inspection.
+- Added page cache exclusion controls for URLs and content that should bypass cache.
+- Added an Assets Manager reset action for safer repeated scans.
+- Hardened sitemap preload traversal and CDN module load gating.
+- Aligned public metadata surfaces and refreshed WordPress.org readme wording.
 
 = 1.6.0 - 2026-05-22 =
 - Redesigned Assets Manager with a more resilient scanner interface and WordPress-native admin controls.
@@ -113,8 +121,8 @@ Contributions and bug reports welcome on GitHub: https://github.com/performwp/pe
 
 == Upgrade Notice ==
 
-= 1.6.0 =
-Review your Assets Manager and cache settings after updating. Perform 1.6.0 adds the redesigned scanner, page cache controls, and safer release validation.
+= 1.7.0 =
+Review your Assets Manager, cache exclusions, and diagnostics after updating. Perform 1.7.0 adds the dashboard overview, runtime diagnostics, page cache exclusions, and safer asset reset controls.
 
 Back up your site before changing performance settings on production, then test important pages after enabling cache or asset controls.
 


### PR DESCRIPTION
Refs #165

## Summary
- bump release metadata from 1.6.0 to 1.7.0 in the plugin header, WordPress.org readme, package metadata, and package lockfile
- add a 1.7.0 changelog section limited to work already merged into release/1.7.0
- update the 1.7.0 FAQ and upgrade notice wording without including unspecced future milestone ideas

## Base Branch
- base: `release/1.7.0`
- source branch: `fix/165-release-1.7.0-metadata`

## Scope
- release metadata and docs only
- no implementation behavior changes
- no production/beta tag, release creation, WordPress.org publish, or production branch merge

## Validation
- `git diff --check` passed
- `php -l perform.php` passed
- `composer validate --no-check-publish` passed
- `composer lint` passed
- `composer phpstan` passed
- `npm run plugin-zip` passed and produced a release ZIP with plugin files, built assets, and production vendor files

## Known Proof Gaps
- `composer check-cs` currently fails on existing repository style findings outside this diff, including `config/constants.php`, JS config/test files, and module interface spacing. This PR does not touch those files.
- `npm run lint` is blocked in this local shell because Node is `v16.15.1`, while this repo requires Node 24 via `.nvmrc` and `.node-version`. CI or a local Node 24 environment should provide the authoritative JS lint proof.
- Plugin Check is not available as a repo-local command or workflow in this checkout.
- Browser proof remains CI/local-WP-env dependent; latest release-branch CI before this metadata patch had green Playwright smoke proof at `696e5ba`.

## Release Notes
- included dashboard overview, runtime diagnostics, page cache exclusion controls, Assets Manager reset action, sitemap preload traversal hardening, CDN module load gating, and metadata/readme wording refresh because those are already merged into `release/1.7.0`

## Hard Gates
Final production or beta release actions still require explicit owner approval after the release-ready brief.