### PR TITLE
Scope runtime diagnostics to dashboard on 1.7.0 beta

### DIFF
--- a/assets/src/js/admin/SettingsApp.jsx
+++ b/assets/src/js/admin/SettingsApp.jsx
@@ -153,7 +153,7 @@ const SettingsApp = () => {
 				fieldValues={ fieldValues }
 				onFieldChange={ handleFieldChange }
 			/>
-			{ 'dashboard' !== activeTab && <DiagnosticsPanel diagnostics={ diagnostics } /> }
+			{ 'dashboard' === activeTab && <DiagnosticsPanel diagnostics={ diagnostics } /> }
 			<Footer dirty={ isDirty } saving={ saving } message={ message } onSave={ handleSave } />
 		</>
 	);

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -17,10 +17,11 @@ test( 'settings save, Assets Manager, and page cache smoke paths work', async ( 
 	await expect( page.getByRole( 'tab', { name: 'Dashboard' } ) ).toBeVisible();
 	await expect( page.getByRole( 'heading', { name: 'Perform overview' } ) ).toBeVisible();
 	await expect( page.getByText( 'Runtime diagnostics currently marked ready.' ) ).toBeVisible();
+	await expect( page.getByText( 'Runtime Diagnostics' ) ).toBeVisible();
 
 	await page.getByRole( 'tab', { name: 'General' } ).click();
 	await expect( page.getByText( 'General Settings' ) ).toBeVisible();
-	await expect( page.getByText( 'Runtime Diagnostics' ) ).toBeVisible();
+	await expect( page.getByText( 'Runtime Diagnostics' ) ).toHaveCount( 0 );
 
 	await page.getByRole( 'tab', { name: 'Assets' } ).click();
 	await page.getByRole( 'checkbox', { name: 'Enable Assets Manager' } ).check();

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -17,11 +17,11 @@ test( 'settings save, Assets Manager, and page cache smoke paths work', async ( 
 	await expect( page.getByRole( 'tab', { name: 'Dashboard' } ) ).toBeVisible();
 	await expect( page.getByRole( 'heading', { name: 'Perform overview' } ) ).toBeVisible();
 	await expect( page.getByText( 'Runtime diagnostics currently marked ready.' ) ).toBeVisible();
-	await expect( page.getByText( 'Runtime Diagnostics' ) ).toBeVisible();
+	await expect( page.getByRole( 'heading', { name: 'Runtime Diagnostics' } ) ).toBeVisible();
 
 	await page.getByRole( 'tab', { name: 'General' } ).click();
 	await expect( page.getByText( 'General Settings' ) ).toBeVisible();
-	await expect( page.getByText( 'Runtime Diagnostics' ) ).toHaveCount( 0 );
+	await expect( page.getByRole( 'heading', { name: 'Runtime Diagnostics' } ) ).toHaveCount( 0 );
 
 	await page.getByRole( 'tab', { name: 'Assets' } ).click();
 	await page.getByRole( 'checkbox', { name: 'Enable Assets Manager' } ).check();


### PR DESCRIPTION
## Summary
- scope the full Runtime Diagnostics panel to the Dashboard tab only
- keep the dashboard diagnostics visible while removing the panel from non-dashboard tabs
- update the smoke test so General no longer expects the diagnostics panel

## Issue
- closes #169

## Validation
- `npm run lint:js`
- `composer test`
- `npm run build`

## Proof gap
- Before and after screenshots are still blocked in this automation path.
- `studio wp` succeeds, but external browser automation against `https://development.wp.local/` is returning a Studio runtime / `Internal Server Error` body instead of a usable settings page, so the requested visual proof could not be attached from the CLI path in this turn.
- The blocker issue records that gap explicitly and this PR should not be treated as fully release-ready until after screenshots are attached or the Studio/browser path is repaired.
