### PR TITLE
Harden full-page cache lifecycle invalidation

### DIFF
--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -535,7 +535,12 @@ class PageCache implements ModuleInterface {
 				$urls[] = $link;
 			}
 		}
-		$this->purge_urls( array_merge( $urls, $this->get_invalidation_urls_for_posts( $this->get_affected_object_ids_for_term( $term_id, $taxonomy ) ) ) );
+		$affected = $this->get_affected_object_ids_for_term( $term_id, $taxonomy );
+		if ( $affected['overflow'] ) {
+			$this->purge_site_cache();
+			return;
+		}
+		$this->purge_urls( array_merge( $urls, $this->get_invalidation_urls_for_posts( $affected['ids'] ) ) );
 	}
 
 	/**
@@ -545,7 +550,12 @@ class PageCache implements ModuleInterface {
 	 * @param array<int,int> $object_ids Object IDs.
 	 */
 	public function purge_related_urls_for_deleted_term( int $term_id, int $tt_id, string $taxonomy, $deleted_term, array $object_ids = [] ): void {
-		$urls = array_merge( [ home_url( '/' ) ], $this->get_invalidation_urls_for_posts( $object_ids ) );
+		$limit = $this->get_term_object_limit();
+		if ( count( $object_ids ) > $limit ) {
+			$this->purge_site_cache();
+			return;
+		}
+		$urls = array_merge( [ home_url( '/' ) ], $this->get_invalidation_urls_for_posts( array_slice( $object_ids, 0, $limit ) ) );
 		if ( $deleted_term instanceof \WP_Term ) {
 			$link = get_term_link( $deleted_term );
 			if ( ! is_wp_error( $link ) ) {
@@ -573,9 +583,9 @@ class PageCache implements ModuleInterface {
 		}
 		$this->site_purge_requested = true;
 		$current                    = $this->get_cache_generation();
+		$this->queue_cloudflare_tracked_urls( null, $current );
 		update_option( $this->get_generation_option_name(), $current + 1, false );
 		$this->schedule_cleanup();
-		$this->queue_cloudflare_tracked_urls();
 	}
 
 	/**
@@ -613,7 +623,10 @@ class PageCache implements ModuleInterface {
 		if ( ! is_array( $old_value ) || ! is_array( $value ) || ! $this->cloudflare_settings_changed( $old_value, $value ) ) {
 			return $value;
 		}
-		$this->queue_cloudflare_tracked_urls( $old_value );
+		$urls = array_slice( (array) get_option( 'perform_cache_urls_' . $this->get_blog_id(), [] ), 0, $this->cloudflare_batch_size );
+		if ( ! empty( $urls ) && ! $this->purge_cloudflare_urls( $urls, $old_value ) ) {
+			update_option( 'perform_cache_cloudflare_credential_residual_' . $this->get_blog_id(), count( $urls ), false );
+		}
 		return $value;
 	}
 
@@ -900,14 +913,36 @@ class PageCache implements ModuleInterface {
 	/**
 	 * Find a bounded set of posts related to a term.
 	 *
-	 * @return array<int, int>
+	 * @return array{ids: array<int, int>, overflow: bool}
 	 */
 	private function get_affected_object_ids_for_term( int $term_id, string $taxonomy ) {
-		if ( '' === $taxonomy || ! function_exists( 'get_objects_in_term' ) ) {
-			return [];
+		if ( '' === $taxonomy || ! function_exists( 'get_posts' ) ) {
+			return [
+				'ids'      => [],
+				'overflow' => false,
+			];
 		}
-		$object_ids = get_objects_in_term( (int) $term_id, $taxonomy, [ 'number' => $this->get_term_object_limit() ] );
-		return is_wp_error( $object_ids ) || ! is_array( $object_ids ) ? [] : array_map( 'intval', $object_ids );
+		$limit      = $this->get_term_object_limit();
+		$object_ids = get_posts(
+			[
+				'fields'         => 'ids',
+				'posts_per_page' => $limit + 1,
+				'post_status'    => 'any',
+				'no_found_rows'  => true,
+				'tax_query'      => [
+					[
+						'taxonomy' => $taxonomy,
+						'field'    => 'term_id',
+						'terms'    => [ $term_id ],
+					],
+				],
+			]
+		);
+		$object_ids = is_array( $object_ids ) ? array_map( 'intval', $object_ids ) : [];
+		return [
+			'ids'      => array_slice( $object_ids, 0, $limit ),
+			'overflow' => count( $object_ids ) > $limit,
+		];
 	}
 
 	/** @return int */
@@ -1862,7 +1897,7 @@ class PageCache implements ModuleInterface {
 
 	/** Queue tracked URLs instead of using Cloudflare purge_everything. */
 	/** @param array<string,mixed>|null $settings */
-	private function queue_cloudflare_tracked_urls( $settings = null ): void {
+	private function queue_cloudflare_tracked_urls( $settings = null, ?int $generation = null ): void {
 		$settings = is_array( $settings ) ? $settings : Helpers::get_settings();
 		if ( ! is_array( $settings ) || empty( $settings['enable_cloudflare_cache_sync'] ) ) {
 			return;
@@ -1870,7 +1905,7 @@ class PageCache implements ModuleInterface {
 		$blog_id = $this->get_blog_id();
 		$urls    = get_option( 'perform_cache_urls_' . $blog_id, [] );
 		$urls    = is_array( $urls ) ? $urls : [];
-		$urls    = array_values( array_unique( array_merge( $urls, $this->get_cached_urls_from_metadata() ) ) );
+		$urls    = array_values( array_unique( array_merge( $urls, $this->get_cached_urls_from_metadata( null === $generation ? $this->get_cache_generation() : (int) $generation ) ) ) );
 		if ( empty( $urls ) ) {
 			return;
 		}
@@ -1878,7 +1913,7 @@ class PageCache implements ModuleInterface {
 		$records = $this->get_cloudflare_queue_records( get_option( $key, [] ) );
 		$found   = false;
 		foreach ( $records as &$record ) {
-			if ( $this->cloudflare_settings_key( $record['settings'] ) === $this->cloudflare_settings_key( $settings ) ) {
+			if ( $record['fingerprint'] === $this->cloudflare_settings_key( $settings ) ) {
 				$record['urls']     = array_values( array_unique( array_merge( $record['urls'], $urls ) ) );
 				$record['failed']   = false;
 				$record['attempts'] = 0;
@@ -1889,10 +1924,11 @@ class PageCache implements ModuleInterface {
 		unset( $record );
 		if ( ! $found ) {
 			$records[] = [
-				'urls'     => array_values( array_unique( $urls ) ),
-				'settings' => $this->cloudflare_settings( $settings ),
-				'attempts' => 0,
-				'failed'   => false,
+				'urls'        => array_values( array_unique( $urls ) ),
+				'zone_id'     => (string) $settings['cloudflare_zone_id'],
+				'fingerprint' => $this->cloudflare_settings_key( $settings ),
+				'attempts'    => 0,
+				'failed'      => false,
 			];
 		}
 		update_option( $key, $records, false );
@@ -1906,10 +1942,10 @@ class PageCache implements ModuleInterface {
 	 *
 	 * @return array<int, string>
 	 */
-	private function get_cached_urls_from_metadata() {
+	private function get_cached_urls_from_metadata( int $generation ) {
 		$limit = max( 1, (int) apply_filters( 'perform_cache_tracked_url_limit', 500 ) );
 		$files = array_merge(
-			is_array( glob( $this->get_generation_dir( $this->get_cache_generation() ) . '*.meta.json' ) ) ? glob( $this->get_generation_dir( $this->get_cache_generation() ) . '*.meta.json' ) : [],
+			is_array( glob( $this->get_generation_dir( $generation ) . '*.meta.json' ) ) ? glob( $this->get_generation_dir( $generation ) . '*.meta.json' ) : [],
 			is_array( glob( $this->cache_dir . '*.meta.json' ) ) ? glob( $this->cache_dir . '*.meta.json' ) : []
 		);
 		$urls  = [];
@@ -1934,8 +1970,12 @@ class PageCache implements ModuleInterface {
 			if ( ! empty( $record['failed'] ) ) {
 				continue;
 			}
-			$batch = array_slice( $record['urls'], 0, max( 1, (int) $this->cloudflare_batch_size ) );
-			if ( $this->purge_cloudflare_urls( $batch, $record['settings'] ) ) {
+			$batch    = array_slice( $record['urls'], 0, max( 1, (int) $this->cloudflare_batch_size ) );
+			$settings = Helpers::get_settings();
+			if ( ! is_array( $settings ) || $record['fingerprint'] !== $this->cloudflare_settings_key( $settings ) ) {
+				$record['failed'] = true;
+				update_option( 'perform_cache_cloudflare_credential_residual_' . $this->get_blog_id(), count( $record['urls'] ), false );
+			} elseif ( $this->purge_cloudflare_urls( $batch, $settings ) ) {
 				$record['urls'] = array_values( array_diff( $record['urls'], $batch ) );
 				$this->retire_tracked_urls( $batch );
 			} else {
@@ -1979,34 +2019,25 @@ class PageCache implements ModuleInterface {
 
 	/**
 	 * @param mixed $records Queue records.
-	 * @return array<int, array{urls: array<int, string>, settings: array<string, mixed>, attempts: int, failed: bool}>
+	 * @return array<int, array{urls: array<int, string>, zone_id: string, fingerprint: string, attempts: int, failed: bool}>
 	 */
 	private function get_cloudflare_queue_records( $records ): array {
 		if ( ! is_array( $records ) || empty( $records ) ) {
 			return []; }
 		if ( isset( $records[0] ) && is_string( $records[0] ) ) {
+			$settings = Helpers::get_settings();
+			$settings = is_array( $settings ) ? $settings : [];
 			return [
 				[
-					'urls'     => array_values( array_unique( $records ) ),
-					'settings' => $this->cloudflare_settings( Helpers::get_settings() ),
-					'attempts' => 0,
-					'failed'   => false,
+					'urls'        => array_values( array_unique( $records ) ),
+					'zone_id'     => (string) ( $settings['cloudflare_zone_id'] ?? '' ),
+					'fingerprint' => $this->cloudflare_settings_key( $settings ),
+					'attempts'    => 0,
+					'failed'      => false,
 				],
 			];
 		}
 		return $records;
-	}
-
-	/**
-	 * @param array<string, mixed> $settings Settings.
-	 * @return array{enable_cloudflare_cache_sync: bool, cloudflare_zone_id: string, cloudflare_api_token: string}
-	 */
-	private function cloudflare_settings( array $settings ): array {
-		return [
-			'enable_cloudflare_cache_sync' => ! empty( $settings['enable_cloudflare_cache_sync'] ),
-			'cloudflare_zone_id'           => (string) ( $settings['cloudflare_zone_id'] ?? '' ),
-			'cloudflare_api_token'         => (string) ( $settings['cloudflare_api_token'] ?? '' ),
-		];
 	}
 
 	/** @param array<string,mixed> $settings */

--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -60,6 +60,9 @@ class PageCache implements ModuleInterface {
 	 */
 	private $cloudflare_max_retries = 3;
 
+	/** @var bool */
+	private $site_purge_requested = false;
+
 	/**
 	 * Current cache key for the request.
 	 *
@@ -175,7 +178,7 @@ class PageCache implements ModuleInterface {
 		add_action( 'deleted_comment', [ $this, 'purge_related_urls_for_comment' ] );
 		add_action( 'created_term', [ $this, 'purge_related_urls_for_term' ], 10, 3 );
 		add_action( 'edited_term', [ $this, 'purge_related_urls_for_term' ], 10, 3 );
-		add_action( 'delete_term', [ $this, 'purge_related_urls_for_term' ], 10, 4 );
+		add_action( 'delete_term', [ $this, 'purge_related_urls_for_deleted_term' ], 10, 5 );
 		add_action( 'added_term_meta', [ $this, 'purge_related_urls_for_term_meta' ], 10, 2 );
 		add_action( 'updated_term_meta', [ $this, 'purge_related_urls_for_term_meta' ], 10, 2 );
 		add_action( 'deleted_term_meta', [ $this, 'purge_related_urls_for_term_meta' ], 10, 2 );
@@ -185,6 +188,7 @@ class PageCache implements ModuleInterface {
 		add_action( 'switch_theme', [ $this, 'purge_site_cache' ] );
 		add_action( 'customize_save_after', [ $this, 'purge_site_cache' ] );
 		add_action( 'updated_option', [ $this, 'purge_related_urls_for_option' ], 10, 3 );
+		add_filter( 'pre_update_option_perform_settings', [ $this, 'capture_cloudflare_settings_before_update' ], 10, 3 );
 
 		add_action( 'perform_cache_preload_event', [ $this, 'run_preload_batch' ] );
 		add_action( 'perform_cache_sitemap_seed_event', [ $this, 'seed_preload_queue_from_sitemap_and_logs' ] );
@@ -219,7 +223,7 @@ class PageCache implements ModuleInterface {
 	 * @return void
 	 */
 	public function maybe_schedule_events() {
-		$preload_enabled = ! empty( Helpers::get_option( 'enable_cache_preload', 'perform_settings', false ) );
+		$preload_enabled = $this->page_cache_enabled() && ! empty( Helpers::get_option( 'enable_cache_preload', 'perform_settings', false ) );
 
 		if ( $preload_enabled && ! wp_next_scheduled( 'perform_cache_preload_event' ) ) {
 			wp_schedule_event( time() + 60, 'perform_cache_every_5_minutes', 'perform_cache_preload_event' );
@@ -244,10 +248,10 @@ class PageCache implements ModuleInterface {
 	 * @return void
 	 */
 	public function maybe_serve_cache() {
-		$this->request_start = microtime( true );
 		if ( ! $this->page_cache_enabled() ) {
 			return;
 		}
+		$this->request_start = microtime( true );
 
 		if ( ! $this->is_cacheable_request() ) {
 			$bypass_increment = $this->increment_stat( 'bypasses' );
@@ -259,10 +263,10 @@ class PageCache implements ModuleInterface {
 
 		$this->ensure_cache_dir();
 
-		$this->current_url       = $this->get_normalized_request_url();
-		$this->current_cache_key = $this->get_cache_key_for_url( $this->current_url );
+		$this->current_url        = $this->get_normalized_request_url();
+		$this->current_cache_key  = $this->get_cache_key_for_url( $this->current_url );
 		$this->request_generation = $this->get_cache_generation();
-		$this->lock_key          = 'perform_cache_lock_' . $this->current_cache_key;
+		$this->lock_key           = 'perform_cache_lock_' . $this->current_cache_key;
 
 		$meta = $this->read_cache_meta( $this->current_cache_key );
 		$html = $this->read_cache_body( $this->current_cache_key );
@@ -397,7 +401,7 @@ class PageCache implements ModuleInterface {
 	 * @return void
 	 */
 	public function record_slow_uncached_request() {
-		if ( 0.0 === $this->request_start || ! $this->is_cacheable_request() ) {
+		if ( ! $this->page_cache_enabled() || 0.0 === $this->request_start || ! $this->is_cacheable_request() ) {
 			return;
 		}
 
@@ -531,24 +535,56 @@ class PageCache implements ModuleInterface {
 				$urls[] = $link;
 			}
 		}
+		$this->purge_urls( array_merge( $urls, $this->get_invalidation_urls_for_posts( $this->get_affected_object_ids_for_term( $term_id, $taxonomy ) ) ) );
+	}
+
+	/**
+	 * Purge affected post URLs supplied by WordPress before a term is deleted.
+	 *
+	 * @param mixed          $deleted_term Deleted term.
+	 * @param array<int,int> $object_ids Object IDs.
+	 */
+	public function purge_related_urls_for_deleted_term( int $term_id, int $tt_id, string $taxonomy, $deleted_term, array $object_ids = [] ): void {
+		$urls = array_merge( [ home_url( '/' ) ], $this->get_invalidation_urls_for_posts( $object_ids ) );
+		if ( $deleted_term instanceof \WP_Term ) {
+			$link = get_term_link( $deleted_term );
+			if ( ! is_wp_error( $link ) ) {
+				$urls[] = $link;
+			}
+		}
 		$this->purge_urls( $urls );
 	}
 
-	/** Purge a term archive when term metadata changes. */
-	public function purge_related_urls_for_term_meta( mixed $meta_id, int $term_id ): void {
-		$this->purge_related_urls_for_term( $term_id );
+	/**
+	 * Purge a term archive when term metadata changes.
+	 *
+	 * @param mixed $meta_id Metadata ID.
+	 */
+	public function purge_related_urls_for_term_meta( $meta_id, int $term_id ): void {
+		$term     = get_term( $term_id );
+		$taxonomy = is_object( $term ) && ! empty( $term->taxonomy ) ? (string) $term->taxonomy : '';
+		$this->purge_related_urls_for_term( $term_id, 0, $taxonomy );
 	}
 
 	/** Rotate the local cache after a site-wide output change. */
 	public function purge_site_cache(): void {
-		$current = $this->get_cache_generation();
+		if ( $this->site_purge_requested ) {
+			return;
+		}
+		$this->site_purge_requested = true;
+		$current                    = $this->get_cache_generation();
 		update_option( $this->get_generation_option_name(), $current + 1, false );
 		$this->schedule_cleanup();
 		$this->queue_cloudflare_tracked_urls();
 	}
 
-	/** Invalidate when a setting changes public output or cache compatibility. */
-	public function purge_related_urls_for_option( string $option, mixed $old_value, mixed $value ): void {
+	/**
+	 * Invalidate when a setting changes public output or cache compatibility.
+	 *
+	 * @param mixed $old_value Previous value.
+	 * @param mixed $value New value.
+	 */
+	public function purge_related_urls_for_option( string $option, $old_value, $value ): void {
 		$global_options = [
 			'permalink_structure',
 			'category_base',
@@ -563,6 +599,22 @@ class PageCache implements ModuleInterface {
 		if ( in_array( $option, $global_options, true ) && $old_value !== $value ) {
 			$this->purge_site_cache();
 		}
+	}
+
+	/**
+	 * Queue tracked edge URLs with the old credentials before they are replaced.
+	 *
+	 * @param mixed $value New settings.
+	 * @param mixed $old_value Previous settings.
+	 * @param mixed $option Option name.
+	 * @return mixed
+	 */
+	public function capture_cloudflare_settings_before_update( $value, $old_value, $option ) {
+		if ( ! is_array( $old_value ) || ! is_array( $value ) || ! $this->cloudflare_settings_changed( $old_value, $value ) ) {
+			return $value;
+		}
+		$this->queue_cloudflare_tracked_urls( $old_value );
+		return $value;
 	}
 
 	/**
@@ -605,7 +657,7 @@ class PageCache implements ModuleInterface {
 	 * @return void
 	 */
 	public function seed_preload_queue_from_sitemap_and_logs() {
-		if ( empty( Helpers::get_option( 'enable_cache_preload', 'perform_settings', false ) ) ) {
+		if ( ! $this->page_cache_enabled() || empty( Helpers::get_option( 'enable_cache_preload', 'perform_settings', false ) ) ) {
 			return;
 		}
 
@@ -630,7 +682,7 @@ class PageCache implements ModuleInterface {
 	 * @return void
 	 */
 	public function run_preload_batch() {
-		if ( empty( Helpers::get_option( 'enable_cache_preload', 'perform_settings', false ) ) ) {
+		if ( ! $this->page_cache_enabled() || empty( Helpers::get_option( 'enable_cache_preload', 'perform_settings', false ) ) ) {
 			return;
 		}
 
@@ -709,7 +761,15 @@ class PageCache implements ModuleInterface {
 			<h1><?php esc_html_e( 'Perform Cache Observability', 'perform' ); ?></h1>
 			<p><?php esc_html_e( 'Live cache effectiveness and warmup health metrics.', 'perform' ); ?></p>
 			<?php if ( isset( $_GET['perform_cache_purged'] ) ) : ?>
-				<div class="notice notice-success is-dismissible"><p><?php esc_html_e( 'The site page cache has been purged. New requests will repopulate it.', 'perform' ); ?></p></div>
+				<div class="notice notice-success is-dismissible"><p><?php esc_html_e( 'The local page-cache generation has been invalidated.', 'perform' ); ?></p></div>
+				<?php
+				if ( ! empty( $_GET['perform_cache_cloudflare_pending'] ) ) :
+					?>
+					<div class="notice notice-warning"><p><?php esc_html_e( 'Cloudflare URL cleanup is pending.', 'perform' ); ?></p></div><?php endif; ?>
+				<?php
+				if ( ! empty( $_GET['perform_cache_cloudflare_failed'] ) ) :
+					?>
+					<div class="notice notice-error"><p><?php esc_html_e( 'Some Cloudflare URL cleanup batches need a manual retry.', 'perform' ); ?></p></div><?php endif; ?>
 			<?php endif; ?>
 			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 				<input type="hidden" name="action" value="perform_purge_page_cache" />
@@ -824,6 +884,38 @@ class PageCache implements ModuleInterface {
 	}
 
 	/**
+	 * Get invalidation URLs for a bounded set of posts.
+	 *
+	 * @param array<int, int> $post_ids Post IDs.
+	 * @return array<int, string>
+	 */
+	private function get_invalidation_urls_for_posts( array $post_ids ) {
+		$urls = [];
+		foreach ( array_slice( array_unique( array_map( 'intval', $post_ids ) ), 0, $this->get_term_object_limit() ) as $post_id ) {
+			$urls = array_merge( $urls, $this->get_invalidation_urls_for_post( $post_id ) );
+		}
+		return array_values( array_unique( $urls ) );
+	}
+
+	/**
+	 * Find a bounded set of posts related to a term.
+	 *
+	 * @return array<int, int>
+	 */
+	private function get_affected_object_ids_for_term( int $term_id, string $taxonomy ) {
+		if ( '' === $taxonomy || ! function_exists( 'get_objects_in_term' ) ) {
+			return [];
+		}
+		$object_ids = get_objects_in_term( (int) $term_id, $taxonomy, [ 'number' => $this->get_term_object_limit() ] );
+		return is_wp_error( $object_ids ) || ! is_array( $object_ids ) ? [] : array_map( 'intval', $object_ids );
+	}
+
+	/** @return int */
+	private function get_term_object_limit() {
+		return max( 1, (int) apply_filters( 'perform_cache_term_invalidation_object_limit', 100 ) );
+	}
+
+	/**
 	 * Purge a specific URL from local cache and Cloudflare.
 	 *
 	 * @param string $url Target URL.
@@ -848,14 +940,28 @@ class PageCache implements ModuleInterface {
 
 	/** Handle the explicit administrator-only site cache purge. */
 	public function handle_manual_purge(): void {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! $this->is_manual_purge_authorized() ) {
 			wp_die( esc_html__( 'You are not allowed to purge the page cache.', 'perform' ) );
 		}
 
-		check_admin_referer( 'perform_purge_page_cache' );
 		$this->purge_site_cache();
-		wp_safe_redirect( add_query_arg( 'perform_cache_purged', '1', admin_url( 'options-general.php?page=perform_cache_observability' ) ) );
+		$status = $this->get_cloudflare_queue_status();
+		wp_safe_redirect(
+			add_query_arg(
+				[
+					'perform_cache_purged'             => '1',
+					'perform_cache_cloudflare_pending' => $status['pending'],
+					'perform_cache_cloudflare_failed'  => $status['failed'],
+				],
+				admin_url( 'options-general.php?page=perform_cache_observability' )
+			)
+		);
 		exit;
+	}
+
+	/** Confirm the administrator capability and action nonce before purging. */
+	private function is_manual_purge_authorized(): bool {
+		return current_user_can( 'manage_options' ) && (bool) check_admin_referer( 'perform_purge_page_cache' );
 	}
 
 	/**
@@ -1007,14 +1113,22 @@ class PageCache implements ModuleInterface {
 	 *
 	 * @return bool
 	 */
-	private function purge_cloudflare_urls( $urls ) {
-		$enabled = Helpers::get_option( 'enable_cloudflare_cache_sync', 'perform_settings', false );
+	/**
+	 * @param array<int, string>        $urls URLs.
+	 * @param array<string, mixed>|null $settings Settings.
+	 */
+	private function purge_cloudflare_urls( array $urls, $settings = null ): bool {
+		$settings = is_array( $settings ) ? $settings : Helpers::get_settings();
+		if ( ! is_array( $settings ) ) {
+			return false;
+		}
+		$enabled = ! empty( $settings['enable_cloudflare_cache_sync'] );
 		if ( empty( $enabled ) ) {
 			return true;
 		}
 
-		$zone_id = trim( (string) Helpers::get_option( 'cloudflare_zone_id', 'perform_settings', '' ) );
-		$token   = trim( (string) Helpers::get_option( 'cloudflare_api_token', 'perform_settings', '' ) );
+		$zone_id = trim( (string) ( $settings['cloudflare_zone_id'] ?? '' ) );
+		$token   = trim( (string) ( $settings['cloudflare_api_token'] ?? '' ) );
 		if ( '' === $zone_id || '' === $token ) {
 			return false;
 		}
@@ -1036,7 +1150,11 @@ class PageCache implements ModuleInterface {
 			]
 		);
 
-		return ! is_wp_error( $response ) && ( empty( $response['response']['code'] ) || 300 > (int) $response['response']['code'] );
+		if ( is_wp_error( $response ) || empty( $response['response']['code'] ) || 200 > (int) $response['response']['code'] || 300 <= (int) $response['response']['code'] ) {
+			return false;
+		}
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		return is_array( $body ) && ! empty( $body['success'] );
 	}
 
 	/**
@@ -1679,15 +1797,23 @@ class PageCache implements ModuleInterface {
 
 	/** Delete a bounded number of files from retired generations. */
 	public function cleanup_obsolete_generations(): void {
-		$site_dir = $this->cache_dir . 'site-' . $this->get_blog_id() . '/';
-		if ( ! is_dir( $site_dir ) ) {
-			return;
+		$site_dir    = $this->cache_dir . 'site-' . $this->get_blog_id() . '/';
+		$remaining   = max( 1, (int) $this->cleanup_batch_size );
+		$has_more    = false;
+		$legacy_html = glob( $this->cache_dir . '*.html' );
+		$legacy_meta = glob( $this->cache_dir . '*.meta.json' );
+		$legacy      = array_merge( is_array( $legacy_html ) ? $legacy_html : [], is_array( $legacy_meta ) ? $legacy_meta : [] );
+		foreach ( $legacy as $file ) {
+			if ( $remaining <= 0 ) {
+				$has_more = true;
+				break;
+			}
+			wp_delete_file( $file );
+			--$remaining;
 		}
 
-		$current   = $this->get_generation_dir( $this->get_cache_generation() );
-		$remaining = max( 1, (int) $this->cleanup_batch_size );
-		$has_more  = false;
-		$dirs      = glob( $site_dir . 'generation-*', GLOB_ONLYDIR );
+		$current = $this->get_generation_dir( $this->get_cache_generation() );
+		$dirs    = is_dir( $site_dir ) ? glob( $site_dir . 'generation-*', GLOB_ONLYDIR ) : [];
 		foreach ( is_array( $dirs ) ? $dirs : [] as $dir ) {
 			if ( trailingslashit( $dir ) === $current ) {
 				continue;
@@ -1715,51 +1841,200 @@ class PageCache implements ModuleInterface {
 
 	/** Store URLs that may need a bounded Cloudflare purge after a global rotation. */
 	private function track_cached_url( string $url ): void {
-		$key  = 'perform_cache_urls_' . $this->get_blog_id();
-		$urls = get_option( $key, [] );
-		$urls = is_array( $urls ) ? $urls : [];
-		$urls[] = esc_url_raw( $url );
-		update_option( $key, array_values( array_unique( array_filter( $urls ) ) ), false );
+		$key   = 'perform_cache_urls_' . $this->get_blog_id();
+		$url   = esc_url_raw( $url );
+		$urls  = get_option( $key, [] );
+		$urls  = is_array( $urls ) ? $urls : [];
+		$limit = max( 1, (int) apply_filters( 'perform_cache_tracked_url_limit', 500 ) );
+		if ( in_array( $url, $urls, true ) ) {
+			return;
+		}
+		if ( count( $urls ) >= $limit ) {
+			$overflow_key = 'perform_cache_url_tracking_overflow_' . $this->get_blog_id();
+			if ( ! get_option( $overflow_key, false ) ) {
+				update_option( $overflow_key, true, false );
+			}
+			return;
+		}
+		$urls[] = $url;
+		update_option( $key, $urls, false );
 	}
 
 	/** Queue tracked URLs instead of using Cloudflare purge_everything. */
-	private function queue_cloudflare_tracked_urls(): void {
-		if ( empty( Helpers::get_option( 'enable_cloudflare_cache_sync', 'perform_settings', false ) ) ) {
+	/** @param array<string,mixed>|null $settings */
+	private function queue_cloudflare_tracked_urls( $settings = null ): void {
+		$settings = is_array( $settings ) ? $settings : Helpers::get_settings();
+		if ( ! is_array( $settings ) || empty( $settings['enable_cloudflare_cache_sync'] ) ) {
 			return;
 		}
-		$urls = get_option( 'perform_cache_urls_' . $this->get_blog_id(), [] );
-		if ( ! is_array( $urls ) || empty( $urls ) ) {
+		$blog_id = $this->get_blog_id();
+		$urls    = get_option( 'perform_cache_urls_' . $blog_id, [] );
+		$urls    = is_array( $urls ) ? $urls : [];
+		$urls    = array_values( array_unique( array_merge( $urls, $this->get_cached_urls_from_metadata() ) ) );
+		if ( empty( $urls ) ) {
 			return;
 		}
-		update_option( 'perform_cache_cloudflare_queue_' . $this->get_blog_id(), array_values( array_unique( $urls ) ), false );
+		$key     = 'perform_cache_cloudflare_queue_' . $blog_id;
+		$records = $this->get_cloudflare_queue_records( get_option( $key, [] ) );
+		$found   = false;
+		foreach ( $records as &$record ) {
+			if ( $this->cloudflare_settings_key( $record['settings'] ) === $this->cloudflare_settings_key( $settings ) ) {
+				$record['urls']     = array_values( array_unique( array_merge( $record['urls'], $urls ) ) );
+				$record['failed']   = false;
+				$record['attempts'] = 0;
+				$found              = true;
+				break;
+			}
+		}
+		unset( $record );
+		if ( ! $found ) {
+			$records[] = [
+				'urls'     => array_values( array_unique( $urls ) ),
+				'settings' => $this->cloudflare_settings( $settings ),
+				'attempts' => 0,
+				'failed'   => false,
+			];
+		}
+		update_option( $key, $records, false );
 		if ( ! wp_next_scheduled( 'perform_cache_cloudflare_purge_event' ) ) {
 			wp_schedule_single_event( time() + 10, 'perform_cache_cloudflare_purge_event' );
 		}
 	}
 
+	/**
+	 * Discover a bounded local cache inventory for pre-tracking installations.
+	 *
+	 * @return array<int, string>
+	 */
+	private function get_cached_urls_from_metadata() {
+		$limit = max( 1, (int) apply_filters( 'perform_cache_tracked_url_limit', 500 ) );
+		$files = array_merge(
+			is_array( glob( $this->get_generation_dir( $this->get_cache_generation() ) . '*.meta.json' ) ) ? glob( $this->get_generation_dir( $this->get_cache_generation() ) . '*.meta.json' ) : [],
+			is_array( glob( $this->cache_dir . '*.meta.json' ) ) ? glob( $this->cache_dir . '*.meta.json' ) : []
+		);
+		$urls  = [];
+		foreach ( array_slice( $files, 0, $limit ) as $file ) {
+			$raw  = file_get_contents( $file );
+			$data = is_string( $raw ) ? json_decode( $raw, true ) : null;
+			if ( is_array( $data ) && ! empty( $data['url'] ) && $this->is_site_url( $data['url'] ) ) {
+				$urls[] = esc_url_raw( $data['url'] );
+			}
+		}
+		return array_values( array_unique( $urls ) );
+	}
+
 	/** Purge a bounded batch of tracked URLs from Cloudflare, with retries. */
 	public function run_cloudflare_purge_batch(): void {
-		$blog_id    = $this->get_blog_id();
-		$key        = 'perform_cache_cloudflare_queue_' . $blog_id;
-		$retry_key  = 'perform_cache_cloudflare_retries_' . $blog_id;
-		$queue      = get_option( $key, [] );
-		if ( ! is_array( $queue ) || empty( $queue ) ) {
+		$key     = 'perform_cache_cloudflare_queue_' . $this->get_blog_id();
+		$records = $this->get_cloudflare_queue_records( get_option( $key, [] ) );
+		if ( empty( $records ) ) {
 			return;
 		}
-		$batch = array_splice( $queue, 0, max( 1, (int) $this->cloudflare_batch_size ) );
-		if ( ! $this->purge_cloudflare_urls( $batch ) ) {
-			$attempts = (int) get_option( $retry_key, 0 ) + 1;
-			if ( $attempts < max( 1, (int) $this->cloudflare_max_retries ) ) {
-				$queue = array_merge( $batch, $queue );
+		foreach ( $records as $index => &$record ) {
+			if ( ! empty( $record['failed'] ) ) {
+				continue;
 			}
-			update_option( $retry_key, $attempts, false );
-		} else {
-			update_option( $retry_key, 0, false );
+			$batch = array_slice( $record['urls'], 0, max( 1, (int) $this->cloudflare_batch_size ) );
+			if ( $this->purge_cloudflare_urls( $batch, $record['settings'] ) ) {
+				$record['urls'] = array_values( array_diff( $record['urls'], $batch ) );
+				$this->retire_tracked_urls( $batch );
+			} else {
+				++$record['attempts'];
+				$record['failed'] = $record['attempts'] >= max( 1, (int) $this->cloudflare_max_retries );
+			}
+			break;
 		}
-		update_option( $key, array_values( $queue ), false );
-		if ( ! empty( $queue ) ) {
+		unset( $record );
+		$records = array_values(
+			array_filter(
+				$records,
+				static function ( $record ) {
+					return ! empty( $record['urls'] );
+				}
+			)
+		);
+		update_option( $key, $records, false );
+		$active = array_filter(
+			$records,
+			static function ( $record ) {
+				return empty( $record['failed'] );
+			}
+		);
+		if ( ! empty( $active ) ) {
 			wp_schedule_single_event( time() + 60, 'perform_cache_cloudflare_purge_event' );
 		}
+	}
+
+	/** @param array<int,string> $urls */
+	private function retire_tracked_urls( array $urls ): void {
+		$key     = 'perform_cache_urls_' . $this->get_blog_id();
+		$tracked = get_option( $key, [] );
+		if ( is_array( $tracked ) ) {
+			$remaining = array_values( array_diff( $tracked, $urls ) );
+			if ( $remaining !== $tracked ) {
+				update_option( $key, $remaining, false );
+			}
+		}
+	}
+
+	/**
+	 * @param mixed $records Queue records.
+	 * @return array<int, array{urls: array<int, string>, settings: array<string, mixed>, attempts: int, failed: bool}>
+	 */
+	private function get_cloudflare_queue_records( $records ): array {
+		if ( ! is_array( $records ) || empty( $records ) ) {
+			return []; }
+		if ( isset( $records[0] ) && is_string( $records[0] ) ) {
+			return [
+				[
+					'urls'     => array_values( array_unique( $records ) ),
+					'settings' => $this->cloudflare_settings( Helpers::get_settings() ),
+					'attempts' => 0,
+					'failed'   => false,
+				],
+			];
+		}
+		return $records;
+	}
+
+	/**
+	 * @param array<string, mixed> $settings Settings.
+	 * @return array{enable_cloudflare_cache_sync: bool, cloudflare_zone_id: string, cloudflare_api_token: string}
+	 */
+	private function cloudflare_settings( array $settings ): array {
+		return [
+			'enable_cloudflare_cache_sync' => ! empty( $settings['enable_cloudflare_cache_sync'] ),
+			'cloudflare_zone_id'           => (string) ( $settings['cloudflare_zone_id'] ?? '' ),
+			'cloudflare_api_token'         => (string) ( $settings['cloudflare_api_token'] ?? '' ),
+		];
+	}
+
+	/** @param array<string,mixed> $settings */
+	private function cloudflare_settings_key( array $settings ): string {
+		return md5( $settings['cloudflare_zone_id'] . '|' . $settings['cloudflare_api_token'] ); }
+
+	/**
+	 * @param array<string, mixed> $old Previous settings.
+	 * @param array<string, mixed> $new_settings New settings.
+	 */
+	private function cloudflare_settings_changed( array $old, array $new_settings ): bool {
+		return $this->cloudflare_settings_key( $old ) !== $this->cloudflare_settings_key( $new_settings ) || ! empty( $old['enable_cloudflare_cache_sync'] ) !== ! empty( $new_settings['enable_cloudflare_cache_sync'] );
+	}
+
+	/** @return array<string, int> */
+	private function get_cloudflare_queue_status() {
+		$records = $this->get_cloudflare_queue_records( get_option( 'perform_cache_cloudflare_queue_' . $this->get_blog_id(), [] ) );
+		$status  = [
+			'pending' => 0,
+			'failed'  => 0,
+		];
+		foreach ( $records as $record ) {
+			if ( ! empty( $record['failed'] ) ) {
+				++$status['failed'];
+			} else {
+				++$status['pending']; }
+		}
+		return $status;
 	}
 
 	/**

--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -1835,9 +1835,13 @@ class PageCache implements ModuleInterface {
 
 	/** Delete a bounded number of files from retired generations. */
 	public function cleanup_obsolete_generations(): void {
-		$site_dir    = $this->cache_dir . 'site-' . $this->get_blog_id() . '/';
-		$remaining   = max( 1, (int) $this->cleanup_batch_size );
-		$has_more    = false;
+		$site_dir  = $this->cache_dir . 'site-' . $this->get_blog_id() . '/';
+		$remaining = max( 1, (int) $this->cleanup_batch_size );
+		$has_more  = false;
+		if ( $this->has_pending_metadata_inventory() ) {
+			$this->schedule_cleanup();
+			return;
+		}
 		$legacy_html = glob( $this->cache_dir . '*.html' );
 		$legacy_meta = glob( $this->cache_dir . '*.meta.json' );
 		$legacy      = array_merge( is_array( $legacy_html ) ? $legacy_html : [], is_array( $legacy_meta ) ? $legacy_meta : [] );
@@ -1899,7 +1903,11 @@ class PageCache implements ModuleInterface {
 		$chunk_key = $this->get_manifest_chunk_option( $generation, (int) $state['chunk'] );
 		$urls      = get_option( $chunk_key, [] );
 		$urls      = is_array( $urls ) ? $urls : [];
-		$urls[]    = esc_url_raw( $url );
+		$url       = esc_url_raw( $url );
+		if ( in_array( $url, $urls, true ) ) {
+			return;
+		}
+		$urls[] = $url;
 		update_option( $chunk_key, $urls, false );
 		++$state['count'];
 		update_option( $state_key, $state, false );
@@ -1917,8 +1925,11 @@ class PageCache implements ModuleInterface {
 		$key        = 'perform_cache_cloudflare_queue_' . $blog_id;
 		$records    = $this->get_cloudflare_queue_records( get_option( $key, [] ) );
 		$state      = get_option( $this->get_manifest_state_option( $generation ), [] );
-		$chunks     = is_array( $state ) ? range( 0, (int) $state['chunk'] ) : [];
+		$chunks     = is_array( $state ) && isset( $state['chunk'] ) ? range( 0, (int) $state['chunk'] ) : [];
 		foreach ( $chunks as $chunk ) {
+			if ( $this->has_cloudflare_source_record( $records, 'manifest', $generation, (int) $chunk ) ) {
+				continue;
+			}
 			$records[] = [
 				'source'      => 'manifest',
 				'generation'  => $generation,
@@ -1930,7 +1941,7 @@ class PageCache implements ModuleInterface {
 				'failed'      => false,
 			];
 		}
-		if ( empty( $chunks ) ) {
+		if ( empty( $chunks ) && ! $this->has_cloudflare_source_record( $records, 'metadata', $generation ) ) {
 			$records[] = [
 				'source'      => 'metadata',
 				'generation'  => $generation,
@@ -1941,7 +1952,7 @@ class PageCache implements ModuleInterface {
 				'failed'      => false,
 			];
 		}
-		if ( 1 === $generation ) {
+		if ( 1 === $generation && ! $this->has_cloudflare_source_record( $records, 'legacy_metadata' ) ) {
 			$records[] = [
 				'source'      => 'legacy_metadata',
 				'cursor'      => 0,
@@ -1952,7 +1963,7 @@ class PageCache implements ModuleInterface {
 			];
 		}
 		$legacy = get_option( 'perform_cache_urls_' . $blog_id, [] );
-		if ( is_array( $legacy ) && ! empty( $legacy ) ) {
+		if ( is_array( $legacy ) && ! empty( $legacy ) && ! $this->has_cloudflare_source_record( $records, 'legacy_option' ) ) {
 			$records[] = [
 				'source'      => 'legacy_option',
 				'offset'      => 0,
@@ -1975,6 +1986,23 @@ class PageCache implements ModuleInterface {
 	private function get_manifest_chunk_size(): int {
 		return max( 1, (int) apply_filters( 'perform_cache_manifest_chunk_size', $this->manifest_chunk_size ) ); }
 
+	/** @param array<int, array<string, mixed>> $records */
+	private function has_cloudflare_source_record( array $records, string $source, ?int $generation = null, ?int $chunk = null ): bool {
+		foreach ( $records as $record ) {
+			if ( ( $record['source'] ?? '' ) !== $source || ! empty( $record['done'] ) ) {
+				continue;
+			}
+			if ( null !== $generation && (int) ( $record['generation'] ?? 0 ) !== (int) $generation ) {
+				continue;
+			}
+			if ( null !== $chunk && (int) ( $record['chunk'] ?? -1 ) !== (int) $chunk ) {
+				continue;
+			}
+			return true;
+		}
+		return false;
+	}
+
 	/** Purge a bounded batch of tracked URLs from Cloudflare, with retries. */
 	public function run_cloudflare_purge_batch(): void {
 		$key     = 'perform_cache_cloudflare_queue_' . $this->get_blog_id();
@@ -1996,9 +2024,11 @@ class PageCache implements ModuleInterface {
 			$settings = Helpers::get_settings();
 			if ( ! is_array( $settings ) || $record['fingerprint'] !== $this->cloudflare_settings_key( $settings ) ) {
 				$record['failed'] = true;
-				update_option( 'perform_cache_cloudflare_credential_residual_' . $this->get_blog_id(), count( $record['urls'] ), false );
+				update_option( 'perform_cache_cloudflare_credential_residual_' . $this->get_blog_id(), $this->get_cloudflare_residual_count( $record, $urls ), false );
 			} elseif ( $this->purge_cloudflare_urls( $batch, $settings ) ) {
-				if ( isset( $record['source'] ) ) {
+				if ( isset( $record['source'] ) && in_array( $record['source'], [ 'metadata', 'legacy_metadata' ], true ) ) {
+					// The inventory cursor advanced while building this batch.
+				} elseif ( isset( $record['source'] ) ) {
 					$record['offset'] = (int) ( $record['offset'] ?? 0 ) + count( $batch );
 				} else {
 					$record['urls'] = array_values( array_diff( $record['urls'], $batch ) );
@@ -2034,7 +2064,7 @@ class PageCache implements ModuleInterface {
 	 * @param array<string, mixed> $record Record.
 	 * @return array<int, string>
 	 */
-	private function get_cloudflare_record_urls( array $record ): array {
+	private function get_cloudflare_record_urls( array &$record ): array {
 		if ( isset( $record['source'] ) && 'manifest' === $record['source'] ) {
 			$urls = get_option( $this->get_manifest_chunk_option( (int) $record['generation'], (int) $record['chunk'] ), [] );
 			return is_array( $urls ) ? $urls : [];
@@ -2043,16 +2073,85 @@ class PageCache implements ModuleInterface {
 			$urls = get_option( 'perform_cache_urls_' . $this->get_blog_id(), [] );
 			return is_array( $urls ) ? $urls : [];
 		}
+		if ( isset( $record['source'] ) && in_array( $record['source'], [ 'metadata', 'legacy_metadata' ], true ) ) {
+			return $this->get_cloudflare_metadata_urls( $record );
+		}
 		return isset( $record['urls'] ) && is_array( $record['urls'] ) ? $record['urls'] : [];
+	}
+
+	/**
+	 * @param array<string, mixed> $record
+	 * @return array<int, string>
+	 */
+	private function get_cloudflare_metadata_urls( array &$record ): array {
+		$directory = 'metadata' === $record['source'] ? $this->get_generation_dir( (int) $record['generation'] ) : $this->cache_dir;
+		if ( ! is_dir( $directory ) ) {
+			$record['inventory_complete'] = true;
+			return [];
+		}
+
+		$cursor = max( 0, (int) ( $record['cursor'] ?? 0 ) );
+		$index  = 0;
+		$urls   = [];
+		$limit  = max( 1, (int) $this->cloudflare_batch_size );
+		$files  = new \DirectoryIterator( $directory );
+		foreach ( $files as $file ) {
+			if ( $file->isDot() || ! $file->isFile() || '.meta.json' !== substr( $file->getFilename(), -10 ) ) {
+				++$index;
+				continue;
+			}
+			if ( $index++ < $cursor ) {
+				continue;
+			}
+			$raw  = file_get_contents( $file->getPathname() );
+			$data = false === $raw ? null : json_decode( $raw, true );
+			$url  = is_array( $data ) && isset( $data['url'] ) ? esc_url_raw( (string) $data['url'] ) : '';
+			if ( '' !== $url && $this->is_site_url( $url ) ) {
+				$urls[] = $url;
+			}
+			$record['cursor'] = $index;
+			if ( count( $urls ) >= $limit ) {
+				return array_values( array_unique( $urls ) );
+			}
+		}
+		$record['cursor']             = $index;
+		$record['inventory_complete'] = true;
+		return array_values( array_unique( $urls ) );
+	}
+
+	/**
+	 * @param array<string, mixed> $record
+	 * @param array<int, string> $urls
+	 */
+	private function get_cloudflare_residual_count( array $record, array $urls ): int {
+		if ( isset( $record['urls'] ) && is_array( $record['urls'] ) ) {
+			return max( 1, count( $record['urls'] ) - (int) ( $record['offset'] ?? 0 ) );
+		}
+		return max( 1, count( $urls ) );
 	}
 
 	/** @param array<string,mixed> $record */
 	private function retire_cloudflare_record( array $record ): void {
 		if ( isset( $record['source'] ) && 'manifest' === $record['source'] ) {
 			delete_option( $this->get_manifest_chunk_option( (int) $record['generation'], (int) $record['chunk'] ) );
+			$state = get_option( $this->get_manifest_state_option( (int) $record['generation'] ), [] );
+			if ( is_array( $state ) && (int) $record['chunk'] >= (int) ( $state['chunk'] ?? 0 ) ) {
+				delete_option( $this->get_manifest_state_option( (int) $record['generation'] ) );
+			}
 		} elseif ( isset( $record['source'] ) && 'legacy_option' === $record['source'] ) {
 			delete_option( 'perform_cache_urls_' . $this->get_blog_id() );
 		}
+	}
+
+	/** Keep local metadata until its bounded Cloudflare inventory is drained. */
+	private function has_pending_metadata_inventory(): bool {
+		$records = $this->get_cloudflare_queue_records( get_option( 'perform_cache_cloudflare_queue_' . $this->get_blog_id(), [] ) );
+		foreach ( $records as $record ) {
+			if ( in_array( $record['source'] ?? '', [ 'metadata', 'legacy_metadata' ], true ) && empty( $record['done'] ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -26,6 +26,41 @@ class PageCache implements ModuleInterface {
 	private $cache_dir = '';
 
 	/**
+	 * Generation captured when this request became eligible to write.
+	 *
+	 * @var int
+	 */
+	private $request_generation = 0;
+
+	/**
+	 * URLs captured before a post mutation removes their old routing context.
+	 *
+	 * @var array<int, array<int, string>>
+	 */
+	private $captured_post_urls = [];
+
+	/**
+	 * Maximum files deleted from obsolete cache generations per cron run.
+	 *
+	 * @var int
+	 */
+	private $cleanup_batch_size = 100;
+
+	/**
+	 * Maximum Cloudflare URLs purged per request.
+	 *
+	 * @var int
+	 */
+	private $cloudflare_batch_size = 30;
+
+	/**
+	 * Maximum retry attempts for a failed Cloudflare URL batch.
+	 *
+	 * @var int
+	 */
+	private $cloudflare_max_retries = 3;
+
+	/**
 	 * Current cache key for the request.
 	 *
 	 * @var string
@@ -101,7 +136,9 @@ class PageCache implements ModuleInterface {
 	 * @return bool
 	 */
 	public function should_load(): bool {
-		return ! empty( Helpers::get_option( 'enable_page_cache', 'perform_settings', false ) );
+		// Invalidation must remain available while the page cache is disabled so a
+		// later enable cannot expose entries written by an earlier configuration.
+		return true;
 	}
 
 	/**
@@ -122,16 +159,40 @@ class PageCache implements ModuleInterface {
 		add_action( 'shutdown', [ $this, 'record_slow_uncached_request' ], 9999 );
 		add_action( 'shutdown', [ $this, 'flush_stats' ], 10000 );
 
+		add_action( 'pre_post_update', [ $this, 'capture_post_urls_before_mutation' ], 10, 2 );
+		add_action( 'wp_trash_post', [ $this, 'capture_post_urls_before_removal' ] );
+		add_action( 'untrash_post', [ $this, 'capture_post_urls_before_removal' ] );
+		add_action( 'before_delete_post', [ $this, 'capture_post_urls_before_removal' ] );
 		add_action( 'save_post', [ $this, 'purge_related_urls_for_post' ], 10, 3 );
 		add_action( 'deleted_post', [ $this, 'purge_related_urls_for_deleted_post' ], 10, 1 );
 		add_action( 'trashed_post', [ $this, 'purge_related_urls_for_deleted_post' ], 10, 1 );
+		add_action( 'untrashed_post', [ $this, 'purge_related_urls_for_untrashed_post' ], 10, 1 );
+		add_action( 'transition_post_status', [ $this, 'purge_related_urls_for_status_transition' ], 10, 3 );
 		add_action( 'set_object_terms', [ $this, 'purge_related_urls_for_object_terms' ], 10, 6 );
-		add_action( 'switch_theme', [ $this, 'purge_homepage' ] );
+		add_action( 'comment_post', [ $this, 'purge_related_urls_for_comment' ], 10, 1 );
+		add_action( 'edit_comment', [ $this, 'purge_related_urls_for_comment' ] );
+		add_action( 'transition_comment_status', [ $this, 'purge_related_urls_for_comment_status' ], 10, 3 );
+		add_action( 'deleted_comment', [ $this, 'purge_related_urls_for_comment' ] );
+		add_action( 'created_term', [ $this, 'purge_related_urls_for_term' ], 10, 3 );
+		add_action( 'edited_term', [ $this, 'purge_related_urls_for_term' ], 10, 3 );
+		add_action( 'delete_term', [ $this, 'purge_related_urls_for_term' ], 10, 4 );
+		add_action( 'added_term_meta', [ $this, 'purge_related_urls_for_term_meta' ], 10, 2 );
+		add_action( 'updated_term_meta', [ $this, 'purge_related_urls_for_term_meta' ], 10, 2 );
+		add_action( 'deleted_term_meta', [ $this, 'purge_related_urls_for_term_meta' ], 10, 2 );
+		add_action( 'wp_update_nav_menu', [ $this, 'purge_site_cache' ] );
+		add_action( 'wp_update_nav_menu_item', [ $this, 'purge_site_cache' ] );
+		add_action( 'wp_delete_nav_menu', [ $this, 'purge_site_cache' ] );
+		add_action( 'switch_theme', [ $this, 'purge_site_cache' ] );
+		add_action( 'customize_save_after', [ $this, 'purge_site_cache' ] );
+		add_action( 'updated_option', [ $this, 'purge_related_urls_for_option' ], 10, 3 );
 
 		add_action( 'perform_cache_preload_event', [ $this, 'run_preload_batch' ] );
 		add_action( 'perform_cache_sitemap_seed_event', [ $this, 'seed_preload_queue_from_sitemap_and_logs' ] );
+		add_action( 'perform_cache_cleanup_event', [ $this, 'cleanup_obsolete_generations' ] );
+		add_action( 'perform_cache_cloudflare_purge_event', [ $this, 'run_cloudflare_purge_batch' ] );
 
 		add_action( 'admin_menu', [ $this, 'register_observability_page' ] );
+		add_action( 'admin_post_perform_purge_page_cache', [ $this, 'handle_manual_purge' ] );
 	}
 
 	/**
@@ -184,6 +245,9 @@ class PageCache implements ModuleInterface {
 	 */
 	public function maybe_serve_cache() {
 		$this->request_start = microtime( true );
+		if ( ! $this->page_cache_enabled() ) {
+			return;
+		}
 
 		if ( ! $this->is_cacheable_request() ) {
 			$bypass_increment = $this->increment_stat( 'bypasses' );
@@ -197,6 +261,7 @@ class PageCache implements ModuleInterface {
 
 		$this->current_url       = $this->get_normalized_request_url();
 		$this->current_cache_key = $this->get_cache_key_for_url( $this->current_url );
+		$this->request_generation = $this->get_cache_generation();
 		$this->lock_key          = 'perform_cache_lock_' . $this->current_cache_key;
 
 		$meta = $this->read_cache_meta( $this->current_cache_key );
@@ -278,7 +343,13 @@ class PageCache implements ModuleInterface {
 	 */
 	public function store_cache( $html ) {
 		try {
-			if ( ! $this->should_write_cache || ! is_string( $html ) || '' === $html ) {
+			if ( ! $this->should_write_cache || ! $this->page_cache_enabled() || ! is_string( $html ) || '' === $html ) {
+				return $html;
+			}
+
+			// A global purge may happen while WordPress renders this response. Do not
+			// let that request repopulate the generation that was just retired.
+			if ( $this->request_generation !== $this->get_cache_generation() ) {
 				return $html;
 			}
 
@@ -300,8 +371,18 @@ class PageCache implements ModuleInterface {
 				return $html;
 			}
 
+			if ( $this->request_generation !== $this->get_cache_generation() ) {
+				wp_delete_file( $this->get_body_file_path( $this->current_cache_key ) );
+				return $html;
+			}
+
 			if ( ! $this->write_cache_meta( $this->current_cache_key, $meta_payload ) ) {
 				wp_delete_file( $this->get_body_file_path( $this->current_cache_key ) );
+			} elseif ( $this->request_generation !== $this->get_cache_generation() ) {
+				wp_delete_file( $this->get_body_file_path( $this->current_cache_key ) );
+				wp_delete_file( $this->get_meta_file_path( $this->current_cache_key ) );
+			} else {
+				$this->track_cached_url( $this->current_url );
 			}
 		} finally {
 			$this->release_lock();
@@ -345,15 +426,13 @@ class PageCache implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function purge_related_urls_for_post( $post_id, $post, $update ) {
+	public function purge_related_urls_for_post( int $post_id, ?\WP_Post $post = null, bool $update = false ): void {
 		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
 			return;
 		}
 
-		$urls = $this->get_invalidation_urls_for_post( $post_id );
-		foreach ( $urls as $url ) {
-			$this->purge_url( $url );
-		}
+		$urls = array_merge( $this->get_captured_post_urls( $post_id ), $this->get_invalidation_urls_for_post( $post_id ) );
+		$this->purge_urls( $urls );
 
 		$this->queue_urls_for_preload( $urls );
 	}
@@ -366,10 +445,12 @@ class PageCache implements ModuleInterface {
 	 * @return void
 	 */
 	public function purge_related_urls_for_deleted_post( $post_id ) {
-		$urls = $this->get_invalidation_urls_for_post( $post_id );
-		foreach ( $urls as $url ) {
-			$this->purge_url( $url );
-		}
+		$this->purge_urls( array_merge( $this->get_captured_post_urls( $post_id ), $this->get_invalidation_urls_for_post( $post_id ) ) );
+	}
+
+	/** Purge newly restored public URLs after WordPress completes untrash. */
+	public function purge_related_urls_for_untrashed_post( int $post_id ): void {
+		$this->purge_related_urls_for_post( $post_id );
 	}
 
 	/**
@@ -386,8 +467,101 @@ class PageCache implements ModuleInterface {
 	 */
 	public function purge_related_urls_for_object_terms( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {
 		$urls = $this->get_invalidation_urls_for_post( $object_id );
-		foreach ( $urls as $url ) {
-			$this->purge_url( $url );
+		foreach ( (array) $old_tt_ids as $term_taxonomy_id ) {
+			$term = get_term_by( 'term_taxonomy_id', $term_taxonomy_id );
+			if ( $term ) {
+				$link = get_term_link( $term );
+				if ( ! is_wp_error( $link ) ) {
+					$urls[] = $link;
+				}
+			}
+		}
+
+		$this->purge_urls( $urls );
+	}
+
+	/**
+	 * Capture URLs before WordPress changes a post's status or permalink.
+	 *
+	 * @param int                 $post_id Post ID.
+	 * @param array<string,mixed> $data Post data.
+	 */
+	public function capture_post_urls_before_mutation( int $post_id, array $data = [] ): void {
+		$this->capture_post_urls_before_removal( $post_id );
+	}
+
+	/** Capture URLs before WordPress removes routing context. */
+	public function capture_post_urls_before_removal( int $post_id ): void {
+		$this->captured_post_urls[ (int) $post_id ] = $this->get_invalidation_urls_for_post( $post_id );
+	}
+
+	/** Purge URLs affected by a public status transition. */
+	public function purge_related_urls_for_status_transition( string $new_status, string $old_status, \WP_Post $post ): void {
+		if ( $new_status === $old_status || empty( $post->ID ) ) {
+			return;
+		}
+
+		$this->purge_related_urls_for_post( (int) $post->ID );
+	}
+
+	/** Purge pages that can render a public comment. */
+	public function purge_related_urls_for_comment( int $comment_id ): void {
+		$comment = get_comment( $comment_id );
+		if ( ! $comment || empty( $comment->comment_post_ID ) ) {
+			return;
+		}
+
+		$this->purge_related_urls_for_post( (int) $comment->comment_post_ID );
+	}
+
+	/** Purge pages for visible comment-status transitions. */
+	public function purge_related_urls_for_comment_status( string $new_status, string $old_status, \WP_Comment $comment ): void {
+		if ( $new_status !== $old_status && ! empty( $comment->comment_post_ID ) ) {
+			$this->purge_related_urls_for_post( (int) $comment->comment_post_ID );
+		}
+	}
+
+	/** Purge a changed term archive and its home surface. */
+	public function purge_related_urls_for_term( int $term_id, int $tt_id = 0, string $taxonomy = '', ?\WP_Term $deleted_term = null ): void {
+		$term = is_object( $deleted_term ) ? $deleted_term : get_term( $term_id, $taxonomy );
+		$urls = [ home_url( '/' ) ];
+		if ( $term ) {
+			$link = get_term_link( $term );
+			if ( ! is_wp_error( $link ) ) {
+				$urls[] = $link;
+			}
+		}
+		$this->purge_urls( $urls );
+	}
+
+	/** Purge a term archive when term metadata changes. */
+	public function purge_related_urls_for_term_meta( mixed $meta_id, int $term_id ): void {
+		$this->purge_related_urls_for_term( $term_id );
+	}
+
+	/** Rotate the local cache after a site-wide output change. */
+	public function purge_site_cache(): void {
+		$current = $this->get_cache_generation();
+		update_option( $this->get_generation_option_name(), $current + 1, false );
+		$this->schedule_cleanup();
+		$this->queue_cloudflare_tracked_urls();
+	}
+
+	/** Invalidate when a setting changes public output or cache compatibility. */
+	public function purge_related_urls_for_option( string $option, mixed $old_value, mixed $value ): void {
+		$global_options = [
+			'permalink_structure',
+			'category_base',
+			'tag_base',
+			'page_on_front',
+			'page_for_posts',
+			'show_on_front',
+			'theme_mods_' . get_option( 'stylesheet' ),
+			'perform_settings',
+		];
+
+		if ( in_array( $option, $global_options, true ) && $old_value !== $value ) {
+			$this->purge_site_cache();
 		}
 	}
 
@@ -398,6 +572,31 @@ class PageCache implements ModuleInterface {
 	 */
 	public function purge_homepage() {
 		$this->purge_url( home_url( '/' ) );
+	}
+
+	/**
+	 * Purge a normalized set of known URLs.
+	 *
+	 * @param array<int, string> $urls URLs.
+	 */
+	private function purge_urls( array $urls ): void {
+		$urls = array_values( array_unique( array_filter( array_map( 'strval', (array) $urls ) ) ) );
+		foreach ( $urls as $url ) {
+			$this->purge_url( $url );
+		}
+	}
+
+	/**
+	 * Retrieve and clear pre-mutation post URLs.
+	 *
+	 * @return array<int, string>
+	 */
+	private function get_captured_post_urls( int $post_id ): array {
+		$post_id = (int) $post_id;
+		$urls    = $this->captured_post_urls[ $post_id ] ?? [];
+		unset( $this->captured_post_urls[ $post_id ] );
+
+		return $urls;
 	}
 
 	/**
@@ -509,6 +708,14 @@ class PageCache implements ModuleInterface {
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Perform Cache Observability', 'perform' ); ?></h1>
 			<p><?php esc_html_e( 'Live cache effectiveness and warmup health metrics.', 'perform' ); ?></p>
+			<?php if ( isset( $_GET['perform_cache_purged'] ) ) : ?>
+				<div class="notice notice-success is-dismissible"><p><?php esc_html_e( 'The site page cache has been purged. New requests will repopulate it.', 'perform' ); ?></p></div>
+			<?php endif; ?>
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+				<input type="hidden" name="action" value="perform_purge_page_cache" />
+				<?php wp_nonce_field( 'perform_purge_page_cache' ); ?>
+				<?php submit_button( esc_html__( 'Purge Site Page Cache', 'perform' ), 'secondary', 'submit', false ); ?>
+			</form>
 
 			<table class="widefat striped" style="max-width:900px;">
 				<tbody>
@@ -637,6 +844,18 @@ class PageCache implements ModuleInterface {
 		}
 
 		$this->purge_cloudflare_url( $url );
+	}
+
+	/** Handle the explicit administrator-only site cache purge. */
+	public function handle_manual_purge(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You are not allowed to purge the page cache.', 'perform' ) );
+		}
+
+		check_admin_referer( 'perform_purge_page_cache' );
+		$this->purge_site_cache();
+		wp_safe_redirect( add_query_arg( 'perform_cache_purged', '1', admin_url( 'options-general.php?page=perform_cache_observability' ) ) );
+		exit;
 	}
 
 	/**
@@ -778,18 +997,34 @@ class PageCache implements ModuleInterface {
 	 * @return void
 	 */
 	private function purge_cloudflare_url( $url ) {
+		$this->purge_cloudflare_urls( [ $url ] );
+	}
+
+	/**
+	 * Purge a bounded set of Cloudflare URLs.
+	 *
+	 * @param array<int, string> $urls URLs to purge.
+	 *
+	 * @return bool
+	 */
+	private function purge_cloudflare_urls( $urls ) {
 		$enabled = Helpers::get_option( 'enable_cloudflare_cache_sync', 'perform_settings', false );
 		if ( empty( $enabled ) ) {
-			return;
+			return true;
 		}
 
 		$zone_id = trim( (string) Helpers::get_option( 'cloudflare_zone_id', 'perform_settings', '' ) );
 		$token   = trim( (string) Helpers::get_option( 'cloudflare_api_token', 'perform_settings', '' ) );
 		if ( '' === $zone_id || '' === $token ) {
-			return;
+			return false;
 		}
 
-		wp_remote_post(
+		$urls = array_values( array_unique( array_filter( array_map( 'esc_url_raw', (array) $urls ) ) ) );
+		if ( empty( $urls ) ) {
+			return true;
+		}
+
+		$response = wp_remote_post(
 			'https://api.cloudflare.com/client/v4/zones/' . rawurlencode( $zone_id ) . '/purge_cache',
 			[
 				'timeout' => 10,
@@ -797,9 +1032,11 @@ class PageCache implements ModuleInterface {
 					'Authorization' => 'Bearer ' . $token,
 					'Content-Type'  => 'application/json',
 				],
-				'body'    => wp_json_encode( [ 'files' => [ esc_url_raw( $url ) ] ] ),
+				'body'    => wp_json_encode( [ 'files' => $urls ] ),
 			]
 		);
+
+		return ! is_wp_error( $response ) && ( empty( $response['response']['code'] ) || 300 > (int) $response['response']['code'] );
 	}
 
 	/**
@@ -1348,8 +1585,10 @@ class PageCache implements ModuleInterface {
 	 * @return void
 	 */
 	private function ensure_cache_dir() {
-		if ( ! is_dir( $this->cache_dir ) ) {
-			wp_mkdir_p( $this->cache_dir );
+		$generation = 0 < $this->request_generation ? $this->request_generation : $this->get_cache_generation();
+		$directory  = $this->get_generation_dir( $generation );
+		if ( ! is_dir( $directory ) ) {
+			wp_mkdir_p( $directory );
 		}
 	}
 
@@ -1389,7 +1628,8 @@ class PageCache implements ModuleInterface {
 	 * @return string
 	 */
 	private function get_body_file_path( $key ) {
-		return $this->cache_dir . $key . '.html';
+		$generation = 0 < $this->request_generation ? $this->request_generation : $this->get_cache_generation();
+		return $this->get_generation_dir( $generation ) . $key . '.html';
 	}
 
 	/**
@@ -1400,7 +1640,126 @@ class PageCache implements ModuleInterface {
 	 * @return string
 	 */
 	private function get_meta_file_path( $key ) {
-		return $this->cache_dir . $key . '.meta.json';
+		$generation = 0 < $this->request_generation ? $this->request_generation : $this->get_cache_generation();
+		return $this->get_generation_dir( $generation ) . $key . '.meta.json';
+	}
+
+	/** Return the current site's cache generation option name. */
+	private function get_generation_option_name(): string {
+		return 'perform_cache_generation_' . $this->get_blog_id();
+	}
+
+	/** Get the current cache generation, initializing legacy sites at one. */
+	private function get_cache_generation(): int {
+		$generation = (int) get_option( $this->get_generation_option_name(), 1 );
+		return max( 1, $generation );
+	}
+
+	/** Get a multisite-isolated generation directory. */
+	private function get_generation_dir( int $generation ): string {
+		return $this->cache_dir . 'site-' . $this->get_blog_id() . '/generation-' . max( 1, (int) $generation ) . '/';
+	}
+
+	/** Get the current site ID without making a network-wide assumption. */
+	private function get_blog_id(): int {
+		return function_exists( 'get_current_blog_id' ) ? max( 1, (int) get_current_blog_id() ) : 1;
+	}
+
+	/** Whether frontend cache reads and writes are enabled. */
+	private function page_cache_enabled(): bool {
+		return ! empty( Helpers::get_option( 'enable_page_cache', 'perform_settings', false ) );
+	}
+
+	/** Schedule bounded cleanup of retired local generations. */
+	private function schedule_cleanup(): void {
+		if ( ! wp_next_scheduled( 'perform_cache_cleanup_event' ) ) {
+			wp_schedule_single_event( time() + 10, 'perform_cache_cleanup_event' );
+		}
+	}
+
+	/** Delete a bounded number of files from retired generations. */
+	public function cleanup_obsolete_generations(): void {
+		$site_dir = $this->cache_dir . 'site-' . $this->get_blog_id() . '/';
+		if ( ! is_dir( $site_dir ) ) {
+			return;
+		}
+
+		$current   = $this->get_generation_dir( $this->get_cache_generation() );
+		$remaining = max( 1, (int) $this->cleanup_batch_size );
+		$has_more  = false;
+		$dirs      = glob( $site_dir . 'generation-*', GLOB_ONLYDIR );
+		foreach ( is_array( $dirs ) ? $dirs : [] as $dir ) {
+			if ( trailingslashit( $dir ) === $current ) {
+				continue;
+			}
+			$files = glob( trailingslashit( $dir ) . '*' );
+			foreach ( is_array( $files ) ? $files : [] as $file ) {
+				if ( $remaining <= 0 ) {
+					$has_more = true;
+					break 2;
+				}
+				if ( is_file( $file ) ) {
+					wp_delete_file( $file );
+					--$remaining;
+				}
+			}
+			if ( is_dir( $dir ) && empty( glob( trailingslashit( $dir ) . '*' ) ) ) {
+				rmdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+			}
+		}
+
+		if ( $has_more ) {
+			wp_schedule_single_event( time() + 30, 'perform_cache_cleanup_event' );
+		}
+	}
+
+	/** Store URLs that may need a bounded Cloudflare purge after a global rotation. */
+	private function track_cached_url( string $url ): void {
+		$key  = 'perform_cache_urls_' . $this->get_blog_id();
+		$urls = get_option( $key, [] );
+		$urls = is_array( $urls ) ? $urls : [];
+		$urls[] = esc_url_raw( $url );
+		update_option( $key, array_values( array_unique( array_filter( $urls ) ) ), false );
+	}
+
+	/** Queue tracked URLs instead of using Cloudflare purge_everything. */
+	private function queue_cloudflare_tracked_urls(): void {
+		if ( empty( Helpers::get_option( 'enable_cloudflare_cache_sync', 'perform_settings', false ) ) ) {
+			return;
+		}
+		$urls = get_option( 'perform_cache_urls_' . $this->get_blog_id(), [] );
+		if ( ! is_array( $urls ) || empty( $urls ) ) {
+			return;
+		}
+		update_option( 'perform_cache_cloudflare_queue_' . $this->get_blog_id(), array_values( array_unique( $urls ) ), false );
+		if ( ! wp_next_scheduled( 'perform_cache_cloudflare_purge_event' ) ) {
+			wp_schedule_single_event( time() + 10, 'perform_cache_cloudflare_purge_event' );
+		}
+	}
+
+	/** Purge a bounded batch of tracked URLs from Cloudflare, with retries. */
+	public function run_cloudflare_purge_batch(): void {
+		$blog_id    = $this->get_blog_id();
+		$key        = 'perform_cache_cloudflare_queue_' . $blog_id;
+		$retry_key  = 'perform_cache_cloudflare_retries_' . $blog_id;
+		$queue      = get_option( $key, [] );
+		if ( ! is_array( $queue ) || empty( $queue ) ) {
+			return;
+		}
+		$batch = array_splice( $queue, 0, max( 1, (int) $this->cloudflare_batch_size ) );
+		if ( ! $this->purge_cloudflare_urls( $batch ) ) {
+			$attempts = (int) get_option( $retry_key, 0 ) + 1;
+			if ( $attempts < max( 1, (int) $this->cloudflare_max_retries ) ) {
+				$queue = array_merge( $batch, $queue );
+			}
+			update_option( $retry_key, $attempts, false );
+		} else {
+			update_option( $retry_key, 0, false );
+		}
+		update_option( $key, array_values( $queue ), false );
+		if ( ! empty( $queue ) ) {
+			wp_schedule_single_event( time() + 60, 'perform_cache_cloudflare_purge_event' );
+		}
 	}
 
 	/**

--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -1930,6 +1930,27 @@ class PageCache implements ModuleInterface {
 				'failed'      => false,
 			];
 		}
+		if ( empty( $chunks ) ) {
+			$records[] = [
+				'source'      => 'metadata',
+				'generation'  => $generation,
+				'cursor'      => 0,
+				'zone_id'     => (string) $settings['cloudflare_zone_id'],
+				'fingerprint' => $this->cloudflare_settings_key( $settings ),
+				'attempts'    => 0,
+				'failed'      => false,
+			];
+		}
+		if ( 1 === $generation ) {
+			$records[] = [
+				'source'      => 'legacy_metadata',
+				'cursor'      => 0,
+				'zone_id'     => (string) $settings['cloudflare_zone_id'],
+				'fingerprint' => $this->cloudflare_settings_key( $settings ),
+				'attempts'    => 0,
+				'failed'      => false,
+			];
+		}
 		$legacy = get_option( 'perform_cache_urls_' . $blog_id, [] );
 		if ( is_array( $legacy ) && ! empty( $legacy ) ) {
 			$records[] = [
@@ -1969,7 +1990,7 @@ class PageCache implements ModuleInterface {
 			$batch = array_slice( $urls, (int) ( $record['offset'] ?? 0 ), max( 1, (int) $this->cloudflare_batch_size ) );
 			if ( empty( $batch ) ) {
 				$this->retire_cloudflare_record( $record );
-				$record['urls'] = [];
+				$record['done'] = true;
 				continue;
 			}
 			$settings = Helpers::get_settings();

--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -60,9 +60,6 @@ class PageCache implements ModuleInterface {
 	 */
 	private $cloudflare_max_retries = 3;
 
-	/** @var int */
-	private $manifest_chunk_size = 100;
-
 	/** @var bool */
 	private $site_purge_requested = false;
 
@@ -200,6 +197,7 @@ class PageCache implements ModuleInterface {
 
 		add_action( 'admin_menu', [ $this, 'register_observability_page' ] );
 		add_action( 'admin_post_perform_purge_page_cache', [ $this, 'handle_manual_purge' ] );
+		add_action( 'admin_post_perform_acknowledge_cloudflare_residual', [ $this, 'handle_cloudflare_residual_acknowledgement' ] );
 	}
 
 	/**
@@ -388,8 +386,6 @@ class PageCache implements ModuleInterface {
 			} elseif ( $this->request_generation !== $this->get_cache_generation() ) {
 				wp_delete_file( $this->get_body_file_path( $this->current_cache_key ) );
 				wp_delete_file( $this->get_meta_file_path( $this->current_cache_key ) );
-			} else {
-				$this->track_cached_url( $this->current_url );
 			}
 		} finally {
 			$this->release_lock();
@@ -772,6 +768,8 @@ class PageCache implements ModuleInterface {
 		$top_misses     = $stats['top_misses'] ?? [];
 		$bypass_reasons = $stats['bypass_reasons'] ?? [];
 		$slow_uncached  = $stats['slow_uncached'] ?? [];
+		$cloudflare     = $this->get_cloudflare_queue_status();
+		$residual       = (int) get_option( 'perform_cache_cloudflare_credential_residual_' . $this->get_blog_id(), 0 );
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Perform Cache Observability', 'perform' ); ?></h1>
@@ -792,6 +790,17 @@ class PageCache implements ModuleInterface {
 				<?php wp_nonce_field( 'perform_purge_page_cache' ); ?>
 				<?php submit_button( esc_html__( 'Purge Site Page Cache', 'perform' ), 'secondary', 'submit', false ); ?>
 			</form>
+			<?php if ( $cloudflare['pending'] || $cloudflare['failed'] || $residual ) : ?>
+				<div class="notice notice-<?php echo $cloudflare['failed'] || $residual ? 'error' : 'warning'; ?>"><p><?php echo esc_html( sprintf( __( 'Cloudflare cleanup: %1$d pending, %2$d failed, %3$d old-credential residual.', 'perform' ), $cloudflare['pending'], $cloudflare['failed'], $residual ) ); ?></p></div>
+			<?php endif; ?>
+			<?php if ( $residual ) : ?>
+				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+					<input type="hidden" name="action" value="perform_acknowledge_cloudflare_residual" />
+					<?php wp_nonce_field( 'perform_acknowledge_cloudflare_residual' ); ?>
+					<p><?php esc_html_e( 'After purging the old Cloudflare zone externally, acknowledge the residual to retire the old token-free queue and allow local cache cleanup.', 'perform' ); ?></p>
+					<?php submit_button( esc_html__( 'Acknowledge External Cloudflare Purge', 'perform' ), 'secondary', 'submit', false ); ?>
+				</form>
+			<?php endif; ?>
 
 			<table class="widefat striped" style="max-width:900px;">
 				<tbody>
@@ -997,6 +1006,28 @@ class PageCache implements ModuleInterface {
 		exit;
 	}
 
+	/** Retire explicitly acknowledged old-credential Cloudflare work. */
+	public function handle_cloudflare_residual_acknowledgement(): void {
+		if ( ! current_user_can( 'manage_options' ) || ! check_admin_referer( 'perform_acknowledge_cloudflare_residual' ) ) {
+			wp_die( esc_html__( 'You are not allowed to acknowledge Cloudflare cleanup.', 'perform' ) );
+		}
+		$key     = 'perform_cache_cloudflare_queue_' . $this->get_blog_id();
+		$records = $this->get_cloudflare_queue_records( get_option( $key, [] ) );
+		$records = array_values(
+			array_filter(
+				$records,
+				static function ( $record ) {
+					return empty( $record['failed'] );
+				}
+			)
+		);
+		update_option( $key, $records, false );
+		delete_option( 'perform_cache_cloudflare_credential_residual_' . $this->get_blog_id() );
+		$this->schedule_cleanup();
+		wp_safe_redirect( admin_url( 'options-general.php?page=perform_cache_observability' ) );
+		exit;
+	}
+
 	/** Confirm the administrator capability and action nonce before purging. */
 	private function is_manual_purge_authorized(): bool {
 		return current_user_can( 'manage_options' ) && (bool) check_admin_referer( 'perform_purge_page_cache' );
@@ -1141,7 +1172,9 @@ class PageCache implements ModuleInterface {
 	 * @return void
 	 */
 	private function purge_cloudflare_url( $url ) {
-		$this->purge_cloudflare_urls( [ $url ] );
+		if ( ! $this->purge_cloudflare_urls( [ $url ] ) ) {
+			$this->queue_cloudflare_inline_urls( [ $url ] );
+		}
 	}
 
 	/**
@@ -1842,37 +1875,20 @@ class PageCache implements ModuleInterface {
 			$this->schedule_cleanup();
 			return;
 		}
-		$legacy_html = glob( $this->cache_dir . '*.html' );
-		$legacy_meta = glob( $this->cache_dir . '*.meta.json' );
-		$legacy      = array_merge( is_array( $legacy_html ) ? $legacy_html : [], is_array( $legacy_meta ) ? $legacy_meta : [] );
-		foreach ( $legacy as $file ) {
-			if ( $remaining <= 0 ) {
-				$has_more = true;
-				break;
-			}
-			wp_delete_file( $file );
-			--$remaining;
-		}
-
-		$current = $this->get_generation_dir( $this->get_cache_generation() );
-		$dirs    = is_dir( $site_dir ) ? glob( $site_dir . 'generation-*', GLOB_ONLYDIR ) : [];
-		foreach ( is_array( $dirs ) ? $dirs : [] as $dir ) {
-			if ( trailingslashit( $dir ) === $current ) {
-				continue;
-			}
-			$files = glob( trailingslashit( $dir ) . '*' );
-			foreach ( is_array( $files ) ? $files : [] as $file ) {
-				if ( $remaining <= 0 ) {
+		$has_more = $this->cleanup_directory_files( $this->cache_dir, $remaining, true );
+		$current  = $this->get_generation_dir( $this->get_cache_generation() );
+		if ( $remaining > 0 && is_dir( $site_dir ) ) {
+			foreach ( new \DirectoryIterator( $site_dir ) as $directory ) {
+				if ( $directory->isDot() || ! $directory->isDir() || 0 !== strpos( $directory->getFilename(), 'generation-' ) || trailingslashit( $directory->getPathname() ) === $current ) {
+					continue;
+				}
+				if ( $this->cleanup_directory_files( $directory->getPathname(), $remaining, false ) ) {
 					$has_more = true;
-					break 2;
+					break;
 				}
-				if ( is_file( $file ) ) {
-					wp_delete_file( $file );
-					--$remaining;
+				if ( ! $this->directory_has_files( $directory->getPathname() ) ) {
+					rmdir( $directory->getPathname() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
 				}
-			}
-			if ( is_dir( $dir ) && empty( glob( trailingslashit( $dir ) . '*' ) ) ) {
-				rmdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
 			}
 		}
 
@@ -1881,39 +1897,40 @@ class PageCache implements ModuleInterface {
 		}
 	}
 
-	/** Store URLs that may need a bounded Cloudflare purge after a global rotation. */
-	private function track_cached_url( string $url ): void {
-		$generation = $this->get_cache_generation();
-		$state_key  = $this->get_manifest_state_option( $generation );
-		$state      = get_option(
-			$state_key,
-			[
-				'chunk' => 0,
-				'count' => 0,
-			]
-		);
-		$state      = is_array( $state ) ? $state : [
-			'chunk' => 0,
-			'count' => 0,
-		];
-		if ( (int) $state['count'] >= $this->get_manifest_chunk_size() ) {
-			++$state['chunk'];
-			$state['count'] = 0;
+	private function cleanup_directory_files( string $directory, int &$remaining, bool $legacy_root ): bool {
+		if ( ! is_dir( $directory ) ) {
+			return false;
 		}
-		$chunk_key = $this->get_manifest_chunk_option( $generation, (int) $state['chunk'] );
-		$urls      = get_option( $chunk_key, [] );
-		$urls      = is_array( $urls ) ? $urls : [];
-		$url       = esc_url_raw( $url );
-		if ( in_array( $url, $urls, true ) ) {
-			return;
+		foreach ( new \DirectoryIterator( $directory ) as $file ) {
+			if ( $file->isDot() || ! $file->isFile() ) {
+				continue;
+			}
+			$name = $file->getFilename();
+			if ( $legacy_root && ! preg_match( '/^[a-f0-9]{32}(?:\.html|\.meta\.json)$/', $name ) ) {
+				continue;
+			}
+			if ( $remaining <= 0 ) {
+				return true;
+			}
+			wp_delete_file( $file->getPathname() );
+			--$remaining;
 		}
-		$urls[] = $url;
-		update_option( $chunk_key, $urls, false );
-		++$state['count'];
-		update_option( $state_key, $state, false );
+		return $remaining <= 0 && $this->directory_has_files( $directory, $legacy_root );
 	}
 
-	/** Queue tracked URLs instead of using Cloudflare purge_everything. */
+	private function directory_has_files( string $directory, bool $legacy_root = false ): bool {
+		foreach ( new \DirectoryIterator( $directory ) as $file ) {
+			if ( $file->isDot() || ! $file->isFile() ) {
+				continue;
+			}
+			if ( ! $legacy_root || preg_match( '/^[a-f0-9]{32}(?:\.html|\.meta\.json)$/', $file->getFilename() ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/** Queue metadata inventory instead of using Cloudflare purge_everything. */
 	/** @param array<string,mixed>|null $settings */
 	private function queue_cloudflare_tracked_urls( $settings = null, ?int $generation = null ): void {
 		$settings = is_array( $settings ) ? $settings : Helpers::get_settings();
@@ -1924,54 +1941,13 @@ class PageCache implements ModuleInterface {
 		$generation = null === $generation ? $this->get_cache_generation() : $generation;
 		$key        = 'perform_cache_cloudflare_queue_' . $blog_id;
 		$records    = $this->get_cloudflare_queue_records( get_option( $key, [] ) );
-		$state      = get_option( $this->get_manifest_state_option( $generation ), [] );
-		$chunks     = is_array( $state ) && isset( $state['chunk'] ) ? range( 0, (int) $state['chunk'] ) : [];
-		foreach ( $chunks as $chunk ) {
-			if ( $this->has_cloudflare_source_record( $records, 'manifest', $generation, (int) $chunk ) ) {
-				continue;
-			}
-			$records[] = [
-				'source'      => 'manifest',
-				'generation'  => $generation,
-				'chunk'       => $chunk,
-				'offset'      => 0,
-				'zone_id'     => (string) $settings['cloudflare_zone_id'],
-				'fingerprint' => $this->cloudflare_settings_key( $settings ),
-				'attempts'    => 0,
-				'failed'      => false,
-			];
-		}
-		if ( empty( $chunks ) && ! $this->has_cloudflare_source_record( $records, 'metadata', $generation ) ) {
-			$records[] = [
-				'source'      => 'metadata',
-				'generation'  => $generation,
-				'cursor'      => 0,
-				'zone_id'     => (string) $settings['cloudflare_zone_id'],
-				'fingerprint' => $this->cloudflare_settings_key( $settings ),
-				'attempts'    => 0,
-				'failed'      => false,
-			];
-		}
-		if ( 1 === $generation && ! $this->has_cloudflare_source_record( $records, 'legacy_metadata' ) ) {
-			$records[] = [
-				'source'      => 'legacy_metadata',
-				'cursor'      => 0,
-				'zone_id'     => (string) $settings['cloudflare_zone_id'],
-				'fingerprint' => $this->cloudflare_settings_key( $settings ),
-				'attempts'    => 0,
-				'failed'      => false,
-			];
+		$records    = $this->queue_cloudflare_source( $records, 'metadata', $generation, $settings );
+		if ( $this->has_legacy_metadata_files() ) {
+			$records = $this->queue_cloudflare_source( $records, 'legacy_metadata', null, $settings );
 		}
 		$legacy = get_option( 'perform_cache_urls_' . $blog_id, [] );
-		if ( is_array( $legacy ) && ! empty( $legacy ) && ! $this->has_cloudflare_source_record( $records, 'legacy_option' ) ) {
-			$records[] = [
-				'source'      => 'legacy_option',
-				'offset'      => 0,
-				'zone_id'     => (string) $settings['cloudflare_zone_id'],
-				'fingerprint' => $this->cloudflare_settings_key( $settings ),
-				'attempts'    => 0,
-				'failed'      => false,
-			];
+		if ( is_array( $legacy ) && ! empty( $legacy ) ) {
+			$records = $this->queue_cloudflare_source( $records, 'legacy_option', null, $settings );
 		}
 		update_option( $key, $records, false );
 		if ( ! wp_next_scheduled( 'perform_cache_cloudflare_purge_event' ) ) {
@@ -1979,28 +1955,82 @@ class PageCache implements ModuleInterface {
 		}
 	}
 
-	private function get_manifest_state_option( int $generation ): string {
-		return 'perform_cache_manifest_state_' . $this->get_blog_id() . '_' . $generation; }
-	private function get_manifest_chunk_option( int $generation, int $chunk ): string {
-		return 'perform_cache_manifest_' . $this->get_blog_id() . '_' . $generation . '_' . $chunk; }
-	private function get_manifest_chunk_size(): int {
-		return max( 1, (int) apply_filters( 'perform_cache_manifest_chunk_size', $this->manifest_chunk_size ) ); }
-
-	/** @param array<int, array<string, mixed>> $records */
-	private function has_cloudflare_source_record( array $records, string $source, ?int $generation = null, ?int $chunk = null ): bool {
-		foreach ( $records as $record ) {
-			if ( ( $record['source'] ?? '' ) !== $source || ! empty( $record['done'] ) ) {
-				continue;
+	private function has_legacy_metadata_files(): bool {
+		if ( ! is_dir( $this->cache_dir ) ) {
+			return false;
+		}
+		foreach ( new \DirectoryIterator( $this->cache_dir ) as $file ) {
+			if ( ! $file->isDot() && $file->isFile() && preg_match( '/^[a-f0-9]{32}\.meta\.json$/', $file->getFilename() ) ) {
+				return true;
 			}
-			if ( null !== $generation && (int) ( $record['generation'] ?? 0 ) !== (int) $generation ) {
-				continue;
-			}
-			if ( null !== $chunk && (int) ( $record['chunk'] ?? -1 ) !== (int) $chunk ) {
-				continue;
-			}
-			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * @param array<int, array<string, mixed>> $records
+	 * @param array<string, mixed> $settings
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function queue_cloudflare_source( array $records, string $source, ?int $generation, array $settings ): array {
+		$fingerprint = $this->cloudflare_settings_key( $settings );
+		foreach ( $records as &$record ) {
+			if ( ! in_array( $source, [ $record['source'] ?? '' ], true ) || ! in_array( (int) $generation, [ (int) ( $record['generation'] ?? 0 ) ], true ) ) {
+				continue;
+			}
+			if ( ( $record['fingerprint'] ?? '' ) === $fingerprint && ! empty( $record['failed'] ) ) {
+				$record['failed']   = false;
+				$record['attempts'] = 0;
+			}
+			unset( $record );
+			return $records;
+		}
+		unset( $record );
+		$records[] = [
+			'source'      => $source,
+			'generation'  => $generation,
+			'cursor'      => 0,
+			'zone_id'     => (string) $settings['cloudflare_zone_id'],
+			'fingerprint' => $fingerprint,
+			'attempts'    => 0,
+			'failed'      => false,
+		];
+		return $records;
+	}
+
+	/** @param array<int, string> $urls */
+	private function queue_cloudflare_inline_urls( array $urls ): void {
+		$settings = Helpers::get_settings();
+		if ( ! is_array( $settings ) || empty( $settings['enable_cloudflare_cache_sync'] ) ) {
+			return;
+		}
+		$urls = array_values( array_unique( array_filter( array_map( 'esc_url_raw', $urls ) ) ) );
+		if ( empty( $urls ) ) {
+			return;
+		}
+		$key     = 'perform_cache_cloudflare_queue_' . $this->get_blog_id();
+		$records = $this->get_cloudflare_queue_records( get_option( $key, [] ) );
+		foreach ( $records as &$record ) {
+			if ( empty( $record['source'] ) && $this->cloudflare_settings_key( $settings ) === ( $record['fingerprint'] ?? '' ) ) {
+				$record['urls']     = array_values( array_unique( array_merge( (array) ( $record['urls'] ?? [] ), $urls ) ) );
+				$record['failed']   = false;
+				$record['attempts'] = 0;
+				unset( $record );
+				update_option( $key, $records, false );
+				wp_schedule_single_event( time() + 10, 'perform_cache_cloudflare_purge_event' );
+				return;
+			}
+		}
+		unset( $record );
+		$records[] = [
+			'urls'        => $urls,
+			'zone_id'     => (string) $settings['cloudflare_zone_id'],
+			'fingerprint' => $this->cloudflare_settings_key( $settings ),
+			'attempts'    => 0,
+			'failed'      => false,
+		];
+		update_option( $key, $records, false );
+		wp_schedule_single_event( time() + 10, 'perform_cache_cloudflare_purge_event' );
 	}
 
 	/** Purge a bounded batch of tracked URLs from Cloudflare, with retries. */
@@ -2014,8 +2044,8 @@ class PageCache implements ModuleInterface {
 			if ( ! empty( $record['failed'] ) ) {
 				continue;
 			}
-			$urls  = $this->get_cloudflare_record_urls( $record );
-			$batch = array_slice( $urls, (int) ( $record['offset'] ?? 0 ), max( 1, (int) $this->cloudflare_batch_size ) );
+			$work  = $this->get_cloudflare_record_work( $record );
+			$batch = $work['urls'];
 			if ( empty( $batch ) ) {
 				$this->retire_cloudflare_record( $record );
 				$record['done'] = true;
@@ -2024,10 +2054,13 @@ class PageCache implements ModuleInterface {
 			$settings = Helpers::get_settings();
 			if ( ! is_array( $settings ) || $record['fingerprint'] !== $this->cloudflare_settings_key( $settings ) ) {
 				$record['failed'] = true;
-				update_option( 'perform_cache_cloudflare_credential_residual_' . $this->get_blog_id(), $this->get_cloudflare_residual_count( $record, $urls ), false );
+				update_option( 'perform_cache_cloudflare_credential_residual_' . $this->get_blog_id(), $this->get_cloudflare_residual_count( $record, $batch ), false );
 			} elseif ( $this->purge_cloudflare_urls( $batch, $settings ) ) {
-				if ( isset( $record['source'] ) && in_array( $record['source'], [ 'metadata', 'legacy_metadata' ], true ) ) {
-					// The inventory cursor advanced while building this batch.
+				if ( isset( $work['cursor'] ) ) {
+					$record['cursor'] = $work['cursor'];
+					if ( ! empty( $work['complete'] ) ) {
+						$record['inventory_complete'] = true;
+					}
 				} elseif ( isset( $record['source'] ) ) {
 					$record['offset'] = (int) ( $record['offset'] ?? 0 ) + count( $batch );
 				} else {
@@ -2062,32 +2095,32 @@ class PageCache implements ModuleInterface {
 
 	/**
 	 * @param array<string, mixed> $record Record.
-	 * @return array<int, string>
+	 * @return array{urls: array<int, string>, cursor?: int, complete?: bool}
 	 */
-	private function get_cloudflare_record_urls( array &$record ): array {
-		if ( isset( $record['source'] ) && 'manifest' === $record['source'] ) {
-			$urls = get_option( $this->get_manifest_chunk_option( (int) $record['generation'], (int) $record['chunk'] ), [] );
-			return is_array( $urls ) ? $urls : [];
-		}
+	private function get_cloudflare_record_work( array $record ): array {
 		if ( isset( $record['source'] ) && 'legacy_option' === $record['source'] ) {
 			$urls = get_option( 'perform_cache_urls_' . $this->get_blog_id(), [] );
-			return is_array( $urls ) ? $urls : [];
+			return [ 'urls' => is_array( $urls ) ? array_slice( $urls, (int) ( $record['offset'] ?? 0 ), max( 1, (int) $this->cloudflare_batch_size ) ) : [] ];
 		}
 		if ( isset( $record['source'] ) && in_array( $record['source'], [ 'metadata', 'legacy_metadata' ], true ) ) {
 			return $this->get_cloudflare_metadata_urls( $record );
 		}
-		return isset( $record['urls'] ) && is_array( $record['urls'] ) ? $record['urls'] : [];
+		$urls = isset( $record['urls'] ) && is_array( $record['urls'] ) ? $record['urls'] : [];
+		return [ 'urls' => array_slice( $urls, 0, max( 1, (int) $this->cloudflare_batch_size ) ) ];
 	}
 
 	/**
 	 * @param array<string, mixed> $record
-	 * @return array<int, string>
+	 * @return array{urls: array<int, string>, cursor: int, complete: bool}
 	 */
-	private function get_cloudflare_metadata_urls( array &$record ): array {
+	private function get_cloudflare_metadata_urls( array $record ): array {
 		$directory = 'metadata' === $record['source'] ? $this->get_generation_dir( (int) $record['generation'] ) : $this->cache_dir;
 		if ( ! is_dir( $directory ) ) {
-			$record['inventory_complete'] = true;
-			return [];
+			return [
+				'urls'     => [],
+				'cursor'   => (int) ( $record['cursor'] ?? 0 ),
+				'complete' => true,
+			];
 		}
 
 		$cursor = max( 0, (int) ( $record['cursor'] ?? 0 ) );
@@ -2109,14 +2142,19 @@ class PageCache implements ModuleInterface {
 			if ( '' !== $url && $this->is_site_url( $url ) ) {
 				$urls[] = $url;
 			}
-			$record['cursor'] = $index;
 			if ( count( $urls ) >= $limit ) {
-				return array_values( array_unique( $urls ) );
+				return [
+					'urls'     => array_values( array_unique( $urls ) ),
+					'cursor'   => $index,
+					'complete' => false,
+				];
 			}
 		}
-		$record['cursor']             = $index;
-		$record['inventory_complete'] = true;
-		return array_values( array_unique( $urls ) );
+		return [
+			'urls'     => array_values( array_unique( $urls ) ),
+			'cursor'   => $index,
+			'complete' => true,
+		];
 	}
 
 	/**
@@ -2132,13 +2170,7 @@ class PageCache implements ModuleInterface {
 
 	/** @param array<string,mixed> $record */
 	private function retire_cloudflare_record( array $record ): void {
-		if ( isset( $record['source'] ) && 'manifest' === $record['source'] ) {
-			delete_option( $this->get_manifest_chunk_option( (int) $record['generation'], (int) $record['chunk'] ) );
-			$state = get_option( $this->get_manifest_state_option( (int) $record['generation'] ), [] );
-			if ( is_array( $state ) && (int) $record['chunk'] >= (int) ( $state['chunk'] ?? 0 ) ) {
-				delete_option( $this->get_manifest_state_option( (int) $record['generation'] ) );
-			}
-		} elseif ( isset( $record['source'] ) && 'legacy_option' === $record['source'] ) {
+		if ( isset( $record['source'] ) && 'legacy_option' === $record['source'] ) {
 			delete_option( 'perform_cache_urls_' . $this->get_blog_id() );
 		}
 	}

--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -200,6 +200,7 @@ class PageCache implements ModuleInterface {
 
 		add_action( 'admin_menu', [ $this, 'register_observability_page' ] );
 		add_action( 'admin_post_perform_purge_page_cache', [ $this, 'handle_manual_purge' ] );
+		add_action( 'admin_post_perform_retry_cloudflare_cleanup', [ $this, 'handle_cloudflare_cleanup_retry' ] );
 		add_action( 'admin_post_perform_acknowledge_cloudflare_residual', [ $this, 'handle_cloudflare_residual_acknowledgement' ] );
 	}
 
@@ -792,8 +793,15 @@ class PageCache implements ModuleInterface {
 				<?php wp_nonce_field( 'perform_purge_page_cache' ); ?>
 				<?php submit_button( esc_html__( 'Purge Site Page Cache', 'perform' ), 'secondary', 'submit', false ); ?>
 			</form>
-			<?php if ( $cloudflare['pending'] || $cloudflare['failed'] || $residual ) : ?>
-				<div class="notice notice-<?php echo $cloudflare['failed'] || $residual ? 'error' : 'warning'; ?>"><p><?php echo esc_html( sprintf( __( 'Cloudflare cleanup: %1$d pending, %2$d failed, %3$d old-credential residual.', 'perform' ), $cloudflare['pending'], $cloudflare['failed'], $residual ) ); ?></p></div>
+			<?php if ( $cloudflare['pending'] || $cloudflare['retryable_failed'] || $cloudflare['credential_residuals'] || $residual ) : ?>
+				<div class="notice notice-<?php echo $cloudflare['retryable_failed'] || $cloudflare['credential_residuals'] || $residual ? 'error' : 'warning'; ?>"><p><?php echo esc_html( sprintf( __( 'Cloudflare cleanup: %1$d pending, %2$d retryable failures, %3$d old-credential residuals.', 'perform' ), $cloudflare['pending'], $cloudflare['retryable_failed'], max( $cloudflare['credential_residuals'], $residual ) ) ); ?></p></div>
+			<?php endif; ?>
+			<?php if ( $cloudflare['retryable_failed'] ) : ?>
+				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+					<input type="hidden" name="action" value="perform_retry_cloudflare_cleanup" />
+					<?php wp_nonce_field( 'perform_retry_cloudflare_cleanup' ); ?>
+					<?php submit_button( esc_html__( 'Retry Failed Cloudflare Cleanup', 'perform' ), 'secondary', 'submit', false ); ?>
+				</form>
 			<?php endif; ?>
 			<?php if ( $residual ) : ?>
 				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
@@ -1019,6 +1027,16 @@ class PageCache implements ModuleInterface {
 		exit;
 	}
 
+	/** Retry failed cleanup records that still match the current credentials. */
+	public function handle_cloudflare_cleanup_retry(): void {
+		if ( ! $this->is_cloudflare_retry_authorized() ) {
+			wp_die( esc_html__( 'You are not allowed to retry Cloudflare cleanup.', 'perform' ) );
+		}
+		$this->retry_current_cloudflare_failures();
+		wp_safe_redirect( admin_url( 'options-general.php?page=perform_cache_observability' ) );
+		exit;
+	}
+
 	/** Retire only records that cannot use the current credentials. */
 	private function acknowledge_cloudflare_credential_residuals(): void {
 		$key     = 'perform_cache_cloudflare_queue_' . $this->get_blog_id();
@@ -1033,6 +1051,39 @@ class PageCache implements ModuleInterface {
 		);
 		update_option( $key, $records, false );
 		delete_option( 'perform_cache_cloudflare_credential_residual_' . $this->get_blog_id() );
+	}
+
+	/** Reset only retryable failures that match the currently configured edge credentials. */
+	private function retry_current_cloudflare_failures(): int {
+		$settings = Helpers::get_settings();
+		if ( ! is_array( $settings ) ) {
+			return 0;
+		}
+		$key         = 'perform_cache_cloudflare_queue_' . $this->get_blog_id();
+		$records     = $this->get_cloudflare_queue_records( get_option( $key, [] ) );
+		$fingerprint = $this->cloudflare_settings_key( $settings );
+		$retries     = 0;
+		foreach ( $records as &$record ) {
+			if ( empty( $record['failed'] ) || ! empty( $record['credential_residual'] ) || ( $record['fingerprint'] ?? '' ) !== $fingerprint ) {
+				continue;
+			}
+			$record['failed']   = false;
+			$record['attempts'] = 0;
+			++$retries;
+		}
+		unset( $record );
+		if ( $retries ) {
+			update_option( $key, $records, false );
+			if ( ! wp_next_scheduled( 'perform_cache_cloudflare_purge_event' ) ) {
+				wp_schedule_single_event( time() + 10, 'perform_cache_cloudflare_purge_event' );
+			}
+		}
+		return $retries;
+	}
+
+	/** Confirm the administrator capability and nonce before retrying current Cloudflare cleanup. */
+	private function is_cloudflare_retry_authorized(): bool {
+		return current_user_can( 'manage_options' ) && (bool) check_admin_referer( 'perform_retry_cloudflare_cleanup' );
 	}
 
 	/** Confirm the administrator capability and action nonce before purging. */
@@ -2258,14 +2309,23 @@ class PageCache implements ModuleInterface {
 
 	/** @return array<string, int> */
 	private function get_cloudflare_queue_status() {
-		$records = $this->get_cloudflare_queue_records( get_option( 'perform_cache_cloudflare_queue_' . $this->get_blog_id(), [] ) );
-		$status  = [
-			'pending' => 0,
-			'failed'  => 0,
+		$records  = $this->get_cloudflare_queue_records( get_option( 'perform_cache_cloudflare_queue_' . $this->get_blog_id(), [] ) );
+		$settings = Helpers::get_settings();
+		$current  = is_array( $settings ) ? $this->cloudflare_settings_key( $settings ) : '';
+		$status   = [
+			'pending'              => 0,
+			'failed'               => 0,
+			'retryable_failed'     => 0,
+			'credential_residuals' => 0,
 		];
 		foreach ( $records as $record ) {
 			if ( ! empty( $record['failed'] ) ) {
 				++$status['failed'];
+				if ( ! empty( $record['credential_residual'] ) ) {
+					++$status['credential_residuals'];
+				} elseif ( ( $record['fingerprint'] ?? '' ) === $current ) {
+					++$status['retryable_failed'];
+				}
 			} else {
 				++$status['pending']; }
 		}

--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -60,6 +60,9 @@ class PageCache implements ModuleInterface {
 	 */
 	private $cloudflare_max_retries = 3;
 
+	/** @var int */
+	private $manifest_chunk_size = 100;
+
 	/** @var bool */
 	private $site_purge_requested = false;
 
@@ -1876,23 +1879,30 @@ class PageCache implements ModuleInterface {
 
 	/** Store URLs that may need a bounded Cloudflare purge after a global rotation. */
 	private function track_cached_url( string $url ): void {
-		$key   = 'perform_cache_urls_' . $this->get_blog_id();
-		$url   = esc_url_raw( $url );
-		$urls  = get_option( $key, [] );
-		$urls  = is_array( $urls ) ? $urls : [];
-		$limit = max( 1, (int) apply_filters( 'perform_cache_tracked_url_limit', 500 ) );
-		if ( in_array( $url, $urls, true ) ) {
-			return;
+		$generation = $this->get_cache_generation();
+		$state_key  = $this->get_manifest_state_option( $generation );
+		$state      = get_option(
+			$state_key,
+			[
+				'chunk' => 0,
+				'count' => 0,
+			]
+		);
+		$state      = is_array( $state ) ? $state : [
+			'chunk' => 0,
+			'count' => 0,
+		];
+		if ( (int) $state['count'] >= $this->get_manifest_chunk_size() ) {
+			++$state['chunk'];
+			$state['count'] = 0;
 		}
-		if ( count( $urls ) >= $limit ) {
-			$overflow_key = 'perform_cache_url_tracking_overflow_' . $this->get_blog_id();
-			if ( ! get_option( $overflow_key, false ) ) {
-				update_option( $overflow_key, true, false );
-			}
-			return;
-		}
-		$urls[] = $url;
-		update_option( $key, $urls, false );
+		$chunk_key = $this->get_manifest_chunk_option( $generation, (int) $state['chunk'] );
+		$urls      = get_option( $chunk_key, [] );
+		$urls      = is_array( $urls ) ? $urls : [];
+		$urls[]    = esc_url_raw( $url );
+		update_option( $chunk_key, $urls, false );
+		++$state['count'];
+		update_option( $state_key, $state, false );
 	}
 
 	/** Queue tracked URLs instead of using Cloudflare purge_everything. */
@@ -1902,29 +1912,29 @@ class PageCache implements ModuleInterface {
 		if ( ! is_array( $settings ) || empty( $settings['enable_cloudflare_cache_sync'] ) ) {
 			return;
 		}
-		$blog_id = $this->get_blog_id();
-		$urls    = get_option( 'perform_cache_urls_' . $blog_id, [] );
-		$urls    = is_array( $urls ) ? $urls : [];
-		$urls    = array_values( array_unique( array_merge( $urls, $this->get_cached_urls_from_metadata( null === $generation ? $this->get_cache_generation() : (int) $generation ) ) ) );
-		if ( empty( $urls ) ) {
-			return;
-		}
-		$key     = 'perform_cache_cloudflare_queue_' . $blog_id;
-		$records = $this->get_cloudflare_queue_records( get_option( $key, [] ) );
-		$found   = false;
-		foreach ( $records as &$record ) {
-			if ( $record['fingerprint'] === $this->cloudflare_settings_key( $settings ) ) {
-				$record['urls']     = array_values( array_unique( array_merge( $record['urls'], $urls ) ) );
-				$record['failed']   = false;
-				$record['attempts'] = 0;
-				$found              = true;
-				break;
-			}
-		}
-		unset( $record );
-		if ( ! $found ) {
+		$blog_id    = $this->get_blog_id();
+		$generation = null === $generation ? $this->get_cache_generation() : $generation;
+		$key        = 'perform_cache_cloudflare_queue_' . $blog_id;
+		$records    = $this->get_cloudflare_queue_records( get_option( $key, [] ) );
+		$state      = get_option( $this->get_manifest_state_option( $generation ), [] );
+		$chunks     = is_array( $state ) ? range( 0, (int) $state['chunk'] ) : [];
+		foreach ( $chunks as $chunk ) {
 			$records[] = [
-				'urls'        => array_values( array_unique( $urls ) ),
+				'source'      => 'manifest',
+				'generation'  => $generation,
+				'chunk'       => $chunk,
+				'offset'      => 0,
+				'zone_id'     => (string) $settings['cloudflare_zone_id'],
+				'fingerprint' => $this->cloudflare_settings_key( $settings ),
+				'attempts'    => 0,
+				'failed'      => false,
+			];
+		}
+		$legacy = get_option( 'perform_cache_urls_' . $blog_id, [] );
+		if ( is_array( $legacy ) && ! empty( $legacy ) ) {
+			$records[] = [
+				'source'      => 'legacy_option',
+				'offset'      => 0,
 				'zone_id'     => (string) $settings['cloudflare_zone_id'],
 				'fingerprint' => $this->cloudflare_settings_key( $settings ),
 				'attempts'    => 0,
@@ -1937,27 +1947,12 @@ class PageCache implements ModuleInterface {
 		}
 	}
 
-	/**
-	 * Discover a bounded local cache inventory for pre-tracking installations.
-	 *
-	 * @return array<int, string>
-	 */
-	private function get_cached_urls_from_metadata( int $generation ) {
-		$limit = max( 1, (int) apply_filters( 'perform_cache_tracked_url_limit', 500 ) );
-		$files = array_merge(
-			is_array( glob( $this->get_generation_dir( $generation ) . '*.meta.json' ) ) ? glob( $this->get_generation_dir( $generation ) . '*.meta.json' ) : [],
-			is_array( glob( $this->cache_dir . '*.meta.json' ) ) ? glob( $this->cache_dir . '*.meta.json' ) : []
-		);
-		$urls  = [];
-		foreach ( array_slice( $files, 0, $limit ) as $file ) {
-			$raw  = file_get_contents( $file );
-			$data = is_string( $raw ) ? json_decode( $raw, true ) : null;
-			if ( is_array( $data ) && ! empty( $data['url'] ) && $this->is_site_url( $data['url'] ) ) {
-				$urls[] = esc_url_raw( $data['url'] );
-			}
-		}
-		return array_values( array_unique( $urls ) );
-	}
+	private function get_manifest_state_option( int $generation ): string {
+		return 'perform_cache_manifest_state_' . $this->get_blog_id() . '_' . $generation; }
+	private function get_manifest_chunk_option( int $generation, int $chunk ): string {
+		return 'perform_cache_manifest_' . $this->get_blog_id() . '_' . $generation . '_' . $chunk; }
+	private function get_manifest_chunk_size(): int {
+		return max( 1, (int) apply_filters( 'perform_cache_manifest_chunk_size', $this->manifest_chunk_size ) ); }
 
 	/** Purge a bounded batch of tracked URLs from Cloudflare, with retries. */
 	public function run_cloudflare_purge_batch(): void {
@@ -1970,14 +1965,23 @@ class PageCache implements ModuleInterface {
 			if ( ! empty( $record['failed'] ) ) {
 				continue;
 			}
-			$batch    = array_slice( $record['urls'], 0, max( 1, (int) $this->cloudflare_batch_size ) );
+			$urls  = $this->get_cloudflare_record_urls( $record );
+			$batch = array_slice( $urls, (int) ( $record['offset'] ?? 0 ), max( 1, (int) $this->cloudflare_batch_size ) );
+			if ( empty( $batch ) ) {
+				$this->retire_cloudflare_record( $record );
+				$record['urls'] = [];
+				continue;
+			}
 			$settings = Helpers::get_settings();
 			if ( ! is_array( $settings ) || $record['fingerprint'] !== $this->cloudflare_settings_key( $settings ) ) {
 				$record['failed'] = true;
 				update_option( 'perform_cache_cloudflare_credential_residual_' . $this->get_blog_id(), count( $record['urls'] ), false );
 			} elseif ( $this->purge_cloudflare_urls( $batch, $settings ) ) {
-				$record['urls'] = array_values( array_diff( $record['urls'], $batch ) );
-				$this->retire_tracked_urls( $batch );
+				if ( isset( $record['source'] ) ) {
+					$record['offset'] = (int) ( $record['offset'] ?? 0 ) + count( $batch );
+				} else {
+					$record['urls'] = array_values( array_diff( $record['urls'], $batch ) );
+				}
 			} else {
 				++$record['attempts'];
 				$record['failed'] = $record['attempts'] >= max( 1, (int) $this->cloudflare_max_retries );
@@ -1989,7 +1993,7 @@ class PageCache implements ModuleInterface {
 			array_filter(
 				$records,
 				static function ( $record ) {
-					return ! empty( $record['urls'] );
+					return ! isset( $record['done'] );
 				}
 			)
 		);
@@ -2005,21 +2009,34 @@ class PageCache implements ModuleInterface {
 		}
 	}
 
-	/** @param array<int,string> $urls */
-	private function retire_tracked_urls( array $urls ): void {
-		$key     = 'perform_cache_urls_' . $this->get_blog_id();
-		$tracked = get_option( $key, [] );
-		if ( is_array( $tracked ) ) {
-			$remaining = array_values( array_diff( $tracked, $urls ) );
-			if ( $remaining !== $tracked ) {
-				update_option( $key, $remaining, false );
-			}
+	/**
+	 * @param array<string, mixed> $record Record.
+	 * @return array<int, string>
+	 */
+	private function get_cloudflare_record_urls( array $record ): array {
+		if ( isset( $record['source'] ) && 'manifest' === $record['source'] ) {
+			$urls = get_option( $this->get_manifest_chunk_option( (int) $record['generation'], (int) $record['chunk'] ), [] );
+			return is_array( $urls ) ? $urls : [];
+		}
+		if ( isset( $record['source'] ) && 'legacy_option' === $record['source'] ) {
+			$urls = get_option( 'perform_cache_urls_' . $this->get_blog_id(), [] );
+			return is_array( $urls ) ? $urls : [];
+		}
+		return isset( $record['urls'] ) && is_array( $record['urls'] ) ? $record['urls'] : [];
+	}
+
+	/** @param array<string,mixed> $record */
+	private function retire_cloudflare_record( array $record ): void {
+		if ( isset( $record['source'] ) && 'manifest' === $record['source'] ) {
+			delete_option( $this->get_manifest_chunk_option( (int) $record['generation'], (int) $record['chunk'] ) );
+		} elseif ( isset( $record['source'] ) && 'legacy_option' === $record['source'] ) {
+			delete_option( 'perform_cache_urls_' . $this->get_blog_id() );
 		}
 	}
 
 	/**
 	 * @param mixed $records Queue records.
-	 * @return array<int, array{urls: array<int, string>, zone_id: string, fingerprint: string, attempts: int, failed: bool}>
+	 * @return array<int, array<string, mixed>>
 	 */
 	private function get_cloudflare_queue_records( $records ): array {
 		if ( ! is_array( $records ) || empty( $records ) ) {

--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -53,6 +53,9 @@ class PageCache implements ModuleInterface {
 	 */
 	private $cloudflare_batch_size = 30;
 
+	/** @var int */
+	private $cloudflare_metadata_scan_limit = 100;
+
 	/**
 	 * Maximum retry attempts for a failed Cloudflare URL batch.
 	 *
@@ -622,9 +625,8 @@ class PageCache implements ModuleInterface {
 		if ( ! is_array( $old_value ) || ! is_array( $value ) || ! $this->cloudflare_settings_changed( $old_value, $value ) ) {
 			return $value;
 		}
-		$urls = array_slice( (array) get_option( 'perform_cache_urls_' . $this->get_blog_id(), [] ), 0, $this->cloudflare_batch_size );
-		if ( ! empty( $urls ) && ! $this->purge_cloudflare_urls( $urls, $old_value ) ) {
-			update_option( 'perform_cache_cloudflare_credential_residual_' . $this->get_blog_id(), count( $urls ), false );
+		if ( ! empty( $old_value['enable_cloudflare_cache_sync'] ) ) {
+			$this->queue_cloudflare_tracked_urls( $old_value, $this->get_cache_generation() );
 		}
 		return $value;
 	}
@@ -1011,21 +1013,26 @@ class PageCache implements ModuleInterface {
 		if ( ! current_user_can( 'manage_options' ) || ! check_admin_referer( 'perform_acknowledge_cloudflare_residual' ) ) {
 			wp_die( esc_html__( 'You are not allowed to acknowledge Cloudflare cleanup.', 'perform' ) );
 		}
+		$this->acknowledge_cloudflare_credential_residuals();
+		$this->schedule_cleanup();
+		wp_safe_redirect( admin_url( 'options-general.php?page=perform_cache_observability' ) );
+		exit;
+	}
+
+	/** Retire only records that cannot use the current credentials. */
+	private function acknowledge_cloudflare_credential_residuals(): void {
 		$key     = 'perform_cache_cloudflare_queue_' . $this->get_blog_id();
 		$records = $this->get_cloudflare_queue_records( get_option( $key, [] ) );
 		$records = array_values(
 			array_filter(
 				$records,
 				static function ( $record ) {
-					return empty( $record['failed'] );
+					return empty( $record['credential_residual'] );
 				}
 			)
 		);
 		update_option( $key, $records, false );
 		delete_option( 'perform_cache_cloudflare_credential_residual_' . $this->get_blog_id() );
-		$this->schedule_cleanup();
-		wp_safe_redirect( admin_url( 'options-general.php?page=perform_cache_observability' ) );
-		exit;
 	}
 
 	/** Confirm the administrator capability and action nonce before purging. */
@@ -1892,7 +1899,7 @@ class PageCache implements ModuleInterface {
 			}
 		}
 
-		if ( $has_more ) {
+		if ( $has_more || $remaining <= 0 ) {
 			wp_schedule_single_event( time() + 30, 'perform_cache_cleanup_event' );
 		}
 	}
@@ -1992,6 +1999,7 @@ class PageCache implements ModuleInterface {
 			'cursor'      => 0,
 			'zone_id'     => (string) $settings['cloudflare_zone_id'],
 			'fingerprint' => $fingerprint,
+			'enabled'     => ! empty( $settings['enable_cloudflare_cache_sync'] ),
 			'attempts'    => 0,
 			'failed'      => false,
 		];
@@ -2008,29 +2016,36 @@ class PageCache implements ModuleInterface {
 		if ( empty( $urls ) ) {
 			return;
 		}
-		$key     = 'perform_cache_cloudflare_queue_' . $this->get_blog_id();
-		$records = $this->get_cloudflare_queue_records( get_option( $key, [] ) );
+		$key         = 'perform_cache_cloudflare_queue_' . $this->get_blog_id();
+		$records     = $this->get_cloudflare_queue_records( get_option( $key, [] ) );
+		$limit       = max( 1, (int) $this->cloudflare_batch_size );
+		$fingerprint = $this->cloudflare_settings_key( $settings );
 		foreach ( $records as &$record ) {
-			if ( empty( $record['source'] ) && $this->cloudflare_settings_key( $settings ) === ( $record['fingerprint'] ?? '' ) ) {
-				$record['urls']     = array_values( array_unique( array_merge( (array) ( $record['urls'] ?? [] ), $urls ) ) );
-				$record['failed']   = false;
-				$record['attempts'] = 0;
-				unset( $record );
-				update_option( $key, $records, false );
-				wp_schedule_single_event( time() + 10, 'perform_cache_cloudflare_purge_event' );
-				return;
+			if ( ! empty( $record['source'] ) || ! in_array( $fingerprint, [ $record['fingerprint'] ?? '' ], true ) || ! empty( $record['failed'] ) ) {
+				continue;
 			}
+			$current  = isset( $record['urls'] ) && is_array( $record['urls'] ) ? $record['urls'] : [];
+			$capacity = $limit - count( $current );
+			if ( $capacity <= 0 ) {
+				continue;
+			}
+			$record['urls'] = array_values( array_unique( array_merge( $current, array_splice( $urls, 0, $capacity ) ) ) );
 		}
 		unset( $record );
-		$records[] = [
-			'urls'        => $urls,
-			'zone_id'     => (string) $settings['cloudflare_zone_id'],
-			'fingerprint' => $this->cloudflare_settings_key( $settings ),
-			'attempts'    => 0,
-			'failed'      => false,
-		];
+		while ( ! empty( $urls ) ) {
+			$records[] = [
+				'urls'        => array_splice( $urls, 0, $limit ),
+				'zone_id'     => (string) $settings['cloudflare_zone_id'],
+				'fingerprint' => $fingerprint,
+				'enabled'     => true,
+				'attempts'    => 0,
+				'failed'      => false,
+			];
+		}
 		update_option( $key, $records, false );
-		wp_schedule_single_event( time() + 10, 'perform_cache_cloudflare_purge_event' );
+		if ( ! wp_next_scheduled( 'perform_cache_cloudflare_purge_event' ) ) {
+			wp_schedule_single_event( time() + 10, 'perform_cache_cloudflare_purge_event' );
+		}
 	}
 
 	/** Purge a bounded batch of tracked URLs from Cloudflare, with retries. */
@@ -2047,28 +2062,36 @@ class PageCache implements ModuleInterface {
 			$work  = $this->get_cloudflare_record_work( $record );
 			$batch = $work['urls'];
 			if ( empty( $batch ) ) {
+				if ( isset( $work['cursor'] ) && empty( $work['complete'] ) ) {
+					$record['cursor'] = $work['cursor'];
+					break;
+				}
 				$this->retire_cloudflare_record( $record );
 				$record['done'] = true;
 				continue;
 			}
 			$settings = Helpers::get_settings();
-			if ( ! is_array( $settings ) || $record['fingerprint'] !== $this->cloudflare_settings_key( $settings ) ) {
-				$record['failed'] = true;
+			if ( ! is_array( $settings ) || ( $record['fingerprint'] ?? '' ) !== $this->cloudflare_settings_key( $settings ) ) {
+				$record['failed']              = true;
+				$record['credential_residual'] = true;
 				update_option( 'perform_cache_cloudflare_credential_residual_' . $this->get_blog_id(), $this->get_cloudflare_residual_count( $record, $batch ), false );
-			} elseif ( $this->purge_cloudflare_urls( $batch, $settings ) ) {
-				if ( isset( $work['cursor'] ) ) {
-					$record['cursor'] = $work['cursor'];
-					if ( ! empty( $work['complete'] ) ) {
-						$record['inventory_complete'] = true;
-					}
-				} elseif ( isset( $record['source'] ) ) {
-					$record['offset'] = (int) ( $record['offset'] ?? 0 ) + count( $batch );
-				} else {
-					$record['urls'] = array_values( array_diff( $record['urls'], $batch ) );
-				}
 			} else {
-				++$record['attempts'];
-				$record['failed'] = $record['attempts'] >= max( 1, (int) $this->cloudflare_max_retries );
+				$settings['enable_cloudflare_cache_sync'] = array_key_exists( 'enabled', $record ) ? ! empty( $record['enabled'] ) : true;
+				if ( $this->purge_cloudflare_urls( $batch, $settings ) ) {
+					if ( isset( $work['cursor'] ) ) {
+						$record['cursor'] = $work['cursor'];
+						if ( ! empty( $work['complete'] ) ) {
+							$record['inventory_complete'] = true;
+						}
+					} elseif ( isset( $record['source'] ) ) {
+						$record['offset'] = (int) ( $record['offset'] ?? 0 ) + count( $batch );
+					} else {
+						$record['urls'] = array_values( array_diff( $record['urls'], $batch ) );
+					}
+				} else {
+					++$record['attempts'];
+					$record['failed'] = $record['attempts'] >= max( 1, (int) $this->cloudflare_max_retries );
+				}
 			}
 			break;
 		}
@@ -2123,17 +2146,29 @@ class PageCache implements ModuleInterface {
 			];
 		}
 
-		$cursor = max( 0, (int) ( $record['cursor'] ?? 0 ) );
-		$index  = 0;
-		$urls   = [];
-		$limit  = max( 1, (int) $this->cloudflare_batch_size );
-		$files  = new \DirectoryIterator( $directory );
+		$cursor  = max( 0, (int) ( $record['cursor'] ?? 0 ) );
+		$index   = 0;
+		$urls    = [];
+		$limit   = max( 1, (int) $this->cloudflare_batch_size );
+		$budget  = max( 1, (int) apply_filters( 'perform_cache_cloudflare_metadata_scan_limit', $this->cloudflare_metadata_scan_limit ) );
+		$scanned = 0;
+		$files   = new \DirectoryIterator( $directory );
 		foreach ( $files as $file ) {
-			if ( $file->isDot() || ! $file->isFile() || '.meta.json' !== substr( $file->getFilename(), -10 ) ) {
-				++$index;
+			if ( $file->isDot() ) {
 				continue;
 			}
 			if ( $index++ < $cursor ) {
+				continue;
+			}
+			++$scanned;
+			if ( ! $file->isFile() || '.meta.json' !== substr( $file->getFilename(), -10 ) ) {
+				if ( $scanned >= $budget ) {
+					return [
+						'urls'     => [],
+						'cursor'   => $index,
+						'complete' => false,
+					];
+				}
 				continue;
 			}
 			$raw  = file_get_contents( $file->getPathname() );
@@ -2142,7 +2177,7 @@ class PageCache implements ModuleInterface {
 			if ( '' !== $url && $this->is_site_url( $url ) ) {
 				$urls[] = $url;
 			}
-			if ( count( $urls ) >= $limit ) {
+			if ( count( $urls ) >= $limit || $scanned >= $budget ) {
 				return [
 					'urls'     => array_values( array_unique( $urls ) ),
 					'cursor'   => $index,
@@ -2211,7 +2246,7 @@ class PageCache implements ModuleInterface {
 
 	/** @param array<string,mixed> $settings */
 	private function cloudflare_settings_key( array $settings ): string {
-		return md5( $settings['cloudflare_zone_id'] . '|' . $settings['cloudflare_api_token'] ); }
+		return md5( (string) ( $settings['cloudflare_zone_id'] ?? '' ) . '|' . (string) ( $settings['cloudflare_api_token'] ?? '' ) ); }
 
 	/**
 	 * @param array<string, mixed> $old Previous settings.

--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -784,7 +784,7 @@ class PageCache implements ModuleInterface {
 					?>
 					<div class="notice notice-warning"><p><?php esc_html_e( 'Cloudflare URL cleanup is pending.', 'perform' ); ?></p></div><?php endif; ?>
 				<?php
-				if ( ! empty( $_GET['perform_cache_cloudflare_failed'] ) ) :
+				if ( ! empty( $_GET['perform_cache_cloudflare_retryable_failed'] ) ) :
 					?>
 					<div class="notice notice-error"><p><?php esc_html_e( 'Some Cloudflare URL cleanup batches need a manual retry.', 'perform' ); ?></p></div><?php endif; ?>
 			<?php endif; ?>
@@ -1008,7 +1008,7 @@ class PageCache implements ModuleInterface {
 				[
 					'perform_cache_purged'             => '1',
 					'perform_cache_cloudflare_pending' => $status['pending'],
-					'perform_cache_cloudflare_failed'  => $status['failed'],
+					'perform_cache_cloudflare_retryable_failed' => $status['retryable_failed'],
 				],
 				admin_url( 'options-general.php?page=perform_cache_observability' )
 			)

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -583,6 +583,14 @@ if ( ! function_exists( 'get_comment' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_objects_in_term' ) ) {
+	function get_objects_in_term( $term_ids, $taxonomies, $args = [] ) {
+		$term_id = (int) ( is_array( $term_ids ) ? reset( $term_ids ) : $term_ids );
+		$ids     = $GLOBALS['perform_test_term_object_ids'][ $term_id ] ?? [];
+		return array_slice( $ids, 0, isset( $args['number'] ) ? (int) $args['number'] : count( $ids ) );
+	}
+}
+
 if ( ! function_exists( 'wp_is_post_revision' ) ) {
 	function wp_is_post_revision( $post_id ) {
 		return false;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -523,6 +523,10 @@ if ( ! function_exists( 'wp_remote_post' ) ) {
 
 if ( ! function_exists( 'wp_schedule_single_event' ) ) {
 	function wp_schedule_single_event( $timestamp, $hook, $args = [] ) {
+		if ( ! isset( $GLOBALS['perform_test_scheduled_events'] ) || ! is_array( $GLOBALS['perform_test_scheduled_events'] ) ) {
+			$GLOBALS['perform_test_scheduled_events'] = [];
+		}
+		$GLOBALS['perform_test_scheduled_events'][ $hook ] = $timestamp;
 		$GLOBALS['perform_test_scheduled_single_events'][] = [
 			'timestamp' => $timestamp,
 			'hook'      => $hook,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -591,6 +591,14 @@ if ( ! function_exists( 'get_objects_in_term' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_posts' ) ) {
+	function get_posts( $args = [] ) {
+		$term_id = (int) ( $args['tax_query'][0]['terms'][0] ?? 0 );
+		$ids     = $GLOBALS['perform_test_term_object_ids'][ $term_id ] ?? [];
+		return array_slice( $ids, 0, (int) ( $args['posts_per_page'] ?? count( $ids ) ) );
+	}
+}
+
 if ( ! function_exists( 'wp_is_post_revision' ) ) {
 	function wp_is_post_revision( $post_id ) {
 		return false;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -131,6 +131,12 @@ if ( ! function_exists( 'add_action' ) ) {
 	}
 }
 
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
+		return add_action( $hook_name, $callback, $priority, $accepted_args );
+	}
+}
+
 if ( ! function_exists( 'wp_enqueue_style' ) ) {
 	function wp_enqueue_style( $handle, $src = '', $deps = [], $ver = false, $media = 'all' ) {
 		$GLOBALS['perform_test_enqueued_styles'][] = $handle;
@@ -472,6 +478,151 @@ if ( ! function_exists( 'sanitize_textarea_field' ) ) {
 if ( ! function_exists( 'wp_unslash' ) ) {
 	function wp_unslash( $value ) {
 		return $value;
+	}
+}
+
+if ( ! function_exists( 'get_current_blog_id' ) ) {
+	function get_current_blog_id() {
+		return isset( $GLOBALS['perform_test_blog_id'] ) ? (int) $GLOBALS['perform_test_blog_id'] : 1;
+	}
+}
+
+if ( ! function_exists( 'wp_mkdir_p' ) ) {
+	function wp_mkdir_p( $target ) {
+		return is_dir( $target ) || mkdir( $target, 0777, true );
+	}
+}
+
+if ( ! function_exists( 'wp_is_writable' ) ) {
+	function wp_is_writable( $path ) {
+		return is_writable( $path );
+	}
+}
+
+if ( ! function_exists( 'wp_delete_file' ) ) {
+	function wp_delete_file( $file ) {
+		return is_file( $file ) ? unlink( $file ) : false;
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value ) {
+		return json_encode( $value );
+	}
+}
+
+if ( ! function_exists( 'wp_remote_post' ) ) {
+	function wp_remote_post( $url, $args = [] ) {
+		$GLOBALS['perform_test_remote_post_calls'][] = [
+			'url'  => $url,
+			'args' => $args,
+		];
+		return $GLOBALS['perform_test_remote_post_response'] ?? [ 'response' => [ 'code' => 200 ] ];
+	}
+}
+
+if ( ! function_exists( 'wp_schedule_single_event' ) ) {
+	function wp_schedule_single_event( $timestamp, $hook, $args = [] ) {
+		$GLOBALS['perform_test_scheduled_single_events'][] = [
+			'timestamp' => $timestamp,
+			'hook'      => $hook,
+			'args'      => $args,
+		];
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_permalink' ) ) {
+	function get_permalink( $post_id = 0 ) {
+		return $GLOBALS['perform_test_permalinks'][ (int) $post_id ] ?? 'https://example.com/post-' . (int) $post_id;
+	}
+}
+
+if ( ! function_exists( 'get_post_type_archive_link' ) ) {
+	function get_post_type_archive_link( $post_type ) {
+		return $GLOBALS['perform_test_post_type_archives'][ $post_type ] ?? 'https://example.com/' . $post_type . '/';
+	}
+}
+
+if ( ! function_exists( 'get_object_taxonomies' ) ) {
+	function get_object_taxonomies( $post_type, $output = 'names' ) {
+		return $GLOBALS['perform_test_taxonomies'][ $post_type ] ?? [];
+	}
+}
+
+if ( ! function_exists( 'get_the_terms' ) ) {
+	function get_the_terms( $post_id, $taxonomy ) {
+		return $GLOBALS['perform_test_post_terms'][ (int) $post_id ][ $taxonomy ] ?? [];
+	}
+}
+
+if ( ! function_exists( 'get_term_link' ) ) {
+	function get_term_link( $term, $taxonomy = '' ) {
+		if ( is_object( $term ) && isset( $term->link ) ) {
+			return $term->link;
+		}
+		return 'https://example.com/term-' . (int) $term . '/';
+	}
+}
+
+if ( ! function_exists( 'get_term' ) ) {
+	function get_term( $term_id, $taxonomy = '' ) {
+		return $GLOBALS['perform_test_terms'][ (int) $term_id ] ?? false;
+	}
+}
+
+if ( ! function_exists( 'get_term_by' ) ) {
+	function get_term_by( $field, $value, $taxonomy = '' ) {
+		return $GLOBALS['perform_test_terms_by_tt_id'][ (int) $value ] ?? false;
+	}
+}
+
+if ( ! function_exists( 'get_comment' ) ) {
+	function get_comment( $comment_id ) {
+		return $GLOBALS['perform_test_comments'][ (int) $comment_id ] ?? false;
+	}
+}
+
+if ( ! function_exists( 'wp_is_post_revision' ) ) {
+	function wp_is_post_revision( $post_id ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'wp_is_post_autosave' ) ) {
+	function wp_is_post_autosave( $post_id ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'wp_nonce_field' ) ) {
+	function wp_nonce_field( $action = -1, $name = '_wpnonce' ) {
+		return '<input type="hidden" name="' . $name . '" value="test-nonce" />';
+	}
+}
+
+if ( ! function_exists( 'check_admin_referer' ) ) {
+	function check_admin_referer( $action = -1, $query_arg = '_wpnonce' ) {
+		return ! empty( $GLOBALS['perform_test_nonce_valid'] );
+	}
+}
+
+if ( ! function_exists( 'wp_safe_redirect' ) ) {
+	function wp_safe_redirect( $location, $status = 302 ) {
+		$GLOBALS['perform_test_redirect'] = $location;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_die' ) ) {
+	function wp_die( $message = '' ) {
+		throw new RuntimeException( (string) $message );
+	}
+}
+
+if ( ! function_exists( 'submit_button' ) ) {
+	function submit_button( $text = null, $type = 'primary', $name = 'submit', $wrap = true ) {
+		return '';
 	}
 }
 

--- a/tests/unit-tests/tests-page-cache.php
+++ b/tests/unit-tests/tests-page-cache.php
@@ -790,6 +790,59 @@ final class Tests_Page_Cache extends TestCase {
 		$this->assertArrayNotHasKey( 'perform_cache_cloudflare_credential_residual_1', $GLOBALS['perform_test_options'] );
 	}
 
+	public function test_cloudflare_retry_requires_capability_and_nonce() {
+		$page_cache = new PageCache();
+		$this->assertFalse( $this->invoke_private( $page_cache, 'is_cloudflare_retry_authorized' ) );
+
+		$GLOBALS['perform_test_current_user_can'] = [ 'manage_options' => true ];
+		$GLOBALS['perform_test_nonce_valid']      = true;
+		$this->assertTrue( $this->invoke_private( $page_cache, 'is_cloudflare_retry_authorized' ) );
+	}
+
+	public function test_cloudflare_retry_selectively_resets_current_failures_and_preserves_residuals() {
+		$page_cache                      = new PageCache();
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings'                 => [
+				'enable_cloudflare_cache_sync' => true,
+				'cloudflare_zone_id'           => 'zone',
+				'cloudflare_api_token'         => 'token',
+			],
+			'perform_cache_cloudflare_queue_1' => [
+				[
+					'urls'        => [ 'https://example.com/retry/' ],
+					'fingerprint' => md5( 'zone|token' ),
+					'attempts'    => 3,
+					'failed'      => true,
+				],
+				[
+					'urls'                => [ 'https://example.com/residual/' ],
+					'fingerprint'         => md5( 'old|token' ),
+					'attempts'            => 3,
+					'failed'              => true,
+					'credential_residual' => true,
+				],
+				[
+					'urls'        => [ 'https://example.com/other/' ],
+					'fingerprint' => md5( 'other|token' ),
+					'attempts'    => 3,
+					'failed'      => true,
+				],
+			],
+		];
+
+		$this->assertSame( 1, $this->invoke_private( $page_cache, 'retry_current_cloudflare_failures' ) );
+		$records = $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'];
+		$this->assertFalse( $records[0]['failed'] );
+		$this->assertSame( 0, $records[0]['attempts'] );
+		$this->assertTrue( $records[1]['failed'] );
+		$this->assertTrue( $records[1]['credential_residual'] );
+		$this->assertTrue( $records[2]['failed'] );
+		$this->assertCount( 1, $GLOBALS['perform_test_scheduled_single_events'] );
+
+		$this->assertSame( 0, $this->invoke_private( $page_cache, 'retry_current_cloudflare_failures' ) );
+		$this->assertCount( 1, $GLOBALS['perform_test_scheduled_single_events'] );
+	}
+
 	public function test_manual_purge_requires_manage_options() {
 		$page_cache = new PageCache();
 		$this->expectException( RuntimeException::class );

--- a/tests/unit-tests/tests-page-cache.php
+++ b/tests/unit-tests/tests-page-cache.php
@@ -843,6 +843,31 @@ final class Tests_Page_Cache extends TestCase {
 		$this->assertCount( 1, $GLOBALS['perform_test_scheduled_single_events'] );
 	}
 
+	public function test_cloudflare_status_separates_retryable_failures_from_residuals() {
+		$page_cache                      = new PageCache();
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings'                 => [
+				'cloudflare_zone_id'   => 'zone',
+				'cloudflare_api_token' => 'token',
+			],
+			'perform_cache_cloudflare_queue_1' => [
+				[
+					'fingerprint' => md5( 'zone|token' ),
+					'failed'      => true,
+				],
+				[
+					'fingerprint'         => md5( 'old|token' ),
+					'failed'              => true,
+					'credential_residual' => true,
+				],
+			],
+		];
+
+		$status = $this->invoke_private( $page_cache, 'get_cloudflare_queue_status' );
+		$this->assertSame( 1, $status['retryable_failed'] );
+		$this->assertSame( 1, $status['credential_residuals'] );
+	}
+
 	public function test_manual_purge_requires_manage_options() {
 		$page_cache = new PageCache();
 		$this->expectException( RuntimeException::class );

--- a/tests/unit-tests/tests-page-cache.php
+++ b/tests/unit-tests/tests-page-cache.php
@@ -479,6 +479,63 @@ final class Tests_Page_Cache extends TestCase {
 		$this->assertSame( 0, $record['attempts'] );
 	}
 
+	public function test_settings_disable_queues_old_metadata_and_still_purges_edge() {
+		$page_cache = new PageCache();
+		$cache_dir  = $this->temporary_cache_dir();
+		$this->set_private_property( $page_cache, 'cache_dir', $cache_dir );
+		mkdir( $cache_dir . 'site-1/generation-1/', 0777, true );
+		file_put_contents( $cache_dir . 'site-1/generation-1/a.meta.json', wp_json_encode( [ 'url' => 'https://example.com/a/' ] ) );
+		$old = [
+			'enable_cloudflare_cache_sync' => true,
+			'cloudflare_zone_id'           => 'zone',
+			'cloudflare_api_token'         => 'token',
+		];
+		$new = [
+			'enable_cloudflare_cache_sync' => false,
+			'cloudflare_zone_id'           => 'zone',
+			'cloudflare_api_token'         => 'token',
+		];
+		$GLOBALS['perform_test_options']['perform_settings'] = $old;
+		$this->invoke_private_with_arguments( $page_cache, 'capture_cloudflare_settings_before_update', [ $new, $old, 'perform_settings' ] );
+		$GLOBALS['perform_test_options']['perform_settings'] = $new;
+		$GLOBALS['perform_test_remote_post_response']        = [
+			'response' => [ 'code' => 200 ],
+			'body'     => '{"success":true}',
+		];
+
+		$page_cache->run_cloudflare_purge_batch();
+		$this->assertCount( 1, $GLOBALS['perform_test_remote_post_calls'] );
+		$this->assertTrue( $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0]['enabled'] );
+	}
+
+	public function test_settings_credential_change_keeps_old_source_as_residual() {
+		$page_cache = new PageCache();
+		$cache_dir  = $this->temporary_cache_dir();
+		$this->set_private_property( $page_cache, 'cache_dir', $cache_dir );
+		mkdir( $cache_dir . 'site-1/generation-1/', 0777, true );
+		file_put_contents( $cache_dir . 'site-1/generation-1/a.meta.json', wp_json_encode( [ 'url' => 'https://example.com/a/' ] ) );
+		$old = [
+			'enable_cloudflare_cache_sync' => true,
+			'cloudflare_zone_id'           => 'old-zone',
+			'cloudflare_api_token'         => 'old-token',
+		];
+		$new = [
+			'enable_cloudflare_cache_sync' => true,
+			'cloudflare_zone_id'           => 'new-zone',
+			'cloudflare_api_token'         => 'new-token',
+		];
+		$GLOBALS['perform_test_options']['perform_settings'] = $old;
+		$this->invoke_private_with_arguments( $page_cache, 'capture_cloudflare_settings_before_update', [ $new, $old, 'perform_settings' ] );
+		$GLOBALS['perform_test_options']['perform_settings'] = $new;
+		$page_cache->run_cloudflare_purge_batch();
+		$this->invoke_private_with_arguments( $page_cache, 'queue_cloudflare_tracked_urls', [ $new, 1 ] );
+
+		$record = $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0];
+		$this->assertCount( 1, $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'] );
+		$this->assertTrue( $record['credential_residual'] );
+		$this->assertSame( md5( 'old-zone|old-token' ), $record['fingerprint'] );
+	}
+
 	public function test_metadata_inventory_drains_in_bounded_batches_without_tokens() {
 		$page_cache = new PageCache();
 		$cache_dir  = $this->temporary_cache_dir();
@@ -550,6 +607,28 @@ final class Tests_Page_Cache extends TestCase {
 		$this->assertGreaterThan( 0, $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0]['cursor'] );
 	}
 
+	public function test_invalid_metadata_scan_advances_in_bounded_runs_without_retiring() {
+		$page_cache = new PageCache();
+		$cache_dir  = $this->temporary_cache_dir();
+		$this->set_private_property( $page_cache, 'cache_dir', $cache_dir );
+		$this->set_private_property( $page_cache, 'cloudflare_metadata_scan_limit', 2 );
+		$GLOBALS['perform_test_options']['perform_settings'] = [
+			'enable_cloudflare_cache_sync' => true,
+			'cloudflare_zone_id'           => 'zone',
+			'cloudflare_api_token'         => 'token',
+		];
+		mkdir( $cache_dir . 'site-1/generation-1/', 0777, true );
+		foreach ( [ 'one.txt', 'two.txt', 'three.txt' ] as $file ) {
+			file_put_contents( $cache_dir . 'site-1/generation-1/' . $file, 'not metadata' );
+		}
+		$this->invoke_private_with_arguments( $page_cache, 'queue_cloudflare_tracked_urls', [ null, 1 ] );
+
+		$page_cache->run_cloudflare_purge_batch();
+		$this->assertNotEmpty( $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'] );
+		$this->assertGreaterThan( 0, $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0]['cursor'] );
+		$this->assertSame( [], $GLOBALS['perform_test_remote_post_calls'] );
+	}
+
 	public function test_targeted_cloudflare_failure_queues_a_token_free_retry() {
 		$page_cache = new PageCache();
 		$GLOBALS['perform_test_options']['perform_settings'] = [
@@ -565,6 +644,32 @@ final class Tests_Page_Cache extends TestCase {
 		$this->assertSame( [ 'https://example.com/a/' ], $record['urls'] );
 		$this->assertArrayNotHasKey( 'cloudflare_api_token', $record );
 		$this->assertSame( 'perform_cache_cloudflare_purge_event', $GLOBALS['perform_test_scheduled_single_events'][0]['hook'] );
+	}
+
+	public function test_inline_cloudflare_retries_are_chunked_and_schedule_once() {
+		$page_cache = new PageCache();
+		$this->set_private_property( $page_cache, 'cloudflare_batch_size', 2 );
+		$GLOBALS['perform_test_options']['perform_settings'] = [
+			'enable_cloudflare_cache_sync' => true,
+			'cloudflare_zone_id'           => 'zone',
+			'cloudflare_api_token'         => 'token',
+		];
+		$urls = [ 'https://example.com/a/', 'https://example.com/b/', 'https://example.com/c/', 'https://example.com/d/', 'https://example.com/e/' ];
+		$this->invoke_private_with_argument( $page_cache, 'queue_cloudflare_inline_urls', $urls );
+		$this->invoke_private_with_argument( $page_cache, 'queue_cloudflare_inline_urls', [ 'https://example.com/f/' ] );
+
+		$records = $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'];
+		$this->assertCount( 3, $records );
+		$this->assertSame(
+			[ 2, 2, 2 ],
+			array_map(
+				static function ( $record ) {
+					return count( $record['urls'] );
+				},
+				$records
+			)
+		);
+		$this->assertCount( 1, $GLOBALS['perform_test_scheduled_single_events'] );
 	}
 
 	public function test_cleanup_waits_for_metadata_inventory_then_removes_retired_files() {
@@ -590,6 +695,21 @@ final class Tests_Page_Cache extends TestCase {
 		$GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'] = [];
 		$page_cache->cleanup_obsolete_generations();
 		$this->assertFileDoesNotExist( $cache_dir . 'site-1/generation-1/retired.meta.json' );
+	}
+
+	public function test_cleanup_schedules_again_when_legacy_files_exactly_exhaust_budget() {
+		$page_cache = new PageCache();
+		$cache_dir  = $this->temporary_cache_dir();
+		$this->set_private_property( $page_cache, 'cache_dir', $cache_dir );
+		$this->set_private_property( $page_cache, 'cleanup_batch_size', 1 );
+		$GLOBALS['perform_test_options']['perform_cache_generation_1'] = 2;
+		file_put_contents( $cache_dir . str_repeat( 'a', 32 ) . '.html', 'legacy' );
+		mkdir( $cache_dir . 'site-1/generation-1/', 0777, true );
+		file_put_contents( $cache_dir . 'site-1/generation-1/retired.html', 'retired' );
+
+		$page_cache->cleanup_obsolete_generations();
+		$this->assertFileExists( $cache_dir . 'site-1/generation-1/retired.html' );
+		$this->assertSame( 'perform_cache_cleanup_event', $GLOBALS['perform_test_scheduled_single_events'][0]['hook'] );
 	}
 
 	public function test_empty_metadata_source_is_retired_without_rescheduling() {
@@ -646,6 +766,28 @@ final class Tests_Page_Cache extends TestCase {
 		$page_cache->run_cloudflare_purge_batch();
 		$this->assertTrue( $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0]['failed'] );
 		$this->assertSame( 1, $GLOBALS['perform_test_options']['perform_cache_cloudflare_credential_residual_1'] );
+	}
+
+	public function test_acknowledgement_retires_only_credential_residual_records() {
+		$page_cache                      = new PageCache();
+		$GLOBALS['perform_test_options'] = [
+			'perform_cache_cloudflare_credential_residual_1' => 1,
+			'perform_cache_cloudflare_queue_1' => [
+				[
+					'urls'                => [ 'https://example.com/old/' ],
+					'failed'              => true,
+					'credential_residual' => true,
+				],
+				[
+					'urls'   => [ 'https://example.com/retry/' ],
+					'failed' => true,
+				],
+			],
+		];
+
+		$this->invoke_private( $page_cache, 'acknowledge_cloudflare_credential_residuals' );
+		$this->assertSame( [ 'https://example.com/retry/' ], $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0]['urls'] );
+		$this->assertArrayNotHasKey( 'perform_cache_cloudflare_credential_residual_1', $GLOBALS['perform_test_options'] );
 	}
 
 	public function test_manual_purge_requires_manage_options() {

--- a/tests/unit-tests/tests-page-cache.php
+++ b/tests/unit-tests/tests-page-cache.php
@@ -387,14 +387,14 @@ final class Tests_Page_Cache extends TestCase {
 		$page_cache = new PageCache();
 		$cache_dir  = $this->temporary_cache_dir();
 		$this->set_private_property( $page_cache, 'cache_dir', $cache_dir );
-		file_put_contents( $cache_dir . 'legacy.html', 'legacy' );
-		file_put_contents( $cache_dir . 'legacy.meta.json', '{}' );
+		file_put_contents( $cache_dir . str_repeat( 'a', 32 ) . '.html', 'legacy' );
+		file_put_contents( $cache_dir . str_repeat( 'a', 32 ) . '.meta.json', '{}' );
 		file_put_contents( $cache_dir . 'keep.txt', 'keep' );
 
 		$page_cache->cleanup_obsolete_generations();
 
-		$this->assertFileDoesNotExist( $cache_dir . 'legacy.html' );
-		$this->assertFileDoesNotExist( $cache_dir . 'legacy.meta.json' );
+		$this->assertFileDoesNotExist( $cache_dir . str_repeat( 'a', 32 ) . '.html' );
+		$this->assertFileDoesNotExist( $cache_dir . str_repeat( 'a', 32 ) . '.meta.json' );
 		$this->assertFileExists( $cache_dir . 'keep.txt' );
 	}
 
@@ -439,15 +439,44 @@ final class Tests_Page_Cache extends TestCase {
 		$this->assertTrue( $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0]['failed'] );
 	}
 
-	public function test_manifest_chunks_keep_urls_beyond_the_chunk_limit() {
+	public function test_global_purge_queues_one_metadata_source_per_generation() {
 		$page_cache = new PageCache();
-		$this->set_private_property( $page_cache, 'manifest_chunk_size', 2 );
-		$this->invoke_private_with_argument( $page_cache, 'track_cached_url', 'https://example.com/a/' );
-		$this->invoke_private_with_argument( $page_cache, 'track_cached_url', 'https://example.com/b/' );
-		$this->invoke_private_with_argument( $page_cache, 'track_cached_url', 'https://example.com/c/' );
+		$GLOBALS['perform_test_options']['perform_settings'] = [
+			'enable_cloudflare_cache_sync' => true,
+			'cloudflare_zone_id'           => 'zone',
+			'cloudflare_api_token'         => 'token',
+		];
+		$this->invoke_private_with_arguments( $page_cache, 'queue_cloudflare_tracked_urls', [ null, 2 ] );
+		$this->invoke_private_with_arguments( $page_cache, 'queue_cloudflare_tracked_urls', [ null, 2 ] );
+		$this->assertCount( 1, $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'] );
+		$this->assertSame( 'metadata', $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0]['source'] );
+	}
 
-		$this->assertSame( [ 'https://example.com/a/', 'https://example.com/b/' ], $GLOBALS['perform_test_options']['perform_cache_manifest_1_1_0'] );
-		$this->assertSame( [ 'https://example.com/c/' ], $GLOBALS['perform_test_options']['perform_cache_manifest_1_1_1'] );
+	public function test_requeueing_a_failed_metadata_source_resets_current_credentials() {
+		$page_cache                      = new PageCache();
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings'                 => [
+				'enable_cloudflare_cache_sync' => true,
+				'cloudflare_zone_id'           => 'zone',
+				'cloudflare_api_token'         => 'token',
+			],
+			'perform_cache_cloudflare_queue_1' => [
+				[
+					'source'      => 'metadata',
+					'generation'  => 2,
+					'cursor'      => 0,
+					'zone_id'     => 'zone',
+					'fingerprint' => md5( 'zone|token' ),
+					'attempts'    => 3,
+					'failed'      => true,
+				],
+			],
+		];
+
+		$this->invoke_private_with_arguments( $page_cache, 'queue_cloudflare_tracked_urls', [ null, 2 ] );
+		$record = $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0];
+		$this->assertFalse( $record['failed'] );
+		$this->assertSame( 0, $record['attempts'] );
 	}
 
 	public function test_metadata_inventory_drains_in_bounded_batches_without_tokens() {
@@ -481,16 +510,61 @@ final class Tests_Page_Cache extends TestCase {
 			$page_cache->run_cloudflare_purge_batch();
 		}
 
-		$this->assertSame(
-			[ 'https://example.com/a/', 'https://example.com/b/', 'https://example.com/c/' ],
-			array_map(
-				static function ( $call ) {
+		$purged_urls = array_map(
+			static function ( $call ) {
 					return json_decode( $call['args']['body'], true )['files'][0];
-				},
-				$GLOBALS['perform_test_remote_post_calls']
-			)
+			},
+			$GLOBALS['perform_test_remote_post_calls']
 		);
+		sort( $purged_urls );
+		$this->assertSame( [ 'https://example.com/a/', 'https://example.com/b/', 'https://example.com/c/' ], $purged_urls );
 		$this->assertSame( [], $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'] );
+	}
+
+	public function test_metadata_cursor_is_committed_only_after_cloudflare_success() {
+		$page_cache = new PageCache();
+		$cache_dir  = $this->temporary_cache_dir();
+		$this->set_private_property( $page_cache, 'cache_dir', $cache_dir );
+		$this->set_private_property( $page_cache, 'cloudflare_batch_size', 1 );
+		$GLOBALS['perform_test_options']['perform_settings'] = [
+			'enable_cloudflare_cache_sync' => true,
+			'cloudflare_zone_id'           => 'zone',
+			'cloudflare_api_token'         => 'token',
+		];
+		mkdir( $cache_dir . 'site-1/generation-1/', 0777, true );
+		file_put_contents( $cache_dir . 'site-1/generation-1/a.meta.json', wp_json_encode( [ 'url' => 'https://example.com/a/' ] ) );
+		$this->invoke_private_with_arguments( $page_cache, 'queue_cloudflare_tracked_urls', [ null, 1 ] );
+		$GLOBALS['perform_test_remote_post_response'] = new WP_Error( 'request_failed', 'No route' );
+
+		$page_cache->run_cloudflare_purge_batch();
+		$this->assertSame( 0, $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0]['cursor'] );
+		$first                                        = json_decode( $GLOBALS['perform_test_remote_post_calls'][0]['args']['body'], true )['files'];
+		$GLOBALS['perform_test_remote_post_response'] = [
+			'response' => [ 'code' => 200 ],
+			'body'     => '{"success":true}',
+		];
+		$page_cache->run_cloudflare_purge_batch();
+		$second = json_decode( $GLOBALS['perform_test_remote_post_calls'][1]['args']['body'], true )['files'];
+
+		$this->assertSame( $first, $second );
+		$this->assertGreaterThan( 0, $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0]['cursor'] );
+	}
+
+	public function test_targeted_cloudflare_failure_queues_a_token_free_retry() {
+		$page_cache = new PageCache();
+		$GLOBALS['perform_test_options']['perform_settings'] = [
+			'enable_cloudflare_cache_sync' => true,
+			'cloudflare_zone_id'           => 'zone',
+			'cloudflare_api_token'         => 'token',
+		];
+		$GLOBALS['perform_test_remote_post_response']        = new WP_Error( 'request_failed', 'No route' );
+
+		$this->invoke_private_with_argument( $page_cache, 'purge_cloudflare_url', 'https://example.com/a/' );
+
+		$record = $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0];
+		$this->assertSame( [ 'https://example.com/a/' ], $record['urls'] );
+		$this->assertArrayNotHasKey( 'cloudflare_api_token', $record );
+		$this->assertSame( 'perform_cache_cloudflare_purge_event', $GLOBALS['perform_test_scheduled_single_events'][0]['hook'] );
 	}
 
 	public function test_cleanup_waits_for_metadata_inventory_then_removes_retired_files() {
@@ -545,7 +619,11 @@ final class Tests_Page_Cache extends TestCase {
 	}
 
 	public function test_source_credential_mismatch_is_visible_and_nonfatal() {
-		$page_cache                      = new PageCache();
+		$page_cache = new PageCache();
+		$cache_dir  = $this->temporary_cache_dir();
+		$this->set_private_property( $page_cache, 'cache_dir', $cache_dir );
+		mkdir( $cache_dir . 'site-1/generation-1/', 0777, true );
+		file_put_contents( $cache_dir . 'site-1/generation-1/a.meta.json', wp_json_encode( [ 'url' => 'https://example.com/a/' ] ) );
 		$GLOBALS['perform_test_options'] = [
 			'perform_settings'                 => [
 				'enable_cloudflare_cache_sync' => true,
@@ -554,17 +632,15 @@ final class Tests_Page_Cache extends TestCase {
 			],
 			'perform_cache_cloudflare_queue_1' => [
 				[
-					'source'      => 'manifest',
+					'source'      => 'metadata',
 					'generation'  => 1,
-					'chunk'       => 0,
-					'offset'      => 0,
+					'cursor'      => 0,
 					'zone_id'     => 'old-zone',
 					'fingerprint' => md5( 'old-zone|old-token' ),
 					'attempts'    => 0,
 					'failed'      => false,
 				],
 			],
-			'perform_cache_manifest_1_1_0'     => [ 'https://example.com/a/' ],
 		];
 
 		$page_cache->run_cloudflare_purge_batch();

--- a/tests/unit-tests/tests-page-cache.php
+++ b/tests/unit-tests/tests-page-cache.php
@@ -13,6 +13,18 @@ final class Tests_Page_Cache extends TestCase {
 		$GLOBALS['perform_test_home_url']         = 'https://example.com';
 		$GLOBALS['perform_test_remote_get_map']   = [];
 		$GLOBALS['perform_test_remote_get_calls'] = [];
+		$GLOBALS['perform_test_remote_post_calls'] = [];
+		$GLOBALS['perform_test_actions']          = [];
+		$GLOBALS['perform_test_scheduled_events'] = [];
+		$GLOBALS['perform_test_scheduled_single_events'] = [];
+		$GLOBALS['perform_test_permalinks']       = [];
+		$GLOBALS['perform_test_post_type_archives'] = [];
+		$GLOBALS['perform_test_taxonomies']       = [];
+		$GLOBALS['perform_test_post_terms']       = [];
+		$GLOBALS['perform_test_terms']            = [];
+		$GLOBALS['perform_test_terms_by_tt_id']   = [];
+		$GLOBALS['perform_test_comments']         = [];
+		$GLOBALS['perform_test_blog_id']          = 1;
 		$_COOKIE                                  = [];
 		$_GET                                     = [];
 		$_SERVER['REQUEST_METHOD']                = 'GET';
@@ -27,7 +39,20 @@ final class Tests_Page_Cache extends TestCase {
 			$GLOBALS['perform_test_options'],
 			$GLOBALS['perform_test_remote_get_calls'],
 			$GLOBALS['perform_test_remote_get_map'],
+			$GLOBALS['perform_test_remote_post_response'],
 			$GLOBALS['perform_test_transients'],
+			$GLOBALS['perform_test_actions'],
+			$GLOBALS['perform_test_remote_post_calls'],
+			$GLOBALS['perform_test_scheduled_events'],
+			$GLOBALS['perform_test_scheduled_single_events'],
+			$GLOBALS['perform_test_permalinks'],
+			$GLOBALS['perform_test_post_type_archives'],
+			$GLOBALS['perform_test_taxonomies'],
+			$GLOBALS['perform_test_post_terms'],
+			$GLOBALS['perform_test_terms'],
+			$GLOBALS['perform_test_terms_by_tt_id'],
+			$GLOBALS['perform_test_comments'],
+			$GLOBALS['perform_test_blog_id'],
 			$_SERVER['REQUEST_METHOD'],
 			$_SERVER['REQUEST_URI'],
 			$_SERVER['HTTP_X_PERFORM_CACHE_REGEN']
@@ -237,6 +262,7 @@ final class Tests_Page_Cache extends TestCase {
 	public function test_bypass_reasons_are_aggregated_in_stats() {
 		$GLOBALS['perform_test_options']                                    = [
 			'perform_settings' => [
+				'enable_page_cache'        => true,
 				'cache_bypass_query_params' => [ 'preview_token' ],
 			],
 		];
@@ -251,7 +277,123 @@ final class Tests_Page_Cache extends TestCase {
 		$this->assertSame( 1, $GLOBALS['perform_test_options']['perform_cache_stats']['bypass_reasons']['query_key'] );
 	}
 
-	private function set_private_property( PageCache $page_cache, string $property_name, int $value ): void {
+	public function test_registers_lifecycle_hooks_even_when_page_cache_is_disabled() {
+		$page_cache = new PageCache();
+		$this->assertTrue( $page_cache->should_load() );
+		$page_cache->register();
+
+		$hooks = array_column( $GLOBALS['perform_test_actions'], 'hook' );
+		foreach ( [ 'pre_post_update', 'before_delete_post', 'transition_post_status', 'transition_comment_status', 'set_object_terms', 'edited_term', 'updated_term_meta', 'wp_update_nav_menu', 'wp_update_nav_menu_item', 'switch_theme', 'customize_save_after', 'updated_option', 'perform_cache_cleanup_event' ] as $hook ) {
+			$this->assertContains( $hook, $hooks );
+		}
+	}
+
+	public function test_targeted_purge_removes_old_post_url_but_keeps_unaffected_cache_entry() {
+		$page_cache = new PageCache();
+		$cache_dir  = $this->temporary_cache_dir();
+		$this->set_private_property( $page_cache, 'cache_dir', $cache_dir );
+		$GLOBALS['perform_test_permalinks'][7] = 'https://example.com/old-post/';
+		$page_cache->capture_post_urls_before_removal( 7 );
+		$this->write_cached_url( $page_cache, 'https://example.com/old-post/' );
+		$this->write_cached_url( $page_cache, 'https://example.com/unaffected/' );
+
+		$GLOBALS['perform_test_permalinks'][7] = 'https://example.com/new-post/';
+		$page_cache->purge_related_urls_for_deleted_post( 7 );
+
+		$this->assertFalse( $this->cache_file_exists( $page_cache, 'https://example.com/old-post/' ) );
+		$this->assertTrue( $this->cache_file_exists( $page_cache, 'https://example.com/unaffected/' ) );
+	}
+
+	public function test_removed_term_url_is_purged_with_current_post_urls() {
+		$page_cache = new PageCache();
+		$cache_dir  = $this->temporary_cache_dir();
+		$this->set_private_property( $page_cache, 'cache_dir', $cache_dir );
+		$GLOBALS['perform_test_terms_by_tt_id'][12] = (object) [ 'link' => 'https://example.com/old-term/' ];
+		$this->write_cached_url( $page_cache, 'https://example.com/old-term/' );
+
+		$page_cache->purge_related_urls_for_object_terms( 7, [], [], 'category', false, [ 12 ] );
+
+		$this->assertFalse( $this->cache_file_exists( $page_cache, 'https://example.com/old-term/' ) );
+	}
+
+	public function test_global_rotation_rejects_stale_write_and_is_scoped_to_current_blog() {
+		$page_cache = new PageCache();
+		$cache_dir  = $this->temporary_cache_dir();
+		$this->set_private_property( $page_cache, 'cache_dir', $cache_dir );
+		$GLOBALS['perform_test_options'] = [ 'perform_settings' => [ 'enable_page_cache' => true ] ];
+		$this->set_private_property( $page_cache, 'request_generation', 1 );
+		$this->set_private_property( $page_cache, 'should_write_cache', true );
+		$this->set_private_property( $page_cache, 'current_cache_key', 'stale-write' );
+		$this->set_private_property( $page_cache, 'current_url', 'https://example.com/stale-write/' );
+		$page_cache->purge_site_cache();
+		$page_cache->store_cache( '<html><body>stale</body></html>' );
+
+		$this->assertSame( 2, $GLOBALS['perform_test_options']['perform_cache_generation_1'] );
+		$this->assertFalse( file_exists( $cache_dir . 'site-1/generation-1/stale-write.html' ) );
+		$GLOBALS['perform_test_blog_id'] = 2;
+		$this->assertSame( 1, $this->invoke_private( $page_cache, 'get_cache_generation' ) );
+	}
+
+	public function test_cleanup_removes_only_a_bounded_obsolete_generation_batch() {
+		$page_cache = new PageCache();
+		$cache_dir  = $this->temporary_cache_dir();
+		$this->set_private_property( $page_cache, 'cache_dir', $cache_dir );
+		$this->set_private_property( $page_cache, 'cleanup_batch_size', 1 );
+		$GLOBALS['perform_test_options']['perform_cache_generation_1'] = 2;
+		mkdir( $cache_dir . 'site-1/generation-1/', 0777, true );
+		file_put_contents( $cache_dir . 'site-1/generation-1/one.html', 'one' );
+		file_put_contents( $cache_dir . 'site-1/generation-1/two.html', 'two' );
+
+		$page_cache->cleanup_obsolete_generations();
+
+		$this->assertCount( 1, glob( $cache_dir . 'site-1/generation-1/*' ) );
+		$this->assertSame( 'perform_cache_cleanup_event', $GLOBALS['perform_test_scheduled_single_events'][0]['hook'] );
+	}
+
+	public function test_cloudflare_global_purge_uses_tracked_urls_in_bounded_batches() {
+		$page_cache = new PageCache();
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings' => [
+				'enable_cloudflare_cache_sync' => true,
+				'cloudflare_zone_id'           => 'zone',
+				'cloudflare_api_token'         => 'token',
+			],
+			'perform_cache_cloudflare_queue_1' => [ 'https://example.com/a/', 'https://example.com/b/', 'https://example.com/c/' ],
+		];
+		$this->set_private_property( $page_cache, 'cloudflare_batch_size', 2 );
+		$page_cache->run_cloudflare_purge_batch();
+
+		$this->assertCount( 1, $GLOBALS['perform_test_remote_post_calls'] );
+		$this->assertSame( [ 'https://example.com/a/', 'https://example.com/b/' ], json_decode( $GLOBALS['perform_test_remote_post_calls'][0]['args']['body'], true )['files'] );
+		$this->assertSame( [ 'https://example.com/c/' ], $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'] );
+	}
+
+	public function test_cloudflare_failed_batch_has_bounded_retries() {
+		$page_cache = new PageCache();
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings' => [
+				'enable_cloudflare_cache_sync' => true,
+				'cloudflare_zone_id'           => 'zone',
+				'cloudflare_api_token'         => 'token',
+			],
+			'perform_cache_cloudflare_queue_1' => [ 'https://example.com/a/' ],
+		];
+		$GLOBALS['perform_test_remote_post_response'] = new WP_Error( 'request_failed', 'No route' );
+		$this->set_private_property( $page_cache, 'cloudflare_max_retries', 2 );
+
+		$page_cache->run_cloudflare_purge_batch();
+		$this->assertSame( [ 'https://example.com/a/' ], $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'] );
+		$page_cache->run_cloudflare_purge_batch();
+		$this->assertSame( [], $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'] );
+	}
+
+	public function test_manual_purge_requires_manage_options() {
+		$page_cache = new PageCache();
+		$this->expectException( RuntimeException::class );
+		$page_cache->handle_manual_purge();
+	}
+
+	private function set_private_property( PageCache $page_cache, string $property_name, $value ): void {
 		$property = new ReflectionProperty( $page_cache, $property_name );
 		$property->setAccessible( true );
 		$property->setValue( $page_cache, $value );
@@ -269,6 +411,40 @@ final class Tests_Page_Cache extends TestCase {
 		$method->setAccessible( true );
 
 		return $method->invoke( $page_cache );
+	}
+
+	private function invoke_private( PageCache $page_cache, string $method ) {
+		$reflection = new ReflectionMethod( $page_cache, $method );
+		$reflection->setAccessible( true );
+		return $reflection->invoke( $page_cache );
+	}
+
+	private function temporary_cache_dir(): string {
+		$directory = sys_get_temp_dir() . '/perform-page-cache-' . uniqid( '', true ) . '/';
+		mkdir( $directory, 0777, true );
+		return $directory;
+	}
+
+	private function write_cached_url( PageCache $page_cache, string $url ): void {
+		$key  = $this->invoke_private_with_argument( $page_cache, 'get_cache_key_for_url', $url );
+		$path = $this->invoke_private_with_argument( $page_cache, 'get_body_file_path', $key );
+		if ( ! is_dir( dirname( $path ) ) ) {
+			mkdir( dirname( $path ), 0777, true );
+		}
+		file_put_contents( $path, 'cached' );
+		file_put_contents( str_replace( '.html', '.meta.json', $path ), '{}' );
+	}
+
+	private function cache_file_exists( PageCache $page_cache, string $url ): bool {
+		$key  = $this->invoke_private_with_argument( $page_cache, 'get_cache_key_for_url', $url );
+		$path = $this->invoke_private_with_argument( $page_cache, 'get_body_file_path', $key );
+		return file_exists( $path );
+	}
+
+	private function invoke_private_with_argument( PageCache $page_cache, string $method, $argument ) {
+		$reflection = new ReflectionMethod( $page_cache, $method );
+		$reflection->setAccessible( true );
+		return $reflection->invoke( $page_cache, $argument );
 	}
 
 	private function build_sitemap_index_xml( int $child_count ): string {

--- a/tests/unit-tests/tests-page-cache.php
+++ b/tests/unit-tests/tests-page-cache.php
@@ -5,30 +5,31 @@ use Perform\Modules\Cache\PageCache;
 
 final class Tests_Page_Cache extends TestCase {
 	protected function setUp(): void {
-		$GLOBALS['perform_test_transients']       = [
+		$GLOBALS['perform_test_transients']              = [
 			'perform_cache_lock_test' => 'expected-token',
 		];
-		$GLOBALS['perform_test_options']          = [];
-		$GLOBALS['perform_test_filters']          = [];
-		$GLOBALS['perform_test_home_url']         = 'https://example.com';
-		$GLOBALS['perform_test_remote_get_map']   = [];
-		$GLOBALS['perform_test_remote_get_calls'] = [];
-		$GLOBALS['perform_test_remote_post_calls'] = [];
-		$GLOBALS['perform_test_actions']          = [];
-		$GLOBALS['perform_test_scheduled_events'] = [];
+		$GLOBALS['perform_test_options']                 = [];
+		$GLOBALS['perform_test_filters']                 = [];
+		$GLOBALS['perform_test_home_url']                = 'https://example.com';
+		$GLOBALS['perform_test_remote_get_map']          = [];
+		$GLOBALS['perform_test_remote_get_calls']        = [];
+		$GLOBALS['perform_test_remote_post_calls']       = [];
+		$GLOBALS['perform_test_actions']                 = [];
+		$GLOBALS['perform_test_scheduled_events']        = [];
 		$GLOBALS['perform_test_scheduled_single_events'] = [];
-		$GLOBALS['perform_test_permalinks']       = [];
-		$GLOBALS['perform_test_post_type_archives'] = [];
-		$GLOBALS['perform_test_taxonomies']       = [];
-		$GLOBALS['perform_test_post_terms']       = [];
-		$GLOBALS['perform_test_terms']            = [];
-		$GLOBALS['perform_test_terms_by_tt_id']   = [];
-		$GLOBALS['perform_test_comments']         = [];
-		$GLOBALS['perform_test_blog_id']          = 1;
-		$_COOKIE                                  = [];
-		$_GET                                     = [];
-		$_SERVER['REQUEST_METHOD']                = 'GET';
-		$_SERVER['REQUEST_URI']                   = '/';
+		$GLOBALS['perform_test_permalinks']              = [];
+		$GLOBALS['perform_test_post_type_archives']      = [];
+		$GLOBALS['perform_test_taxonomies']              = [];
+		$GLOBALS['perform_test_post_terms']              = [];
+		$GLOBALS['perform_test_terms']                   = [];
+		$GLOBALS['perform_test_terms_by_tt_id']          = [];
+		$GLOBALS['perform_test_comments']                = [];
+		$GLOBALS['perform_test_term_object_ids']         = [];
+		$GLOBALS['perform_test_blog_id']                 = 1;
+		$_COOKIE                   = [];
+		$_GET                      = [];
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['REQUEST_URI']    = '/';
 		unset( $_SERVER['HTTP_X_PERFORM_CACHE_REGEN'] );
 	}
 
@@ -52,7 +53,10 @@ final class Tests_Page_Cache extends TestCase {
 			$GLOBALS['perform_test_terms'],
 			$GLOBALS['perform_test_terms_by_tt_id'],
 			$GLOBALS['perform_test_comments'],
+			$GLOBALS['perform_test_term_object_ids'],
 			$GLOBALS['perform_test_blog_id'],
+			$GLOBALS['perform_test_current_user_can'],
+			$GLOBALS['perform_test_nonce_valid'],
 			$_SERVER['REQUEST_METHOD'],
 			$_SERVER['REQUEST_URI'],
 			$_SERVER['HTTP_X_PERFORM_CACHE_REGEN']
@@ -155,6 +159,7 @@ final class Tests_Page_Cache extends TestCase {
 	public function test_seed_preload_queue_keeps_existing_queue_when_sitemap_fetch_fails() {
 		$GLOBALS['perform_test_options']        = [
 			'perform_settings'            => [
+				'enable_page_cache'    => true,
 				'enable_cache_preload' => true,
 			],
 			'perform_cache_preload_queue' => [
@@ -262,7 +267,7 @@ final class Tests_Page_Cache extends TestCase {
 	public function test_bypass_reasons_are_aggregated_in_stats() {
 		$GLOBALS['perform_test_options']                                    = [
 			'perform_settings' => [
-				'enable_page_cache'        => true,
+				'enable_page_cache'         => true,
 				'cache_bypass_query_params' => [ 'preview_token' ],
 			],
 		];
@@ -286,6 +291,17 @@ final class Tests_Page_Cache extends TestCase {
 		foreach ( [ 'pre_post_update', 'before_delete_post', 'transition_post_status', 'transition_comment_status', 'set_object_terms', 'edited_term', 'updated_term_meta', 'wp_update_nav_menu', 'wp_update_nav_menu_item', 'switch_theme', 'customize_save_after', 'updated_option', 'perform_cache_cleanup_event' ] as $hook ) {
 			$this->assertContains( $hook, $hooks );
 		}
+	}
+
+	public function test_disabled_cache_does_not_start_stats_or_preload_work() {
+		$page_cache                      = new PageCache();
+		$GLOBALS['perform_test_options'] = [ 'perform_settings' => [ 'enable_cache_preload' => true ] ];
+		$page_cache->maybe_serve_cache();
+		$page_cache->maybe_schedule_events();
+		$page_cache->seed_preload_queue_from_sitemap_and_logs();
+
+		$this->assertSame( 0.0, $this->get_private_property( $page_cache, 'request_start' ) );
+		$this->assertSame( [], $GLOBALS['perform_test_scheduled_single_events'] );
 	}
 
 	public function test_targeted_purge_removes_old_post_url_but_keeps_unaffected_cache_entry() {
@@ -314,6 +330,23 @@ final class Tests_Page_Cache extends TestCase {
 		$page_cache->purge_related_urls_for_object_terms( 7, [], [], 'category', false, [ 12 ] );
 
 		$this->assertFalse( $this->cache_file_exists( $page_cache, 'https://example.com/old-term/' ) );
+	}
+
+	public function test_term_metadata_purges_bounded_affected_post_urls() {
+		$page_cache = new PageCache();
+		$cache_dir  = $this->temporary_cache_dir();
+		$this->set_private_property( $page_cache, 'cache_dir', $cache_dir );
+		$GLOBALS['perform_test_term_object_ids'][4] = [ 8 ];
+		$GLOBALS['perform_test_terms'][4]           = (object) [
+			'taxonomy' => 'category',
+			'link'     => 'https://example.com/term/',
+		];
+		$GLOBALS['perform_test_permalinks'][8]      = 'https://example.com/affected-post/';
+		$this->write_cached_url( $page_cache, 'https://example.com/affected-post/' );
+
+		$page_cache->purge_related_urls_for_term_meta( 1, 4 );
+
+		$this->assertFalse( $this->cache_file_exists( $page_cache, 'https://example.com/affected-post/' ) );
 	}
 
 	public function test_global_rotation_rejects_stale_write_and_is_scoped_to_current_blog() {
@@ -350,10 +383,25 @@ final class Tests_Page_Cache extends TestCase {
 		$this->assertSame( 'perform_cache_cleanup_event', $GLOBALS['perform_test_scheduled_single_events'][0]['hook'] );
 	}
 
-	public function test_cloudflare_global_purge_uses_tracked_urls_in_bounded_batches() {
+	public function test_cleanup_removes_legacy_root_cache_files_only() {
 		$page_cache = new PageCache();
+		$cache_dir  = $this->temporary_cache_dir();
+		$this->set_private_property( $page_cache, 'cache_dir', $cache_dir );
+		file_put_contents( $cache_dir . 'legacy.html', 'legacy' );
+		file_put_contents( $cache_dir . 'legacy.meta.json', '{}' );
+		file_put_contents( $cache_dir . 'keep.txt', 'keep' );
+
+		$page_cache->cleanup_obsolete_generations();
+
+		$this->assertFileDoesNotExist( $cache_dir . 'legacy.html' );
+		$this->assertFileDoesNotExist( $cache_dir . 'legacy.meta.json' );
+		$this->assertFileExists( $cache_dir . 'keep.txt' );
+	}
+
+	public function test_cloudflare_global_purge_uses_tracked_urls_in_bounded_batches() {
+		$page_cache                      = new PageCache();
 		$GLOBALS['perform_test_options'] = [
-			'perform_settings' => [
+			'perform_settings'                 => [
 				'enable_cloudflare_cache_sync' => true,
 				'cloudflare_zone_id'           => 'zone',
 				'cloudflare_api_token'         => 'token',
@@ -361,17 +409,21 @@ final class Tests_Page_Cache extends TestCase {
 			'perform_cache_cloudflare_queue_1' => [ 'https://example.com/a/', 'https://example.com/b/', 'https://example.com/c/' ],
 		];
 		$this->set_private_property( $page_cache, 'cloudflare_batch_size', 2 );
+		$GLOBALS['perform_test_remote_post_response'] = [
+			'response' => [ 'code' => 200 ],
+			'body'     => '{"success":true}',
+		];
 		$page_cache->run_cloudflare_purge_batch();
 
 		$this->assertCount( 1, $GLOBALS['perform_test_remote_post_calls'] );
 		$this->assertSame( [ 'https://example.com/a/', 'https://example.com/b/' ], json_decode( $GLOBALS['perform_test_remote_post_calls'][0]['args']['body'], true )['files'] );
-		$this->assertSame( [ 'https://example.com/c/' ], $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'] );
+		$this->assertSame( [ 'https://example.com/c/' ], $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0]['urls'] );
 	}
 
 	public function test_cloudflare_failed_batch_has_bounded_retries() {
-		$page_cache = new PageCache();
-		$GLOBALS['perform_test_options'] = [
-			'perform_settings' => [
+		$page_cache                                   = new PageCache();
+		$GLOBALS['perform_test_options']              = [
+			'perform_settings'                 => [
 				'enable_cloudflare_cache_sync' => true,
 				'cloudflare_zone_id'           => 'zone',
 				'cloudflare_api_token'         => 'token',
@@ -382,15 +434,23 @@ final class Tests_Page_Cache extends TestCase {
 		$this->set_private_property( $page_cache, 'cloudflare_max_retries', 2 );
 
 		$page_cache->run_cloudflare_purge_batch();
-		$this->assertSame( [ 'https://example.com/a/' ], $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'] );
+		$this->assertSame( [ 'https://example.com/a/' ], $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0]['urls'] );
 		$page_cache->run_cloudflare_purge_batch();
-		$this->assertSame( [], $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'] );
+		$this->assertTrue( $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0]['failed'] );
 	}
 
 	public function test_manual_purge_requires_manage_options() {
 		$page_cache = new PageCache();
 		$this->expectException( RuntimeException::class );
 		$page_cache->handle_manual_purge();
+	}
+
+	public function test_manual_purge_authorization_requires_valid_nonce() {
+		$page_cache                               = new PageCache();
+		$GLOBALS['perform_test_current_user_can'] = [ 'manage_options' => true ];
+		$GLOBALS['perform_test_nonce_valid']      = true;
+
+		$this->assertTrue( $this->invoke_private( $page_cache, 'is_manual_purge_authorized' ) );
 	}
 
 	private function set_private_property( PageCache $page_cache, string $property_name, $value ): void {

--- a/tests/unit-tests/tests-page-cache.php
+++ b/tests/unit-tests/tests-page-cache.php
@@ -450,6 +450,128 @@ final class Tests_Page_Cache extends TestCase {
 		$this->assertSame( [ 'https://example.com/c/' ], $GLOBALS['perform_test_options']['perform_cache_manifest_1_1_1'] );
 	}
 
+	public function test_metadata_inventory_drains_in_bounded_batches_without_tokens() {
+		$page_cache = new PageCache();
+		$cache_dir  = $this->temporary_cache_dir();
+		$this->set_private_property( $page_cache, 'cache_dir', $cache_dir );
+		$this->set_private_property( $page_cache, 'cloudflare_batch_size', 1 );
+		$GLOBALS['perform_test_options']['perform_settings'] = [
+			'enable_cloudflare_cache_sync' => true,
+			'cloudflare_zone_id'           => 'zone',
+			'cloudflare_api_token'         => 'token',
+		];
+		$directory = $cache_dir . 'site-1/generation-1/';
+		mkdir( $directory, 0777, true );
+		file_put_contents( $directory . 'bad.meta.json', '{not-json' );
+		foreach ( [ 'a', 'b', 'c' ] as $slug ) {
+			file_put_contents( $directory . $slug . '.meta.json', wp_json_encode( [ 'url' => 'https://example.com/' . $slug . '/' ] ) );
+		}
+		$GLOBALS['perform_test_remote_post_response'] = [
+			'response' => [ 'code' => 200 ],
+			'body'     => '{"success":true}',
+		];
+
+		$this->invoke_private_with_arguments( $page_cache, 'queue_cloudflare_tracked_urls', [ null, 1 ] );
+		$record = $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0];
+		$this->assertSame( 'metadata', $record['source'] );
+		$this->assertArrayNotHasKey( 'cloudflare_api_token', $record );
+		$this->assertStringNotContainsString( 'token', wp_json_encode( $record ) );
+
+		for ( $run = 0; $run < 5; $run++ ) {
+			$page_cache->run_cloudflare_purge_batch();
+		}
+
+		$this->assertSame(
+			[ 'https://example.com/a/', 'https://example.com/b/', 'https://example.com/c/' ],
+			array_map(
+				static function ( $call ) {
+					return json_decode( $call['args']['body'], true )['files'][0];
+				},
+				$GLOBALS['perform_test_remote_post_calls']
+			)
+		);
+		$this->assertSame( [], $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'] );
+	}
+
+	public function test_cleanup_waits_for_metadata_inventory_then_removes_retired_files() {
+		$page_cache = new PageCache();
+		$cache_dir  = $this->temporary_cache_dir();
+		$this->set_private_property( $page_cache, 'cache_dir', $cache_dir );
+		$GLOBALS['perform_test_options']['perform_cache_generation_1'] = 2;
+		mkdir( $cache_dir . 'site-1/generation-1/', 0777, true );
+		file_put_contents( $cache_dir . 'site-1/generation-1/retired.meta.json', '{}' );
+		$GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'] = [
+			[
+				'source'     => 'metadata',
+				'generation' => 1,
+				'cursor'     => 0,
+				'failed'     => false,
+			],
+		];
+
+		$page_cache->cleanup_obsolete_generations();
+		$this->assertFileExists( $cache_dir . 'site-1/generation-1/retired.meta.json' );
+		$this->assertSame( 'perform_cache_cleanup_event', $GLOBALS['perform_test_scheduled_single_events'][0]['hook'] );
+
+		$GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'] = [];
+		$page_cache->cleanup_obsolete_generations();
+		$this->assertFileDoesNotExist( $cache_dir . 'site-1/generation-1/retired.meta.json' );
+	}
+
+	public function test_empty_metadata_source_is_retired_without_rescheduling() {
+		$page_cache                      = new PageCache();
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings'                 => [
+				'enable_cloudflare_cache_sync' => true,
+				'cloudflare_zone_id'           => 'zone',
+				'cloudflare_api_token'         => 'token',
+			],
+			'perform_cache_cloudflare_queue_1' => [
+				[
+					'source'      => 'metadata',
+					'generation'  => 99,
+					'cursor'      => 0,
+					'zone_id'     => 'zone',
+					'fingerprint' => md5( 'zone|token' ),
+					'attempts'    => 0,
+					'failed'      => false,
+				],
+			],
+		];
+
+		$page_cache->run_cloudflare_purge_batch();
+		$this->assertSame( [], $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'] );
+		$this->assertSame( [], $GLOBALS['perform_test_scheduled_single_events'] );
+	}
+
+	public function test_source_credential_mismatch_is_visible_and_nonfatal() {
+		$page_cache                      = new PageCache();
+		$GLOBALS['perform_test_options'] = [
+			'perform_settings'                 => [
+				'enable_cloudflare_cache_sync' => true,
+				'cloudflare_zone_id'           => 'new-zone',
+				'cloudflare_api_token'         => 'new-token',
+			],
+			'perform_cache_cloudflare_queue_1' => [
+				[
+					'source'      => 'manifest',
+					'generation'  => 1,
+					'chunk'       => 0,
+					'offset'      => 0,
+					'zone_id'     => 'old-zone',
+					'fingerprint' => md5( 'old-zone|old-token' ),
+					'attempts'    => 0,
+					'failed'      => false,
+				],
+			],
+			'perform_cache_manifest_1_1_0'     => [ 'https://example.com/a/' ],
+		];
+
+		$page_cache->run_cloudflare_purge_batch();
+		$this->assertTrue( $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0]['failed'] );
+		$this->assertSame( 1, $GLOBALS['perform_test_options']['perform_cache_cloudflare_credential_residual_1'] );
+	}
+
 	public function test_manual_purge_requires_manage_options() {
 		$page_cache = new PageCache();
 		$this->expectException( RuntimeException::class );
@@ -516,6 +638,12 @@ final class Tests_Page_Cache extends TestCase {
 		$reflection = new ReflectionMethod( $page_cache, $method );
 		$reflection->setAccessible( true );
 		return $reflection->invoke( $page_cache, $argument );
+	}
+
+	private function invoke_private_with_arguments( PageCache $page_cache, string $method, array $arguments ) {
+		$reflection = new ReflectionMethod( $page_cache, $method );
+		$reflection->setAccessible( true );
+		return $reflection->invokeArgs( $page_cache, $arguments );
 	}
 
 	private function build_sitemap_index_xml( int $child_count ): string {

--- a/tests/unit-tests/tests-page-cache.php
+++ b/tests/unit-tests/tests-page-cache.php
@@ -439,6 +439,17 @@ final class Tests_Page_Cache extends TestCase {
 		$this->assertTrue( $GLOBALS['perform_test_options']['perform_cache_cloudflare_queue_1'][0]['failed'] );
 	}
 
+	public function test_manifest_chunks_keep_urls_beyond_the_chunk_limit() {
+		$page_cache = new PageCache();
+		$this->set_private_property( $page_cache, 'manifest_chunk_size', 2 );
+		$this->invoke_private_with_argument( $page_cache, 'track_cached_url', 'https://example.com/a/' );
+		$this->invoke_private_with_argument( $page_cache, 'track_cached_url', 'https://example.com/b/' );
+		$this->invoke_private_with_argument( $page_cache, 'track_cached_url', 'https://example.com/c/' );
+
+		$this->assertSame( [ 'https://example.com/a/', 'https://example.com/b/' ], $GLOBALS['perform_test_options']['perform_cache_manifest_1_1_0'] );
+		$this->assertSame( [ 'https://example.com/c/' ], $GLOBALS['perform_test_options']['perform_cache_manifest_1_1_1'] );
+	}
+
 	public function test_manual_purge_requires_manage_options() {
 		$page_cache = new PageCache();
 		$this->expectException( RuntimeException::class );


### PR DESCRIPTION
## Summary
- keep the page-cache lifecycle module registered while frontend reads/writes remain gated by the setting
- invalidate known post, status, comment, term, and removed-term URLs; rotate a per-site cache generation for global presentation/settings changes
- add bounded retired-generation cleanup, tracked URL Cloudflare batches with bounded retries, and a nonce/capability-protected admin purge

## Validation
- PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.8
Configuration: /Users/mehulgohil/Documents/Codex/2026-07-08/aculect-cto-control/perform-issue-197-worker/phpunit.xml

.....................................................             53 / 53 (100%)

Time: 00:00.016, Memory: 6.00 MB

OK (53 tests, 128 assertions)
- PHP 8.4.8 | 10 parallel jobs
............................................................ 60/62 ( 96%)
..                                                           62/62 (100%)


Checked 62 files in 0.6 seconds
No syntax error found
- 
 [OK] No errors                                                                 
- No syntax errors detected in src/Modules/Cache/PageCache.php
No syntax errors detected in tests/bootstrap.php
No syntax errors detected in tests/unit-tests/tests-page-cache.php
- scoped PHPCS reported no errors (warnings only); repository-wide 
FILE: ...cto-control/perform-issue-197-worker/tests/unit-tests/tests-page-cache.php
--------------------------------------------------------------------------------
FOUND 0 ERRORS AND 27 WARNINGS AFFECTING 27 LINES
--------------------------------------------------------------------------------
   8 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 14 spaces but found 7 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  11 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 17 spaces but found 10 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  12 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 17 spaces but found 10 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  13 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 16 spaces but found 9 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  14 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 10 spaces but found 3 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  15 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 8 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  16 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 7 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  17 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 17 spaces but found 10 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  18 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 8 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  20 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 14 spaces but found 7 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  21 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 6 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  22 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 14 spaces but found 7 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  23 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 14 spaces but found 7 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  24 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 19 spaces but found 12 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  25 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 10 spaces but found 3 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  26 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 16 spaces but found 9 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  27 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 17 spaces but found 10 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  28 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 19 spaces but found 34 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  29 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 22 spaces but found 37 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  30 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 1 space but found 16 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  31 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 4 spaces but found 19 spaces
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 265 | WARNING | [x] Array double arrow not aligned correctly; expected 9
     |         |     space(s) between "'enable_page_cache'" and double arrow,
     |         |     but found 8.
     |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
 354 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 22 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 356 | WARNING | [x] Array double arrow not aligned correctly; expected 17
     |         |     space(s) between "'perform_settings'" and double arrow,
     |         |     but found 1.
     |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
 372 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 35 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 373 | WARNING | [x] Equals sign not aligned with surrounding assignments;
     |         |     expected 14 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 374 | WARNING | [x] Array double arrow not aligned correctly; expected 17
     |         |     space(s) between "'perform_settings'" and double arrow,
     |         |     but found 1.
     |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 27 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...control/perform-issue-197-worker/tests/unit-tests/tests-url-normalizer.php
--------------------------------------------------------------------------------
FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 3 LINES
--------------------------------------------------------------------------------
 17 | WARNING | [x] Equals sign not aligned with surrounding assignments;
    |         |     expected 8 spaces but found 1 space
    |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 24 | WARNING | [x] Equals sign not aligned with surrounding assignments;
    |         |     expected 6 spaces but found 1 space
    |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 25 | WARNING | [x] Equals sign not aligned with surrounding assignments;
    |         |     expected 6 spaces but found 1 space
    |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...ulect-cto-control/perform-issue-197-worker/tests/e2e/perform-smoke.spec.js
--------------------------------------------------------------------------------
FOUND 23 ERRORS AFFECTING 21 LINES
--------------------------------------------------------------------------------
 11 | ERROR | [x] Space before opening parenthesis of function call prohibited
    |       |     (PEAR.Functions.FunctionCallSignature.SpaceBeforeOpenBracket)
 30 | ERROR | [x] Opening parenthesis of a multi-line function call must be the
    |       |     last content on the line
    |       |     (PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket)
 32 | ERROR | [x] Multi-line function call not indented correctly; expected 12
    |       |     spaces but found 4
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 33 | ERROR | [x] Multi-line function call not indented correctly; expected 12
    |       |     spaces but found 4
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 34 | ERROR | [x] Empty lines are not allowed in multi-line function calls
    |       |     (PEAR.Functions.FunctionCallSignature.EmptyLine)
 35 | ERROR | [x] Multi-line function call not indented correctly; expected 12
    |       |     spaces but found 4
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 36 | ERROR | [x] Multi-line function call not indented correctly; expected 12
    |       |     spaces but found 4
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 37 | ERROR | [x] Multi-line function call not indented correctly; expected 12
    |       |     spaces but found 4
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 38 | ERROR | [x] Multi-line function call not indented correctly; expected 12
    |       |     spaces but found 4
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 39 | ERROR | [x] Empty lines are not allowed in multi-line function calls
    |       |     (PEAR.Functions.FunctionCallSignature.EmptyLine)
 40 | ERROR | [x] Multi-line function call not indented correctly; expected 12
    |       |     spaces but found 4
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 41 | ERROR | [x] Multi-line function call not indented correctly; expected 12
    |       |     spaces but found 4
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 42 | ERROR | [x] Multi-line function call not indented correctly; expected 12
    |       |     spaces but found 4
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 43 | ERROR | [x] Multi-line function call not indented correctly; expected 12
    |       |     spaces but found 4
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 44 | ERROR | [x] Empty lines are not allowed in multi-line function calls
    |       |     (PEAR.Functions.FunctionCallSignature.EmptyLine)
 45 | ERROR | [x] Multi-line function call not indented correctly; expected 12
    |       |     spaces but found 4
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 46 | ERROR | [x] Multi-line function call not indented correctly; expected 12
    |       |     spaces but found 4
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 47 | ERROR | [x] Multi-line function call not indented correctly; expected 12
    |       |     spaces but found 4
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 48 | ERROR | [x] Multi-line function call not indented correctly; expected 12
    |       |     spaces but found 4
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 49 | ERROR | [x] Multi-line function call not indented correctly; expected 12
    |       |     spaces but found 4
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 50 | ERROR | [x] Line indented incorrectly; expected at least 2 tabs, found 0
    |       |     (Generic.WhiteSpace.ScopeIndent.Incorrect)
 50 | ERROR | [x] Multi-line function call not indented correctly; expected 8
    |       |     spaces but found 0
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 50 | ERROR | [x] Closing parenthesis of a multi-line function call must be on
    |       |     a line by itself
    |       |     (PEAR.Functions.FunctionCallSignature.CloseBracketLine)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 23 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...26-07-08/aculect-cto-control/perform-issue-197-worker/playwright.config.js
--------------------------------------------------------------------------------
FOUND 4 ERRORS AFFECTING 4 LINES
--------------------------------------------------------------------------------
  5 | ERROR | [x] Opening parenthesis of a multi-line function call must be the
    |       |     last content on the line
    |       |     (PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket)
 15 | ERROR | [x] Expected 1 space before ":"; 0 found
    |       |     (WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore)
 28 | ERROR | [x] Line indented incorrectly; expected 1 tabs, found 2
    |       |     (Generic.WhiteSpace.ScopeIndent.IncorrectExact)
 30 | ERROR | [x] Closing parenthesis of a multi-line function call must be on
    |       |     a line by itself
    |       |     (PEAR.Functions.FunctionCallSignature.CloseBracketLine)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 4 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: .../2026-07-08/aculect-cto-control/perform-issue-197-worker/webpack.config.js
--------------------------------------------------------------------------------
FOUND 21 ERRORS AND 7 WARNINGS AFFECTING 17 LINES
--------------------------------------------------------------------------------
  1 | WARNING | [x] Equals sign not aligned with surrounding assignments;
    |         |     expected 19 spaces but found 1 space
    |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  2 | WARNING | [x] Equals sign not aligned with surrounding assignments;
    |         |     expected 10 spaces but found 1 space
    |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  3 | WARNING | [x] Equals sign not aligned with surrounding assignments;
    |         |     expected 6 spaces but found 1 space
    |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  4 | WARNING | [x] Equals sign not aligned with surrounding assignments;
    |         |     expected 9 spaces but found 1 space
    |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  6 | WARNING | [x] Equals sign not aligned with surrounding assignments;
    |         |     expected 3 spaces but found 1 space
    |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  7 | WARNING | [x] Equals sign not aligned with surrounding assignments;
    |         |     expected 18 spaces but found 1 space
    |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 10 | WARNING | [x] Equals sign not aligned with surrounding assignments;
    |         |     expected 9 spaces but found 1 space
    |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 32 | ERROR   | [x] Opening parenthesis of a multi-line function call must be
    |         |     the last content on the line
    |         |     (PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket)
 34 | ERROR   | [x] Closing parenthesis of a multi-line function call must be
    |         |     on a line by itself
    |         |     (PEAR.Functions.FunctionCallSignature.CloseBracketLine)
 36 | ERROR   | [x] Opening parenthesis of a multi-line function call must be
    |         |     the last content on the line
    |         |     (PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket)
 38 | ERROR   | [x] Closing parenthesis of a multi-line function call must be
    |         |     on a line by itself
    |         |     (PEAR.Functions.FunctionCallSignature.CloseBracketLine)
 40 | ERROR   | [x] Opening parenthesis of a multi-line function call must be
    |         |     the last content on the line
    |         |     (PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket)
 45 | ERROR   | [x] Line indented incorrectly; expected 3 tabs, found 4
    |         |     (Generic.WhiteSpace.ScopeIndent.IncorrectExact)
 47 | ERROR   | [x] Closing parenthesis of a multi-line function call must be
    |         |     on a line by itself
    |         |     (PEAR.Functions.FunctionCallSignature.CloseBracketLine)
 54 | ERROR   | [x] Expected 1 space after "/"; 0 found
    |         |     (WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter)
 54 | ERROR   | [x] Expected 1 space before "?"; 0 found
    |         |     (WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore)
 54 | ERROR   | [x] Expected 1 space after "?"; 0 found
    |         |     (WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter)
 54 | ERROR   | [x] Expected 1 space before "|"; 0 found
    |         |     (WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore)
 54 | ERROR   | [x] Expected 1 space after "|"; 0 found
    |         |     (WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter)
 54 | ERROR   | [x] Expected 1 space before "|"; 0 found
    |         |     (WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore)
 54 | ERROR   | [x] Expected 1 space after "|"; 0 found
    |         |     (WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter)
 54 | ERROR   | [x] Expected 1 space before "|"; 0 found
    |         |     (WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore)
 54 | ERROR   | [x] Expected 1 space after "|"; 0 found
    |         |     (WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter)
 54 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found
    |         |     (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 54 | ERROR   | [x] Expected 1 space before "/"; 0 found
    |         |     (WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore)
 54 | ERROR   | [x] Expected 1 space after "/"; 0 found
    |         |     (WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter)
 57 | ERROR   | [x] Opening parenthesis of a multi-line function call must be
    |         |     the last content on the line
    |         |     (PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket)
 72 | ERROR   | [x] Closing parenthesis of a multi-line function call must be
    |         |     on a line by itself
    |         |     (PEAR.Functions.FunctionCallSignature.CloseBracketLine)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 28 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...x/2026-07-08/aculect-cto-control/perform-issue-197-worker/wp-textdomain.js
--------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 2 LINES
--------------------------------------------------------------------------------
 3 | ERROR | [x] Opening parenthesis of a multi-line function call must be the
   |       |     last content on the line
   |       |     (PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket)
 3 | ERROR | [x] Only one argument is allowed per line in a multi-line function
   |       |     call (PEAR.Functions.FunctionCallSignature.MultipleArguments)
 6 | ERROR | [x] Closing parenthesis of a multi-line function call must be on a
   |       |     line by itself
   |       |     (PEAR.Functions.FunctionCallSignature.CloseBracketLine)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...odex/2026-07-08/aculect-cto-control/perform-issue-197-worker/uninstall.php
--------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
--------------------------------------------------------------------------------
 21 | WARNING | [x] Short array syntax must be used to define arrays
    |         |     (Generic.Arrays.DisallowLongArraySyntax.Found)
 47 | WARNING | [x] Short array syntax must be used to define arrays
    |         |     (Generic.Arrays.DisallowLongArraySyntax.Found)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...7-08/aculect-cto-control/perform-issue-197-worker/src/Includes/Filters.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 16 | ERROR | [x] Function closing brace must go on the next line following the
    |       |     body; found 1 blank lines before brace
    |       |     (PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...ulect-cto-control/perform-issue-197-worker/src/Modules/Cache/PageCache.php
--------------------------------------------------------------------------------
FOUND 0 ERRORS AND 10 WARNINGS AFFECTING 10 LINES
--------------------------------------------------------------------------------
  262 | WARNING | [x] Equals sign not aligned with surrounding assignments;
      |         |     expected 8 spaces but found 7 spaces
      |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  263 | WARNING | [x] Equals sign not aligned with surrounding assignments;
      |         |     expected 2 spaces but found 1 space
      |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  265 | WARNING | [x] Equals sign not aligned with surrounding assignments;
      |         |     expected 11 spaces but found 10 spaces
      |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 1718 | WARNING | [x] Equals sign not aligned with surrounding assignments;
      |         |     expected 4 spaces but found 2 spaces
      |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 1719 | WARNING | [x] Equals sign not aligned with surrounding assignments;
      |         |     expected 3 spaces but found 1 space
      |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 1720 | WARNING | [x] Equals sign not aligned with surrounding assignments;
      |         |     expected 3 spaces but found 1 space
      |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 1742 | WARNING | [x] Equals sign not aligned with surrounding assignments;
      |         |     expected 3 spaces but found 4 spaces
      |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 1743 | WARNING | [x] Equals sign not aligned with surrounding assignments;
      |         |     expected 7 spaces but found 8 spaces
      |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 1744 | WARNING | [x] Equals sign not aligned with surrounding assignments;
      |         |     expected 1 space but found 2 spaces
      |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 1745 | WARNING | [x] Equals sign not aligned with surrounding assignments;
      |         |     expected 5 spaces but found 6 spaces
      |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 10 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...t-cto-control/perform-issue-197-worker/src/Modules/Cache/UrlNormalizer.php
--------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
--------------------------------------------------------------------------------
 42 | WARNING | [x] Equals sign not aligned with surrounding assignments;
    |         |     expected 7 spaces but found 1 space
    |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...ct-cto-control/perform-issue-197-worker/src/Modules/Basic/DisableEmoji.php
--------------------------------------------------------------------------------
FOUND 35 ERRORS AFFECTING 31 LINES
--------------------------------------------------------------------------------
 15 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 19 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 21 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 22 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 23 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 24 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 27 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 28 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 29 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 30 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 32 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 33 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 34 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 36 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 37 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 38 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 39 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 41 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 42 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 43 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 44 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 46 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 47 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 49 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 49 | ERROR | [ ] Variable "$relationType" is not in valid snake_case format,
    |       |     try "$relation_type"
    |       |     (WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase)
 50 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 50 | ERROR | [ ] Variable "$relationType" is not in valid snake_case format,
    |       |     try "$relation_type"
    |       |     (WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase)
 51 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 51 | ERROR | [ ] Variable "$svgUrl" is not in valid snake_case format, try
    |       |     "$svg_url"
    |       |     (WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase)
 52 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 52 | ERROR | [ ] Variable "$svgUrl" is not in valid snake_case format, try
    |       |     "$svg_url"
    |       |     (WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase)
 53 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 55 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 56 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 31 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...to-control/perform-issue-197-worker/src/Modules/Basic/DisableDashicons.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...cto-control/perform-issue-197-worker/src/Modules/Basic/DisableRssFeeds.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...ect-cto-control/perform-issue-197-worker/src/Modules/Basic/DnsPrefetch.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...t-cto-control/perform-issue-197-worker/src/Modules/Basic/DisableEmbeds.php
--------------------------------------------------------------------------------
FOUND 30 ERRORS AFFECTING 30 LINES
--------------------------------------------------------------------------------
 15 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 19 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 21 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 22 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 23 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 25 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 27 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 28 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 29 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 31 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 32 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 33 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 35 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 36 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 38 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 39 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 40 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 41 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 43 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 44 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 45 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 47 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 48 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 49 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 50 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 51 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 52 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 54 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 55 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 30 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...-control/perform-issue-197-worker/src/Modules/Basic/RemoveQueryStrings.php
--------------------------------------------------------------------------------
FOUND 14 ERRORS AFFECTING 14 LINES
--------------------------------------------------------------------------------
 15 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 19 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 21 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 22 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 23 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 24 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 25 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 27 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 28 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 29 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 31 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 32 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 33 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 34 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 14 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...t-cto-control/perform-issue-197-worker/src/Modules/Basic/HideWpVersion.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...control/perform-issue-197-worker/src/Modules/Basic/RemoveJqueryMigrate.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...ntrol/perform-issue-197-worker/src/Modules/Basic/RemoveWlwmanifestLink.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...to-control/perform-issue-197-worker/src/Modules/Basic/DisableFeedLinks.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...erform-issue-197-worker/src/Modules/Basic/DisablePasswordStrengthMeter.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...lect-cto-control/perform-issue-197-worker/src/Modules/Basic/Preconnect.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...t-cto-control/perform-issue-197-worker/src/Modules/Basic/RemoveRsdLink.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...-control/perform-issue-197-worker/src/Modules/Basic/LimitPostRevisions.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...-control/perform-issue-197-worker/src/Modules/Basic/RemoveRestApiLinks.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...cto-control/perform-issue-197-worker/src/Modules/Basic/RemoveShortlink.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...culect-cto-control/perform-issue-197-worker/src/Modules/AbstractModule.php
--------------------------------------------------------------------------------
FOUND 54 ERRORS AFFECTING 54 LINES
--------------------------------------------------------------------------------
 16 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 20 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 21 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 22 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 23 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 24 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 25 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 27 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 28 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 29 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 30 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 31 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 32 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 33 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 35 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 36 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 37 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 38 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 39 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 40 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 41 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 42 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 44 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 45 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 46 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 47 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 48 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 49 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 50 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 51 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 52 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 54 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 55 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 57 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 58 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 59 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 60 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 61 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 62 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 63 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 64 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 65 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 66 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 68 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 69 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 70 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 72 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 73 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 75 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 76 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 77 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 78 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 79 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 80 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 54 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------


FILE: ...ulect-cto-control/perform-issue-197-worker/src/Modules/ModuleInterface.php
--------------------------------------------------------------------------------
FOUND 18 ERRORS AFFECTING 18 LINES
--------------------------------------------------------------------------------
 14 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 18 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 19 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 20 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 21 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 22 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 23 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 24 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 25 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 26 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 28 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 29 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 30 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 31 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 32 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 33 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 34 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 35 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 18 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------

Time: 923ms; Memory: 30MB remains blocked by pre-existing errors in unrelated JS/PHP files

## Proof
Focused PHPUnit lifecycle coverage verifies hook registration, targeted old-URL/removed-term invalidation, unaffected cache retention, stale-generation write rejection, bounded cleanup, Cloudflare batching/retries, manual-purge authorization, and multisite generation isolation.

Fixes #197