### PR TITLE
Move Cache Stats into Perform settings tabs

### DIFF
--- a/assets/src/css/admin/settings.css
+++ b/assets/src/css/admin/settings.css
@@ -21,11 +21,24 @@
 }
 
 .perform-settings-tab-panel {
-	background-color: var(--bg-color);
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 	margin-bottom: 20px;
 }
 
+.perform-settings-tab-panel .components-tab-panel__tabs {
+	overflow-x: auto;
+	background-color: var(--bg-color);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+	scrollbar-width: thin;
+}
+
+.perform-settings-tab-panel .components-tab-panel__tabs-item {
+	flex: 0 0 auto;
+}
+
+.perform-settings-tab-panel .components-tab-panel__tabs-item:focus-visible {
+	outline: 2px solid #2271b1;
+	outline-offset: -2px;
+}
 
 .perform-card-title,
 .perform-card-description {
@@ -34,6 +47,43 @@
 
 .perform-settings-content {
     padding: 0 20px;
+}
+
+.perform-cache-stats-container {
+	max-width: 1200px;
+}
+
+.perform-cache-stats h2 {
+	margin-top: 0;
+}
+
+.perform-cache-stats form {
+	margin: 16px 0;
+}
+
+.perform-cache-stats .widefat {
+	display: table;
+	width: 100%;
+	max-width: 1200px;
+	margin-bottom: 24px;
+}
+
+.perform-cache-stats__summary {
+	max-width: 900px !important;
+}
+
+@media screen and (max-width: 782px) {
+
+	.perform-settings-page {
+		margin-left: -10px;
+	}
+
+	.perform-settings-header,
+	.perform-settings-content {
+		padding-right: 12px;
+		padding-left: 12px;
+	}
+
 }
 
 

--- a/assets/src/js/admin/SettingsApp.jsx
+++ b/assets/src/js/admin/SettingsApp.jsx
@@ -10,6 +10,11 @@ const SETTINGS_FIELDS = SETTINGS.fields || {};
 const SAVED_SETTINGS = SETTINGS.saved || {};
 const INITIAL_DIAGNOSTICS = SETTINGS.diagnostics || {};
 const DASHBOARD = SETTINGS.dashboard || {};
+const TAB_KEYS = [ 'dashboard', ...Object.keys( SETTINGS_TABS ) ];
+
+const normalizeTab = ( tab ) => ( TAB_KEYS.includes( tab ) ? tab : 'dashboard' );
+
+const getTabFromUrl = () => normalizeTab( new URL( window.location.href ).searchParams.get( 'tab' ) || 'dashboard' );
 
 const SettingsApp = () => {
 	const tabs = SETTINGS_TABS;
@@ -39,8 +44,21 @@ const SettingsApp = () => {
 	const [ saving, setSaving ] = useState( false );
 	const [ message, setMessage ] = useState( null );
 	const [ diagnostics, setDiagnostics ] = useState( INITIAL_DIAGNOSTICS );
-	const [ activeTab, setActiveTab ] = useState( 'dashboard' );
+	const [ activeTab, setActiveTab ] = useState( () => normalizeTab( SETTINGS.activeTab ) );
 	const messageTimerRef = useRef( null );
+
+	const handleTabChange = ( tab ) => {
+		const nextTab = normalizeTab( tab );
+		setActiveTab( nextTab );
+
+		const url = new URL( window.location.href );
+		if ( 'dashboard' === nextTab ) {
+			url.searchParams.delete( 'tab' );
+		} else {
+			url.searchParams.set( 'tab', nextTab );
+		}
+		window.history.pushState( { performTab: nextTab }, '', url );
+	};
 
 	// dirty detection
 
@@ -140,6 +158,13 @@ const SettingsApp = () => {
 		[]
 	);
 
+	useEffect( () => {
+		const handlePopState = () => setActiveTab( getTabFromUrl() );
+		window.addEventListener( 'popstate', handlePopState );
+
+		return () => window.removeEventListener( 'popstate', handlePopState );
+	}, [] );
+
 	return (
 		<>
 			<SettingsHeader />
@@ -149,12 +174,14 @@ const SettingsApp = () => {
 				dashboard={ DASHBOARD }
 				diagnostics={ diagnostics }
 				activeTab={ activeTab }
-				onTabChange={ setActiveTab }
+				onTabChange={ handleTabChange }
 				fieldValues={ fieldValues }
 				onFieldChange={ handleFieldChange }
 			/>
 			{ 'dashboard' === activeTab && <DiagnosticsPanel diagnostics={ diagnostics } /> }
-			<Footer dirty={ isDirty } saving={ saving } message={ message } onSave={ handleSave } />
+			{ 'cache-stats' !== activeTab && (
+				<Footer dirty={ isDirty } saving={ saving } message={ message } onSave={ handleSave } />
+			) }
 		</>
 	);
 };

--- a/assets/src/js/admin/SettingsNav.jsx
+++ b/assets/src/js/admin/SettingsNav.jsx
@@ -8,7 +8,7 @@ import {
 	SelectControl,
 	TextareaControl,
 } from '@wordpress/components';
-import { useState, useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import DashboardPanel from './DashboardPanel';
 
 const FIELD_COMPONENTS = {
@@ -48,6 +48,24 @@ const MASKED_SECRET_VALUE = window.performwpSettings?.maskedSecretValue || '__PE
 const SETTINGS = window.performwpSettings || {};
 
 const isSensitiveField = ( fieldId ) => SENSITIVE_KEYS.includes( fieldId );
+
+const CacheStatsPanel = () => {
+	const containerRef = useRef( null );
+
+	useEffect( () => {
+		const template = document.getElementById( 'perform-cache-stats-template' );
+		const container = containerRef.current;
+		if ( ! template || ! container ) {
+			return undefined;
+		}
+
+		container.replaceChildren( template.content.cloneNode( true ) );
+
+		return () => container.replaceChildren();
+	}, [] );
+
+	return <div ref={ containerRef } className="perform-cache-stats-container" />;
+};
 
 const renderField = ( field, value, onChange ) => {
 	const {
@@ -180,6 +198,12 @@ const SettingsNav = ( {
 	const fieldValues = propFieldValues ?? internalFieldValues;
 	const onFieldChange =
 		propOnFieldChange ?? ( ( id, val ) => setInternalFieldValues( ( p ) => ( { ...p, [ id ]: val } ) ) );
+	const tabPanelRef = useRef( null );
+
+	useEffect( () => {
+		const selectedTab = tabPanelRef.current?.querySelector( '[role="tab"][aria-selected="true"]' );
+		selectedTab?.scrollIntoView( { block: 'nearest', inline: 'nearest' } );
+	}, [ activeTab ] );
 
 	const tabPanelTabs = useMemo(
 		() =>
@@ -190,61 +214,71 @@ const SettingsNav = ( {
 		[ tabKeys, tabs ]
 	);
 
-	const cards = useMemo( () => fields[ activeTab ] || [], [ fields, activeTab ] );
-
 	if ( ! tabKeys.length ) {
 		return null;
 	}
 
 	return (
-		<>
-			<div className="perform-settings-content">
-				<TabPanel
-					className="perform-settings-tab-panel"
-					tabs={ tabPanelTabs }
-					initialTabName={ activeTab }
-					onSelect={ onTabChange }
-				>
-					{ () => null }
-				</TabPanel>
-				{ 'dashboard' === activeTab ? (
-					<DashboardPanel dashboard={ dashboard } diagnostics={ diagnostics } />
-				) : (
-					<div className="perform-settings-cards">
-						{ cards.map( ( card, idx ) => (
-							<Card
-								key={ idx }
-								style={ {
-									marginBottom: '24px',
-									boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
-									borderRadius: 0,
-								} }
-							>
-								<CardHeader style={ { alignItems: 'flex-start', flexDirection: 'column' } }>
-									<h3 className="perform-card-title">{ card.title }</h3>
-									{ card.description && (
-										<p className="perform-card-description">{ card.description }</p>
+		<div ref={ tabPanelRef }>
+			<TabPanel
+				key={ activeTab }
+				className="perform-settings-tab-panel"
+				tabs={ tabPanelTabs }
+				initialTabName={ activeTab }
+				onSelect={ ( tabName ) => {
+					if ( tabName !== activeTab ) {
+						onTabChange( tabName );
+					}
+				} }
+			>
+				{ ( selectedTab ) => {
+					const selectedTabName = selectedTab?.name || activeTab;
+					const cards = fields[ selectedTabName ] || [];
+					let content = (
+						<div className="perform-settings-cards">
+							{ cards.map( ( card, idx ) => (
+								<Card
+									key={ idx }
+									style={ {
+										marginBottom: '24px',
+										boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
+										borderRadius: 0,
+									} }
+								>
+									<CardHeader style={ { alignItems: 'flex-start', flexDirection: 'column' } }>
+										<h3 className="perform-card-title">{ card.title }</h3>
+										{ card.description && (
+											<p className="perform-card-description">{ card.description }</p>
+										) }
+									</CardHeader>
+									{ card.fields && card.fields.length > 0 && (
+										<CardBody>
+											{ card.fields.map( ( field ) => (
+												<div
+													key={ field.id }
+													className="perform-field"
+													style={ { marginBottom: 16 } }
+												>
+													{ renderField( field, fieldValues[ field.id ], onFieldChange ) }
+												</div>
+											) ) }
+										</CardBody>
 									) }
-								</CardHeader>
-								{ card.fields && card.fields.length > 0 && (
-									<CardBody>
-										{ card.fields.map( ( field ) => (
-											<div
-												key={ field.id }
-												className="perform-field"
-												style={ { marginBottom: 16 } }
-											>
-												{ renderField( field, fieldValues[ field.id ], onFieldChange ) }
-											</div>
-										) ) }
-									</CardBody>
-								) }
-							</Card>
-						) ) }
-					</div>
-				) }
-			</div>
-		</>
+								</Card>
+							) ) }
+						</div>
+					);
+
+					if ( 'dashboard' === selectedTabName ) {
+						content = <DashboardPanel dashboard={ dashboard } diagnostics={ diagnostics } />;
+					} else if ( 'cache-stats' === selectedTabName ) {
+						content = <CacheStatsPanel />;
+					}
+
+					return <div className="perform-settings-content">{ content }</div>;
+				} }
+			</TabPanel>
+		</div>
 	);
 };
 

--- a/languages/perform.pot
+++ b/languages/perform.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: PerformWP <hello@performwp.com>\n"
-"POT-Creation-Date: 2026-07-02 10:16+0000\n"
+"POT-Creation-Date: 2026-07-21 14:39+0000\n"
 "Report-Msgid-Bugs-To: https://github.com/performwp/perform/issues/new\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
@@ -16,19 +16,19 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/Admin/Actions.php:102
+#: src/Admin/Actions.php:104
 msgid "Close Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:99, src/Modules/Assets/AssetsManager.php:258
+#: src/Admin/Actions.php:101, src/Modules/Assets/AssetsManager.php:258
 msgid "Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:109, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:238
+#: src/Admin/Actions.php:111, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:238
 msgid "Perform"
 msgstr ""
 
-#: src/Admin/Actions.php:129
+#: src/Admin/Actions.php:131
 msgid "Support Forum"
 msgstr ""
 
@@ -660,19 +660,23 @@ msgstr ""
 msgid "Assets Manager summary reports configured rule coverage, not historical byte savings."
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:82
+#: src/Admin/Settings/Menu.php:55
+msgid "Cache Stats"
+msgstr ""
+
+#: src/Admin/Settings/Menu.php:109
 msgid "Insufficient permissions."
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:93
+#: src/Admin/Settings/Menu.php:120
 msgid "Security check failed."
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:209
+#: src/Admin/Settings/Menu.php:236
 msgid "Unable to save the settings. Please try again."
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:201
+#: src/Admin/Settings/Menu.php:228
 msgid "Settings saved successfully."
 msgstr ""
 
@@ -995,78 +999,126 @@ msgstr ""
 msgid "No feed available, please visit the homepage!"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:148
+#: src/Modules/Cache/PageCache.php:219
 msgid "Every 5 minutes (Perform Cache)"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:480, src/Modules/Cache/PageCache.php:510
+#: src/Modules/Cache/PageCache.php:743, src/Modules/Cache/PageCache.php:810
 msgid "Perform Cache Observability"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:481
+#: src/Modules/Cache/PageCache.php:744
 msgid "Perform Cache Stats"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:511
+#: src/Modules/Cache/PageCache.php:764, src/Modules/Cache/PageCache.php:789
+msgid "Sorry, you are not allowed to access this page."
+msgstr ""
+
+#: src/Modules/Cache/PageCache.php:811
 msgid "Live cache effectiveness and warmup health metrics."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:515
+#: src/Modules/Cache/PageCache.php:813
+msgid "The local page-cache generation has been invalidated."
+msgstr ""
+
+#: src/Modules/Cache/PageCache.php:817
+msgid "Cloudflare URL cleanup is pending."
+msgstr ""
+
+#: src/Modules/Cache/PageCache.php:821
+msgid "Some Cloudflare URL cleanup batches need a manual retry."
+msgstr ""
+
+#: src/Modules/Cache/PageCache.php:826
+msgid "Purge Site Page Cache"
+msgstr ""
+
+#: src/Modules/Cache/PageCache.php:829
+msgid "Cloudflare cleanup: %1$d pending, %2$d retryable failures, %3$d old-credential residuals."
+msgstr ""
+
+#: src/Modules/Cache/PageCache.php:835
+msgid "Retry Failed Cloudflare Cleanup"
+msgstr ""
+
+#: src/Modules/Cache/PageCache.php:842
+msgid "After purging the old Cloudflare zone externally, acknowledge the residual to retire the old token-free queue and allow local cache cleanup."
+msgstr ""
+
+#: src/Modules/Cache/PageCache.php:843
+msgid "Acknowledge External Cloudflare Purge"
+msgstr ""
+
+#: src/Modules/Cache/PageCache.php:849
 msgid "Cache Hit Ratio"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:516
+#: src/Modules/Cache/PageCache.php:850
 msgid "Hits"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:517
+#: src/Modules/Cache/PageCache.php:851
 msgid "Stale Hits"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:518, src/Modules/Cache/PageCache.php:527
+#: src/Modules/Cache/PageCache.php:852, src/Modules/Cache/PageCache.php:861
 msgid "Misses"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:519, src/Modules/Cache/PageCache.php:530
+#: src/Modules/Cache/PageCache.php:853, src/Modules/Cache/PageCache.php:864
 msgid "Bypasses"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:520
+#: src/Modules/Cache/PageCache.php:854
 msgid "Lock Waits"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:521
+#: src/Modules/Cache/PageCache.php:855
 msgid "Preload Queue Size"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:522
+#: src/Modules/Cache/PageCache.php:856
 msgid "Preload Requests"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:526
+#: src/Modules/Cache/PageCache.php:860
 msgid "Top Missed URLs"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:529
+#: src/Modules/Cache/PageCache.php:863
 msgid "Bypass Reasons"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:530
+#: src/Modules/Cache/PageCache.php:864
 msgid "Reason"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:532
+#: src/Modules/Cache/PageCache.php:866
 msgid "Slow Uncached URLs (ms)"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:533
+#: src/Modules/Cache/PageCache.php:867
 msgid "Render Time (ms)"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:549
+#: src/Modules/Cache/PageCache.php:883
 msgid "No data yet."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:554
+#: src/Modules/Cache/PageCache.php:888
 msgid "URL"
+msgstr ""
+
+#: src/Modules/Cache/PageCache.php:1033
+msgid "You are not allowed to purge the page cache."
+msgstr ""
+
+#: src/Modules/Cache/PageCache.php:1054
+msgid "You are not allowed to acknowledge Cloudflare cleanup."
+msgstr ""
+
+#: src/Modules/Cache/PageCache.php:1065
+msgid "You are not allowed to retry Cloudflare cleanup."
 msgstr ""

--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -13,6 +13,7 @@ namespace Perform\Admin;
 use Perform\Includes\Helpers;
 use Perform\Admin\Settings\ClientPayload;
 use Perform\Admin\Settings\DashboardPayload;
+use Perform\Admin\Settings\Menu;
 use Perform\Admin\Settings\RuntimeDiagnostics;
 
 // Bailout, if accessed directly.
@@ -70,7 +71,8 @@ class Actions {
 					'diagnostics'       => RuntimeDiagnostics::get_results(),
 					'sensitiveKeys'     => ClientPayload::get_sensitive_keys(),
 					'maskedSecretValue' => ClientPayload::MASKED_SECRET,
-					'tabs'              => \Perform\Includes\Helpers::get_settings_tabs(),
+					'tabs'              => Menu::get_navigation_tabs(),
+					'activeTab'         => Menu::get_requested_tab(),
 					'fields'            => \Perform\Includes\Helpers::get_settings_fields(), // Expose fields to JS
 				]
 			);

--- a/src/Admin/Settings/Menu.php
+++ b/src/Admin/Settings/Menu.php
@@ -46,6 +46,30 @@ class Menu {
 	}
 
 	/**
+	 * Get tabs shown on the canonical settings screen.
+	 *
+	 * @return array<string, string>
+	 */
+	public static function get_navigation_tabs() {
+		$tabs                = Helpers::get_settings_tabs();
+		$tabs['cache-stats'] = esc_html__( 'Cache Stats', 'perform' );
+
+		return $tabs;
+	}
+
+	/**
+	 * Resolve the requested settings tab to a known tab slug.
+	 *
+	 * @return string
+	 */
+	public static function get_requested_tab() {
+		$requested_tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : 'dashboard'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only navigation state.
+		$valid_tabs    = array_merge( [ 'dashboard' ], array_keys( self::get_navigation_tabs() ) );
+
+		return in_array( $requested_tab, $valid_tabs, true ) ? $requested_tab : 'dashboard';
+	}
+
+	/**
 	 * Render Settings Page.
 	 *
 	 * @since  1.0.0
@@ -62,6 +86,9 @@ class Menu {
 		}
 		?>
 		<div id="perform-settings-page" class="perform-settings-page"></div>
+		<template id="perform-cache-stats-template">
+			<?php do_action( 'perform_settings_cache_stats_content' ); ?>
+		</template>
 		<?php
 	}
 

--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -198,7 +198,8 @@ class PageCache implements ModuleInterface {
 		add_action( 'perform_cache_cleanup_event', [ $this, 'cleanup_obsolete_generations' ] );
 		add_action( 'perform_cache_cloudflare_purge_event', [ $this, 'run_cloudflare_purge_batch' ] );
 
-		add_action( 'admin_menu', [ $this, 'register_observability_page' ] );
+		add_action( 'admin_menu', [ $this, 'register_legacy_observability_route' ], 20 );
+		add_action( 'perform_settings_cache_stats_content', [ $this, 'render_observability_page' ] );
 		add_action( 'admin_post_perform_purge_page_cache', [ $this, 'handle_manual_purge' ] );
 		add_action( 'admin_post_perform_retry_cloudflare_cleanup', [ $this, 'handle_cloudflare_cleanup_retry' ] );
 		add_action( 'admin_post_perform_acknowledge_cloudflare_residual', [ $this, 'handle_cloudflare_residual_acknowledgement' ] );
@@ -735,20 +736,47 @@ class PageCache implements ModuleInterface {
 		$this->set_stat_value( 'preload_queue_size', count( $queue ) );
 	}
 
-	/**
-	 * Register cache observability page.
-	 *
-	 * @return void
-	 */
-	public function register_observability_page() {
-		add_submenu_page(
+	/** Register the retired URL as a hidden, capability-checked compatibility route. */
+	public function register_legacy_observability_route(): void {
+		$hook_suffix = add_submenu_page(
 			'options-general.php',
 			esc_html__( 'Perform Cache Observability', 'perform' ),
 			esc_html__( 'Perform Cache Stats', 'perform' ),
 			'manage_options',
 			'perform_cache_observability',
-			[ $this, 'render_observability_page' ]
+			[ $this, 'maybe_redirect_legacy_observability_page' ]
 		);
+		remove_submenu_page( 'options-general.php', 'perform_cache_observability' );
+
+		if ( $hook_suffix ) {
+			add_action( 'load-' . $hook_suffix, [ $this, 'maybe_redirect_legacy_observability_page' ] );
+		}
+	}
+
+	/** Redirect the retired Cache Stats submenu URL to its canonical settings tab. */
+	public function maybe_redirect_legacy_observability_page(): void {
+		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only route compatibility.
+		if ( 'perform_cache_observability' !== $page ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'perform' ), '', [ 'response' => 403 ] );
+		}
+
+		$args = [];
+		if ( isset( $_GET['perform_cache_purged'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Existing post-action notice state.
+			$args['perform_cache_purged'] = 1;
+		}
+
+		foreach ( [ 'perform_cache_cloudflare_pending', 'perform_cache_cloudflare_retryable_failed' ] as $key ) {
+			if ( isset( $_GET[ $key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Existing post-action notice state.
+				$args[ $key ] = absint( wp_unslash( $_GET[ $key ] ) );
+			}
+		}
+
+		wp_safe_redirect( $this->get_observability_url( $args ) );
+		exit;
 	}
 
 	/**
@@ -757,6 +785,10 @@ class PageCache implements ModuleInterface {
 	 * @return void
 	 */
 	public function render_observability_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'perform' ), '', [ 'response' => 403 ] );
+		}
+
 		$stats = get_option( 'perform_cache_stats', [] );
 		if ( ! is_array( $stats ) ) {
 			$stats = [];
@@ -774,8 +806,8 @@ class PageCache implements ModuleInterface {
 		$cloudflare     = $this->get_cloudflare_queue_status();
 		$residual       = (int) get_option( 'perform_cache_cloudflare_credential_residual_' . $this->get_blog_id(), 0 );
 		?>
-		<div class="wrap">
-			<h1><?php esc_html_e( 'Perform Cache Observability', 'perform' ); ?></h1>
+		<section class="perform-cache-stats" aria-labelledby="perform-cache-stats-heading">
+			<h2 id="perform-cache-stats-heading"><?php esc_html_e( 'Perform Cache Observability', 'perform' ); ?></h2>
 			<p><?php esc_html_e( 'Live cache effectiveness and warmup health metrics.', 'perform' ); ?></p>
 			<?php if ( isset( $_GET['perform_cache_purged'] ) ) : ?>
 				<div class="notice notice-success is-dismissible"><p><?php esc_html_e( 'The local page-cache generation has been invalidated.', 'perform' ); ?></p></div>
@@ -812,7 +844,7 @@ class PageCache implements ModuleInterface {
 				</form>
 			<?php endif; ?>
 
-			<table class="widefat striped" style="max-width:900px;">
+			<table class="widefat striped perform-cache-stats__summary">
 				<tbody>
 					<tr><th><?php esc_html_e( 'Cache Hit Ratio', 'perform' ); ?></th><td><?php echo esc_html( $hit_ratio . '%' ); ?></td></tr>
 					<tr><th><?php esc_html_e( 'Hits', 'perform' ); ?></th><td><?php echo esc_html( $hits ); ?></td></tr>
@@ -833,7 +865,7 @@ class PageCache implements ModuleInterface {
 
 			<h2><?php esc_html_e( 'Slow Uncached URLs (ms)', 'perform' ); ?></h2>
 			<?php $this->render_stat_map_table( $slow_uncached, esc_html__( 'Render Time (ms)', 'perform' ) ); ?>
-		</div>
+		</section>
 		<?php
 	}
 
@@ -1010,7 +1042,7 @@ class PageCache implements ModuleInterface {
 					'perform_cache_cloudflare_pending' => $status['pending'],
 					'perform_cache_cloudflare_retryable_failed' => $status['retryable_failed'],
 				],
-				admin_url( 'options-general.php?page=perform_cache_observability' )
+				$this->get_observability_url()
 			)
 		);
 		exit;
@@ -1023,7 +1055,7 @@ class PageCache implements ModuleInterface {
 		}
 		$this->acknowledge_cloudflare_credential_residuals();
 		$this->schedule_cleanup();
-		wp_safe_redirect( admin_url( 'options-general.php?page=perform_cache_observability' ) );
+		wp_safe_redirect( $this->get_observability_url() );
 		exit;
 	}
 
@@ -1033,8 +1065,37 @@ class PageCache implements ModuleInterface {
 			wp_die( esc_html__( 'You are not allowed to retry Cloudflare cleanup.', 'perform' ) );
 		}
 		$this->retry_current_cloudflare_failures();
-		wp_safe_redirect( admin_url( 'options-general.php?page=perform_cache_observability' ) );
+		wp_safe_redirect( $this->get_observability_url() );
 		exit;
+	}
+
+	/**
+	 * Build the canonical Cache Stats tab URL with constrained notice arguments.
+	 *
+	 * @param array<string, mixed> $args Post-action notice arguments.
+	 *
+	 * @return string
+	 */
+	private function get_observability_url( array $args = [] ) {
+		$url     = add_query_arg(
+			[
+				'page' => 'perform_settings',
+				'tab'  => 'cache-stats',
+			],
+			admin_url( 'options-general.php' )
+		);
+		$allowed = array_intersect_key(
+			$args,
+			array_flip(
+				[
+					'perform_cache_purged',
+					'perform_cache_cloudflare_pending',
+					'perform_cache_cloudflare_retryable_failed',
+				]
+			)
+		);
+
+		return empty( $allowed ) ? $url : add_query_arg( $allowed, $url );
 	}
 
 	/** Retire only records that cannot use the current credentials. */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -137,6 +137,43 @@ if ( ! function_exists( 'add_filter' ) ) {
 	}
 }
 
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+		foreach ( $GLOBALS['perform_test_actions'] ?? [] as $action ) {
+			if ( $hook_name === $action['hook'] ) {
+				call_user_func_array( $action['callback'], array_slice( $args, 0, $action['accepted_args'] ) );
+			}
+		}
+	}
+}
+
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook_name ) {
+		return isset( $GLOBALS['perform_test_did_actions'][ $hook_name ] ) ? (int) $GLOBALS['perform_test_did_actions'][ $hook_name ] : 0;
+	}
+}
+
+if ( ! function_exists( 'add_options_page' ) ) {
+	function add_options_page( $page_title, $menu_title, $capability, $menu_slug, $callback = '' ) {
+		$GLOBALS['perform_test_options_pages'][] = compact( 'page_title', 'menu_title', 'capability', 'menu_slug', 'callback' );
+		return 'settings_page_' . $menu_slug;
+	}
+}
+
+if ( ! function_exists( 'add_submenu_page' ) ) {
+	function add_submenu_page( $parent_slug, $page_title, $menu_title, $capability, $menu_slug, $callback = '' ) {
+		$GLOBALS['perform_test_submenu_pages'][] = compact( 'parent_slug', 'page_title', 'menu_title', 'capability', 'menu_slug', 'callback' );
+		return $parent_slug . '_page_' . $menu_slug;
+	}
+}
+
+if ( ! function_exists( 'remove_submenu_page' ) ) {
+	function remove_submenu_page( $menu_slug, $submenu_slug ) {
+		$GLOBALS['perform_test_removed_submenu_pages'][] = compact( 'menu_slug', 'submenu_slug' );
+		return [];
+	}
+}
+
 if ( ! function_exists( 'wp_enqueue_style' ) ) {
 	function wp_enqueue_style( $handle, $src = '', $deps = [], $ver = false, $media = 'all' ) {
 		$GLOBALS['perform_test_enqueued_styles'][] = $handle;
@@ -151,6 +188,9 @@ if ( ! function_exists( 'wp_enqueue_script' ) ) {
 
 if ( ! function_exists( 'add_query_arg' ) ) {
 	function add_query_arg( $key, $value = null, $url = null ) {
+		if ( is_array( $key ) && null === $url ) {
+			$url = $value;
+		}
 		$url  = null === $url ? ( $GLOBALS['perform_test_current_url'] ?? 'https://example.com/' ) : $url;
 		$args = is_array( $key ) ? $key : [ $key => $value ];
 
@@ -234,6 +274,18 @@ if ( ! function_exists( 'esc_url' ) ) {
 if ( ! function_exists( 'esc_html__' ) ) {
 	function esc_html__( $text, $domain = 'default' ) {
 		return (string) $text;
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'esc_html_e' ) ) {
+	function esc_html_e( $text, $domain = 'default' ) {
+		echo esc_html( $text );
 	}
 }
 
@@ -469,6 +521,18 @@ if ( ! function_exists( 'sanitize_text_field' ) ) {
 	}
 }
 
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+	}
+}
+
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ) {
+		return abs( (int) $value );
+	}
+}
+
 if ( ! function_exists( 'sanitize_textarea_field' ) ) {
 	function sanitize_textarea_field( $value ) {
 		return is_scalar( $value ) ? trim( (string) $value ) : $value;
@@ -478,6 +542,18 @@ if ( ! function_exists( 'sanitize_textarea_field' ) ) {
 if ( ! function_exists( 'wp_unslash' ) ) {
 	function wp_unslash( $value ) {
 		return $value;
+	}
+}
+
+if ( ! function_exists( 'wp_parse_args' ) ) {
+	function wp_parse_args( $args, $defaults = [] ) {
+		return array_merge( $defaults, is_array( $args ) ? $args : [] );
+	}
+}
+
+if ( ! function_exists( 'wp_verify_nonce' ) ) {
+	function wp_verify_nonce( $nonce, $action = -1 ) {
+		return ! empty( $GLOBALS['perform_test_nonce_valid'] );
 	}
 }
 
@@ -635,8 +711,37 @@ if ( ! function_exists( 'wp_safe_redirect' ) ) {
 }
 
 if ( ! function_exists( 'wp_die' ) ) {
-	function wp_die( $message = '' ) {
+	function wp_die( $message = '', $title = '', $args = [] ) {
 		throw new RuntimeException( (string) $message );
+	}
+}
+
+if ( ! function_exists( 'wp_send_json_success' ) ) {
+	function wp_send_json_success( $data = null, $status_code = null, $flags = 0 ) {
+		$GLOBALS['perform_test_json_response'] = [
+			'success' => true,
+			'data'    => $data,
+		];
+		throw new RuntimeException( 'perform_test_json_response' );
+	}
+}
+
+if ( ! function_exists( 'wp_send_json_error' ) ) {
+	function wp_send_json_error( $data = null, $status_code = null, $flags = 0 ) {
+		$GLOBALS['perform_test_json_response'] = [
+			'success' => false,
+			'data'    => $data,
+		];
+		throw new RuntimeException( 'perform_test_json_response' );
+	}
+}
+
+if ( ! function_exists( 'get_current_screen' ) ) {
+	function get_current_screen() {
+		return (object) [
+			'id'   => $GLOBALS['perform_test_current_screen_id'] ?? '',
+			'base' => $GLOBALS['perform_test_current_screen_base'] ?? '',
+		];
 	}
 }
 

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -1,17 +1,48 @@
 const { test, expect, request } = require( '@playwright/test' );
 
-async function loginAsAdmin( page ) {
+async function dismissPluginOnboarding( page ) {
+	const skipButton = page.getByText( 'Skip', { exact: true } );
+	if ( await skipButton.isVisible() ) {
+		await skipButton.click();
+		await page.waitForLoadState( 'domcontentloaded' );
+		return true;
+	}
+
+	return false;
+}
+
+async function openAdminPage( page, path ) {
+	await page.goto( path );
+	if ( await dismissPluginOnboarding( page ) ) {
+		await page.goto( path );
+	}
+}
+
+async function login(
+	page,
+	username = process.env.WP_USERNAME || 'admin',
+	password = process.env.WP_PASSWORD || 'password'
+) {
+	if ( 'admin' === username ) {
+		await page.goto( '/wp-admin/' );
+		if ( await page.locator( '#wpadminbar' ).isVisible() ) {
+			await dismissPluginOnboarding( page );
+			return;
+		}
+	}
+
 	await page.goto( '/wp-login.php' );
-	await page.locator( '#user_login' ).fill( process.env.WP_USERNAME || 'admin' );
-	await page.locator( '#user_pass' ).fill( process.env.WP_PASSWORD || 'password' );
+	await page.locator( '#user_login' ).fill( username );
+	await page.locator( '#user_pass' ).fill( password );
 	await page.locator( '#wp-submit' ).click();
 	await expect( page.locator( '#wpadminbar' ) ).toBeVisible();
+	await dismissPluginOnboarding( page );
 }
 
 test( 'settings save, Assets Manager, and page cache smoke paths work', async ( { page, baseURL } ) => {
-	await loginAsAdmin( page );
+	await login( page );
 
-	await page.goto( '/wp-admin/options-general.php?page=perform_settings' );
+	await openAdminPage( page, '/wp-admin/options-general.php?page=perform_settings' );
 	await expect( page.locator( '#perform-settings-page' ) ).toBeVisible();
 	await expect( page.getByRole( 'button', { name: 'Save Settings' } ) ).toBeVisible();
 	await expect( page.getByRole( 'tab', { name: 'Dashboard' } ) ).toBeVisible();
@@ -22,29 +53,97 @@ test( 'settings save, Assets Manager, and page cache smoke paths work', async ( 
 	await page.getByRole( 'tab', { name: 'General' } ).click();
 	await expect( page.getByText( 'General Settings' ) ).toBeVisible();
 	await expect( page.getByRole( 'heading', { name: 'Runtime Diagnostics' } ) ).toHaveCount( 0 );
+	await expect( page ).toHaveURL( /[?&]tab=general(?:&|$)/ );
 
 	await page.getByRole( 'tab', { name: 'Assets' } ).click();
 	await page.getByRole( 'checkbox', { name: 'Enable Assets Manager' } ).check();
-	await page
-		.getByRole( 'textbox', { name: 'Preconnect' } )
-		.fill( `//ci-${ Date.now() }.example.com` );
+	await page.getByRole( 'textbox', { name: 'Preconnect' } ).fill( `//ci-${ Date.now() }.example.com` );
 
-	await page.getByRole( 'tab', { name: 'Cache' } ).click();
+	await page.getByRole( 'tab', { name: 'Cache', exact: true } ).click();
 	await page.getByRole( 'checkbox', { name: 'Enable Full-Page Cache' } ).check();
 
 	const saveButton = page.getByRole( 'button', { name: 'Save Settings' } );
 	await expect( saveButton ).toBeEnabled();
 	await saveButton.click();
 	await expect( page.getByText( /Settings saved/ ) ).toBeVisible();
+	await expect( page ).toHaveURL( /[?&]tab=cache(?:&|$)/ );
 
 	await page.goto( '/?perform' );
 	await expect( page.locator( '#perform-assets-manager' ) ).toBeVisible();
 	await expect( page.getByRole( 'heading', { name: 'Assets Manager' } ) ).toBeVisible();
 	await expect( page.getByRole( 'button', { name: 'Reset' } ) ).toBeVisible();
 
-	const anonymous = await request.newContext( { baseURL } );
+	const anonymous = await request.newContext( {
+		baseURL,
+		extraHTTPHeaders: {
+			Cookie: 'playground_auto_login_already_happened=1',
+		},
+	} );
 	await anonymous.get( '/' );
 	const cachedResponse = await anonymous.get( '/' );
 	expect( cachedResponse.headers()[ 'x-perform-cache' ] ).toMatch( /HIT|STALE/ );
 	await anonymous.dispose();
+} );
+
+test( 'Cache Stats tab preserves legacy routing, actions, and keyboard access', async ( { page } ) => {
+	await login( page );
+
+	await openAdminPage( page, '/wp-admin/options-general.php?page=perform_settings' );
+	const cacheStatsTab = page.getByRole( 'tab', { name: 'Cache Stats' } );
+	await cacheStatsTab.focus();
+	await expect( cacheStatsTab ).toBeFocused();
+	await expect( cacheStatsTab ).toHaveCSS( 'outline-style', 'solid' );
+	await page.keyboard.press( 'Enter' );
+
+	await expect( cacheStatsTab ).toHaveAttribute( 'aria-selected', 'true' );
+	await expect( page ).toHaveURL( /[?&]tab=cache-stats(?:&|$)/ );
+	await expect( page.getByRole( 'heading', { name: 'Perform Cache Observability' } ) ).toBeVisible();
+	await expect( page.getByRole( 'button', { name: 'Purge Site Page Cache' } ) ).toBeVisible();
+	await expect( page.getByRole( 'button', { name: 'Save Settings' } ) ).toHaveCount( 0 );
+
+	await openAdminPage(
+		page,
+		'/wp-admin/options-general.php?page=perform_cache_observability&redirect_to=https%3A%2F%2Fattacker.example.com'
+	);
+	await expect( page ).toHaveURL( /options-general\.php\?page=perform_settings&tab=cache-stats$/ );
+	await expect( page.getByRole( 'heading', { name: 'Perform Cache Observability' } ) ).toBeVisible();
+
+	await page.getByRole( 'button', { name: 'Purge Site Page Cache' } ).click();
+	await expect( page ).toHaveURL( /page=perform_settings&tab=cache-stats&perform_cache_purged=1/ );
+	await expect( page.getByText( 'The local page-cache generation has been invalidated.' ) ).toBeVisible();
+} );
+
+test( 'lower-privilege users cannot access the legacy or canonical Cache Stats routes', async ( { page } ) => {
+	await login( page );
+	await page.context().clearCookies( { name: /^wordpress_/ } );
+	await login( page, 'perform-editor', 'password' );
+
+	const legacyResponse = await page.goto( '/wp-admin/options-general.php?page=perform_cache_observability' );
+	expect( legacyResponse.status() ).not.toBe( 302 );
+	await expect( page ).toHaveURL( /page=perform_cache_observability$/ );
+	await expect( page.getByText( 'Sorry, you are not allowed to access this page.' ) ).toBeVisible();
+	await expect( page.getByText( 'Perform Cache Observability' ) ).toHaveCount( 0 );
+
+	const canonicalResponse = await page.goto( '/wp-admin/options-general.php?page=perform_settings&tab=cache-stats' );
+	expect( canonicalResponse.status() ).not.toBe( 302 );
+	await expect( page ).toHaveURL( /page=perform_settings&tab=cache-stats$/ );
+	await expect( page.getByText( 'Sorry, you are not allowed to access this page.' ) ).toBeVisible();
+	await expect( page.getByRole( 'tab', { name: 'Cache Stats' } ) ).toHaveCount( 0 );
+
+	const protectedActions = [
+		[ 'perform_purge_page_cache', 'You are not allowed to purge the page cache.' ],
+		[ 'perform_retry_cloudflare_cleanup', 'You are not allowed to retry Cloudflare cleanup.' ],
+		[ 'perform_acknowledge_cloudflare_residual', 'You are not allowed to acknowledge Cloudflare cleanup.' ],
+	];
+
+	for ( const [ action, denialMessage ] of protectedActions ) {
+		const response = await page.request.post( '/wp-admin/admin-post.php', {
+			form: {
+				action,
+				_wpnonce: 'invalid-for-editor-capability-check',
+			},
+		} );
+		expect( response.status() ).not.toBe( 302 );
+		expect( await response.text() ).toContain( denialMessage );
+	}
 } );

--- a/tests/e2e/run-ci.mjs
+++ b/tests/e2e/run-ci.mjs
@@ -39,6 +39,16 @@ try {
 			'eval',
 			'if ( class_exists( "Freemius" ) ) { $perform_fs = Freemius::get_instance_by_id( 18658 ); if ( $perform_fs ) { $perform_fs->skip_connection(); } }',
 		] );
+		await run( 'npm', [
+			'run',
+			'wp-env',
+			'--',
+			'run',
+			'cli',
+			'wp',
+			'eval',
+			'$user = get_user_by( "login", "perform-editor" ); if ( ! $user ) { $user_id = wp_create_user( "perform-editor", "password", "perform-editor@example.com" ); if ( is_wp_error( $user_id ) ) { throw new RuntimeException( $user_id->get_error_message() ); } $user = get_user_by( "id", $user_id ); } wp_set_password( "password", $user->ID ); $user->set_role( "editor" );',
+		] );
 	}
 
 	await run( 'npx', [ 'playwright', 'test', '--reporter=line' ] );

--- a/tests/unit-tests/tests-page-cache.php
+++ b/tests/unit-tests/tests-page-cache.php
@@ -868,6 +868,68 @@ final class Tests_Page_Cache extends TestCase {
 		$this->assertSame( 1, $status['credential_residuals'] );
 	}
 
+	public function test_registers_cache_stats_content_and_a_hidden_legacy_route() {
+		$page_cache = new PageCache();
+		$page_cache->register();
+
+		$hooks = array_column( $GLOBALS['perform_test_actions'], 'hook' );
+		$this->assertContains( 'perform_settings_cache_stats_content', $hooks );
+		$this->assertContains( 'admin_menu', $hooks );
+		$this->assertNotContains( 'admin_init', $hooks );
+
+		$GLOBALS['perform_test_submenu_pages']         = [];
+		$GLOBALS['perform_test_removed_submenu_pages'] = [];
+		$page_cache->register_legacy_observability_route();
+
+		$this->assertSame( 'perform_cache_observability', $GLOBALS['perform_test_submenu_pages'][0]['menu_slug'] );
+		$this->assertSame( 'manage_options', $GLOBALS['perform_test_submenu_pages'][0]['capability'] );
+		$this->assertSame( 'perform_cache_observability', $GLOBALS['perform_test_removed_submenu_pages'][0]['submenu_slug'] );
+		$this->assertContains( 'load-options-general.php_page_perform_cache_observability', array_column( $GLOBALS['perform_test_actions'], 'hook' ) );
+	}
+
+	public function test_cache_stats_url_is_canonical_and_drops_unapproved_arguments() {
+		$page_cache = new PageCache();
+		$method     = new ReflectionMethod( $page_cache, 'get_observability_url' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			'https://example.com/wp-admin/options-general.php?page=perform_settings&tab=cache-stats&perform_cache_purged=1',
+			$method->invoke(
+				$page_cache,
+				[
+					'perform_cache_purged' => 1,
+					'redirect_to'          => 'https://attacker.example.com',
+				]
+			)
+		);
+	}
+
+	public function test_legacy_cache_stats_url_retains_denial_for_unauthorized_users() {
+		$_GET['page'] = 'perform_cache_observability';
+
+		$this->expectException( RuntimeException::class );
+		( new PageCache() )->maybe_redirect_legacy_observability_page();
+	}
+
+	public function test_cache_stats_render_preserves_existing_counts_and_actions() {
+		$GLOBALS['perform_test_current_user_can']               = [ 'manage_options' => true ];
+		$GLOBALS['perform_test_options']['perform_cache_stats'] = [
+			'hits'       => 12,
+			'stale_hits' => 2,
+			'misses'     => 6,
+			'top_misses' => [ '/slow-page/' => 4 ],
+		];
+
+		ob_start();
+		( new PageCache() )->render_observability_page();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Perform Cache Observability', $output );
+		$this->assertStringContainsString( '70%', $output );
+		$this->assertStringContainsString( '/slow-page/', $output );
+		$this->assertStringContainsString( 'perform_purge_page_cache', $output );
+	}
+
 	public function test_manual_purge_requires_manage_options() {
 		$page_cache = new PageCache();
 		$this->expectException( RuntimeException::class );

--- a/tests/unit-tests/tests-settings-menu.php
+++ b/tests/unit-tests/tests-settings-menu.php
@@ -4,6 +4,91 @@ use PHPUnit\Framework\TestCase;
 use Perform\Admin\Settings\Menu;
 
 final class Tests_Settings_Menu extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['perform_test_actions']          = [];
+		$GLOBALS['perform_test_options_pages']    = [];
+		$GLOBALS['perform_test_submenu_pages']    = [];
+		$GLOBALS['perform_test_current_user_can'] = [ 'manage_options' => true ];
+		$GLOBALS['perform_test_options']          = [];
+		$_GET                                     = [];
+		$_POST                                    = [];
+	}
+
+	protected function tearDown(): void {
+		unset(
+			$GLOBALS['perform_test_actions'],
+			$GLOBALS['perform_test_options_pages'],
+			$GLOBALS['perform_test_submenu_pages'],
+			$GLOBALS['perform_test_current_user_can'],
+			$GLOBALS['perform_test_options'],
+			$GLOBALS['perform_test_nonce_valid'],
+			$GLOBALS['perform_test_json_response']
+		);
+		$_GET  = [];
+		$_POST = [];
+	}
+
+	public function test_registers_one_canonical_settings_page_without_a_cache_stats_submenu() {
+		$menu = new Menu();
+		$menu->register_admin_menu();
+
+		$this->assertCount( 1, $GLOBALS['perform_test_options_pages'] );
+		$this->assertSame( 'perform_settings', $GLOBALS['perform_test_options_pages'][0]['menu_slug'] );
+		$this->assertSame( 'manage_options', $GLOBALS['perform_test_options_pages'][0]['capability'] );
+		$this->assertSame( [], $GLOBALS['perform_test_submenu_pages'] );
+	}
+
+	public function test_cache_stats_is_a_known_canonical_tab_and_unknown_tabs_fall_back() {
+		$this->assertArrayHasKey( 'cache-stats', Menu::get_navigation_tabs() );
+
+		$_GET['tab'] = 'cache-stats';
+		$this->assertSame( 'cache-stats', Menu::get_requested_tab() );
+
+		$_GET['tab'] = 'unknown<script>';
+		$this->assertSame( 'dashboard', Menu::get_requested_tab() );
+	}
+
+	public function test_settings_save_preserves_option_name_shape_and_unposted_values() {
+		$GLOBALS['perform_test_options']['perform_settings'] = [
+			'enable_ssl'  => 0,
+			'preconnect'  => [ 'https://existing.example.com' ],
+			'custom_keep' => 'preserved',
+		];
+		$GLOBALS['perform_test_nonce_valid']                 = true;
+		$_POST = [
+			'nonce' => 'valid',
+			'data'  => wp_json_encode(
+				[
+					'enable_ssl' => true,
+					'preconnect' => "https://one.example.com\nhttps://two.example.com",
+				]
+			),
+		];
+
+		try {
+			( new Menu() )->save_settings();
+			$this->fail( 'Expected the JSON response to end the request.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'perform_test_json_response', $exception->getMessage() );
+			$this->assertTrue( $GLOBALS['perform_test_json_response']['success'] );
+		}
+
+		$this->assertSame(
+			[
+				'enable_ssl'                   => 1,
+				'preconnect'                   => [ 'https://one.example.com', 'https://two.example.com' ],
+				'custom_keep'                  => 'preserved',
+				'dns_prefetch'                 => '',
+				'cache_bypass_exact_paths'     => [],
+				'cache_bypass_path_prefixes'   => [],
+				'cache_bypass_query_params'    => [],
+				'cache_bypass_cookie_names'    => [],
+				'cache_bypass_cookie_prefixes' => [],
+			],
+			$GLOBALS['perform_test_options']['perform_settings']
+		);
+	}
+
 	public function test_multiline_settings_preserve_line_boundaries() {
 		$menu   = new Menu();
 		$method = new ReflectionMethod( $menu, 'normalize_multiline_setting' );


### PR DESCRIPTION
## Summary

- move Cache Stats from its visible Settings submenu into the canonical Perform settings tab shell
- preserve the existing Cache Stats data, notices, forms, action hooks, nonces, capabilities, and option names/shapes
- add accessible tab state, deep-link/history behavior, visible keyboard focus, and responsive tab/table handling
- retain a hidden capability-checked compatibility route for the retired submenu URL
- add focused PHPUnit and Playwright coverage, including deterministic WP-CLI editor provisioning

Refs #206.

## Admin surface decision

- **Moved:** Cache Stats is settings-only observability and now lives at `options-general.php?page=perform_settings&tab=cache-stats`.
- **Retained:** Assets Manager remains the distinct `/?perform` operational workflow because it acts on the currently viewed page and is not a settings surface.
- Freemius-provided Contact Us and Support Forum links remain vendor-owned support navigation and are outside the Perform settings tab shell.

## Legacy URL map

`/wp-admin/options-general.php?page=perform_cache_observability`

redirects, for users with `manage_options`, to:

`/wp-admin/options-general.php?page=perform_settings&tab=cache-stats`

Only these existing notice arguments are retained: `perform_cache_purged`, `perform_cache_cloudflare_pending`, and `perform_cache_cloudflare_retryable_failed`. Unapproved arguments such as `redirect_to` are dropped. Lower-privilege requests retain WordPress's access-denied behavior and are not redirected.

## Compatibility and security

- keeps `perform_settings` and `perform_cache_stats` persistence unchanged
- keeps `manage_options` authorization and existing nonce checks on purge/retry/acknowledgement actions
- sends all Cache Stats post-action redirects to the canonical tab while preserving notices
- validates requested tab slugs and falls back to Dashboard
- preserves regular settings save behavior and the active tab URL

## Validation

- `composer test`: **81 tests, 208 assertions**
- `composer lint`: **62 files, no syntax errors**
- `composer phpstan`: **45 files, no errors**
- touched-PHP `./vendor/bin/phpcs -s ...`: **pass**
- `npm run lint`: **JS and CSS pass**
- `npm run build`: **production build passes**
- `npm run test:e2e -- --project=chromium`: **3 passed in 24.5s**
- `node --check` for the Playwright test and CI runner: **pass**
- generated `languages/perform.pot` and full 12-file diff reviewed
- `git diff --check origin/release/1.7.0...HEAD`: **pass**

Repository-wide `composer check-cs` is not used as the scoped signal because the current configuration scans non-PHP assets with PHP sniffs and includes pre-existing unrelated debt. Targeted PHPCS across every touched PHP file is green.

## Browser proof

Approved temporary WordPress Playground runtime:

- WordPress 7.0.2
- PHP 8.5.6
- Playground CLI 3.1.34
- Node 24.16.0 / npm 11.13.0
- Playwright 1.60.0 / Chromium
- production assets with debug display disabled

Verified at desktop and 390px mobile widths:

- Cache Stats active-state semantics, keyboard activation, visible focus, and responsive layout
- canonical and legacy routes plus purge notice redirect
- editor denial on both routes and all three protected actions, with no protected tab or data exposed
- Assets Manager remains available as its separate operational screen

Screenshots captured in the approved runtime: desktop Cache Stats, mobile Cache Stats, retained Assets Manager, and editor access denial.

Commit: `c2ae1fa7bd9b933c4f3a78e9aad2553eed43cd54`
