### PR TITLE
Align admin dashboard version for 1.7.0

### DIFF
--- a/config/constants.php
+++ b/config/constants.php
@@ -6,12 +6,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Define plugin version in SemVer format.
 if ( ! defined( 'PERFORM_VERSION' ) ) {
-	define( 'PERFORM_VERSION', '1.6.0' );
+	define( 'PERFORM_VERSION', '1.7.0' );
 }
 
 // Define plugin root File.
 if ( ! defined( 'PERFORM_PLUGIN_FILE' ) ) {
-	define( 'PERFORM_PLUGIN_FILE', dirname( dirname( __FILE__ ) ) . '/perform.php' );
+	define( 'PERFORM_PLUGIN_FILE', dirname( __DIR__ ) . '/perform.php' );
 }
 
 // Define plugin basename.

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -17,7 +17,7 @@ if ( ! defined( 'WP_CONTENT_FOLDERNAME' ) ) {
 }
 
 if ( ! defined( 'PERFORM_VERSION' ) ) {
-	define( 'PERFORM_VERSION', '1.6.0' );
+	define( 'PERFORM_VERSION', '1.7.0' );
 }
 
 if ( ! defined( 'PERFORM_PLUGIN_FILE' ) ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,6 +19,29 @@ if ( ! defined( 'PHP_URL_HOST' ) ) {
 	define( 'PHP_URL_HOST', 1 );
 }
 
+if ( ! function_exists( 'plugin_basename' ) ) {
+	function plugin_basename( $file ) {
+		$basename = basename( (string) $file );
+		$slug     = 'perform.php' === $basename ? 'perform' : basename( dirname( (string) $file ) );
+
+		return $slug . '/' . $basename;
+	}
+}
+
+if ( ! function_exists( 'plugin_dir_path' ) ) {
+	function plugin_dir_path( $file ) {
+		return rtrim( dirname( (string) $file ), '/\\' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'plugin_dir_url' ) ) {
+	function plugin_dir_url( $file ) {
+		$slug = 'perform.php' === basename( (string) $file ) ? 'perform' : basename( dirname( (string) $file ) );
+
+		return 'https://example.com/wp-content/plugins/' . $slug . '/';
+	}
+}
+
 if ( ! function_exists( 'get_option' ) ) {
 	function get_option( $name, $default_value = false ) {
 		if ( ! isset( $GLOBALS['perform_test_get_option_counts'] ) || ! is_array( $GLOBALS['perform_test_get_option_counts'] ) ) {
@@ -451,5 +474,7 @@ if ( ! function_exists( 'wp_unslash' ) ) {
 		return $value;
 	}
 }
+
+require_once dirname( __DIR__ ) . '/config/constants.php';
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';

--- a/tests/unit-tests/tests-dashboard-payload.php
+++ b/tests/unit-tests/tests-dashboard-payload.php
@@ -86,6 +86,7 @@ final class Tests_Dashboard_Payload extends TestCase {
 	public function test_empty_dashboard_payload_has_safe_defaults() {
 		$payload = DashboardPayload::get_data();
 
+		$this->assertSame( '1.7.0', $payload['version'] );
 		$this->assertFalse( $payload['cache']['hasStats'] );
 		$this->assertSame( 0.0, $payload['cache']['hitRatio'] );
 		$this->assertSame( 0, $payload['assetsManager']['disabledJsHandles'] );


### PR DESCRIPTION
## Summary
- align `PERFORM_VERSION` with the `1.7.0` release branch metadata
- keep the PHPStan bootstrap version mirror in sync
- load plugin constants in the PHPUnit bootstrap and assert the dashboard payload reports `1.7.0`

## Issue
- Fixes #188

## Validation
- `php -l tests/bootstrap.php && php -l config/constants.php && php -l phpstan-bootstrap.php && php -l tests/unit-tests/tests-dashboard-payload.php`
- `./vendor/bin/parallel-lint config/constants.php phpstan-bootstrap.php tests/bootstrap.php tests/unit-tests/tests-dashboard-payload.php --show-deprecated`
- `./vendor/bin/phpcs -s config/constants.php phpstan-bootstrap.php tests/bootstrap.php tests/unit-tests/tests-dashboard-payload.php`
- `./vendor/bin/phpunit --dont-report-useless-tests --filter Tests_Dashboard_Payload`
- `composer test`
- `composer lint`
- `composer phpstan`

## Proof
- Current-state screenshot from the existing Studio checkout shows the Perform dashboard version card rendering `1.6.0` at `output/playwright/perform-169-dashboard.png`.
- Code-path proof now covers the admin dashboard payload source: `DashboardPayload::get_data()` reads `PERFORM_VERSION`, and the focused PHPUnit assertion verifies the payload reports `1.7.0`.

## Browser proof gap
- I did not install this patched branch into the active Studio plugin path because that checkout is dirty and was explicitly read-only for this task.
- After-merge or owner-run browser proof should verify the dashboard card on `options-general.php?page=perform_settings` shows `1.7.0` and that the #169 diagnostics behavior remains unchanged.

## Scope notes
- This does not refresh or replace `1.7.0.beta.1`.
- This does not tag, release, publish, merge production/main, close issues, or change milestone dates.
