### PR TITLE
Make Playwright smoke workflow manual only

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,37 +1,6 @@
 name: Playwright Smoke
 
 on:
-  push:
-    branches:
-      - main
-      - develop
-      - 'release/[0-9]+.[0-9]+*'
-      - 'hotfix/[0-9]+.[0-9]+*'
-    paths:
-      - 'assets/src/**'
-      - 'src/**'
-      - 'perform.php'
-      - 'composer.json'
-      - 'composer.lock'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.wp-env.json'
-      - 'playwright.config.js'
-      - 'tests/e2e/**'
-      - '.github/workflows/e2e.yml'
-  pull_request:
-    paths:
-      - 'assets/src/**'
-      - 'src/**'
-      - 'perform.php'
-      - 'composer.json'
-      - 'composer.lock'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.wp-env.json'
-      - 'playwright.config.js'
-      - 'tests/e2e/**'
-      - '.github/workflows/e2e.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- limit the dedicated Playwright Smoke workflow to manual `workflow_dispatch` runs
- retain the workflow file and its existing smoke job for deliberate hosted validation
- keep local-first validation via `npm run test:e2e:ci`

## Validation
- Ruby YAML parse confirms `workflow_dispatch` is present and no push, pull_request, schedule, or workflow_run trigger remains
- `git diff --check`
- `node --check playwright.config.js`
- `node --check tests/e2e/run-ci.mjs`

## Non-goals
- no change to lint, unit, static analysis, build, package, metadata, secrets, or environments
- no hosted Actions dispatch or rerun