### PR TITLE
Resolve Plugin Check release proof findings

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -42,7 +42,6 @@ AGENTS.md
 sample-data/wordpress.sql
 sample-data/sample-data.numbers
 bower.json
-composer.json
 composer.lock
 package.json
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "npm run lint:js && npm run lint:css",
     "lint:css": "wp-scripts lint-style \"assets/src/**/*.css\"",
     "lint:js": "wp-scripts lint-js \"assets/src/**/*.js\" \"assets/src/**/*.jsx\" postcss.config.js webpack.config.js",
-    "plugin-zip": "rm -rf build/perform perform.zip && mkdir -p build/perform && rsync -rc --exclude-from=.distignore ./ build/perform/ --delete --delete-excluded && cp composer.json composer.lock build/perform/ && composer install --working-dir=build/perform --no-dev --prefer-dist --optimize-autoloader --no-interaction --no-progress --no-scripts && rm -f build/perform/composer.json build/perform/composer.lock && rm -rf build/perform/vendor/bin build/perform/vendor/composer/installers && cd build && zip -qr ../perform.zip perform && cd .. && rm -rf build/perform",
+    "plugin-zip": "rm -rf build/perform perform.zip && mkdir -p build/perform && rsync -rc --exclude-from=.distignore ./ build/perform/ --delete --delete-excluded && cp composer.json composer.lock build/perform/ && composer install --working-dir=build/perform --no-dev --prefer-dist --optimize-autoloader --no-interaction --no-progress --no-scripts && rm -f build/perform/composer.lock && rm -rf build/perform/vendor/bin build/perform/vendor/composer/installers && cd build && zip -qr ../perform.zip perform && cd .. && rm -rf build/perform",
     "test:e2e": "playwright test",
     "test:e2e:ci": "node tests/e2e/run-ci.mjs",
     "wp-env": "wp-env"

--- a/readme.txt
+++ b/readme.txt
@@ -122,7 +122,7 @@ Contributions and bug reports welcome on GitHub: https://github.com/performwp/pe
 == Upgrade Notice ==
 
 = 1.7.0 =
-Review your Assets Manager, cache exclusions, and diagnostics after updating. Perform 1.7.0 adds the dashboard overview, runtime diagnostics, page cache exclusions, and safer asset reset controls.
+Review Assets Manager, cache exclusions, and runtime diagnostics after updating.
 
 Back up your site before changing performance settings on production, then test important pages after enabling cache or asset controls.
 

--- a/src/Admin/Settings/RuntimeDiagnostics.php
+++ b/src/Admin/Settings/RuntimeDiagnostics.php
@@ -74,7 +74,7 @@ final class RuntimeDiagnostics {
 
 		$cache_dir      = self::get_cache_dir();
 		$cache_parent   = dirname( $cache_dir );
-		$storage_ready  = is_dir( $cache_dir ) ? is_writable( $cache_dir ) : ( is_dir( $cache_parent ) && is_writable( $cache_parent ) );
+		$storage_ready  = is_dir( $cache_dir ) ? wp_is_writable( $cache_dir ) : ( is_dir( $cache_parent ) && wp_is_writable( $cache_parent ) );
 		$storage_status = $storage_ready ? 'ready' : 'needs-attention';
 
 		return self::item(

--- a/src/Modules/Assets/AssetsManager.php
+++ b/src/Modules/Assets/AssetsManager.php
@@ -1196,7 +1196,7 @@ class AssetsManager implements ModuleInterface {
 	private function reset_assets_manager_settings(): string {
 		delete_option( 'perform_assets_manager_options' );
 
-		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? (string) wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 		if ( '' === $request_uri ) {
 			$request_uri = home_url( add_query_arg( [] ) );
 		}


### PR DESCRIPTION
## Summary
- replace direct runtime diagnostics `is_writable()` checks with `wp_is_writable()`
- sanitize the Assets Manager reset request URI before URL mutation
- include `composer.json` in packaged builds when `vendor/` is present
- shorten the 1.7.0 upgrade notice to satisfy Plugin Check

## Issue
Works toward #167.

## Validation
- `git diff --check`
- `php -l src/Admin/Settings/RuntimeDiagnostics.php`
- `php -l src/Modules/Assets/AssetsManager.php`
- `composer validate --no-check-publish`
- `composer lint`
- `composer phpstan`
- `composer test`
- `npm run plugin-zip`
- packaged ZIP check: `studio wp plugin check perform-rc-check --slug=perform --path /Users/mehulgohil/Studio/development --format=csv --fields=file,line,column,type,code,message --mode=update` -> `Success: Checks complete. No errors found.`

## Proof notes
- Plugin Check was run against the generated `perform.zip` by installing the package as a temporary inactive Studio plugin slug `perform-rc-check`; the temporary copy was removed after validation.
- No production/beta tag, release, WordPress.org publish, main merge, or human contributor PR/issue action was taken.

## UI/browser proof
- Not applicable: this is release packaging/static-analysis cleanup with no intended UI change. Existing release-branch Playwright Smoke was green after #166; CI will rerun for this PR where configured.