### PR TITLE
Finalize the Perform 1.7.0 release candidate

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -39,6 +39,7 @@
 .wp-env.json
 
 AGENTS.md
+DESIGN.md
 sample-data/wordpress.sql
 sample-data/sample-data.numbers
 bower.json

--- a/languages/perform.pot
+++ b/languages/perform.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: PerformWP <hello@performwp.com>\n"
-"POT-Creation-Date: 2026-07-26 04:03+0000\n"
+"POT-Creation-Date: 2026-07-26 06:25+0000\n"
 "Report-Msgid-Bugs-To: https://github.com/performwp/perform/issues/new\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Clear all collected cache activity? This does not clear cached pages."
 msgstr ""
 
-#: src/Admin/Actions.php:91, src/Modules/Cache/PageCache.php:826, src/Modules/Cache/PageCache.php:1088
+#: src/Admin/Actions.php:91, src/Modules/Cache/PageCache.php:828, src/Modules/Cache/PageCache.php:1090
 msgid "Cache activity cleared."
 msgstr ""
 
@@ -1047,130 +1047,130 @@ msgstr ""
 msgid "Every 5 minutes (Perform Cache)"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:745, src/Modules/Cache/PageCache.php:812
+#: src/Modules/Cache/PageCache.php:746, src/Modules/Cache/PageCache.php:814
 msgid "Perform Cache Observability"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:746
+#: src/Modules/Cache/PageCache.php:747
 msgid "Perform Cache Stats"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:766, src/Modules/Cache/PageCache.php:791
+#: src/Modules/Cache/PageCache.php:768, src/Modules/Cache/PageCache.php:793
 msgid "Sorry, you are not allowed to access this page."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:813
+#: src/Modules/Cache/PageCache.php:815
 msgid "Live cache effectiveness and warmup health metrics."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:815
+#: src/Modules/Cache/PageCache.php:817
 msgid "The local page-cache generation has been invalidated."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:819
+#: src/Modules/Cache/PageCache.php:821
 msgid "Cloudflare URL cleanup is pending."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:823
+#: src/Modules/Cache/PageCache.php:825
 msgid "Some Cloudflare URL cleanup batches need a manual retry."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:831
+#: src/Modules/Cache/PageCache.php:833
 msgid "Purge Site Page Cache"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:834
+#: src/Modules/Cache/PageCache.php:836
 msgid "Cloudflare cleanup: %1$d pending, %2$d retryable failures, %3$d old-credential residuals."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:840
+#: src/Modules/Cache/PageCache.php:842
 msgid "Retry Failed Cloudflare Cleanup"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:847
+#: src/Modules/Cache/PageCache.php:849
 msgid "After purging the old Cloudflare zone externally, acknowledge the residual to retire the old token-free queue and allow local cache cleanup."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:848
+#: src/Modules/Cache/PageCache.php:850
 msgid "Acknowledge External Cloudflare Purge"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:854
+#: src/Modules/Cache/PageCache.php:856
 msgid "Cache Hit Ratio"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:855
+#: src/Modules/Cache/PageCache.php:857
 msgid "Hits"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:856
+#: src/Modules/Cache/PageCache.php:858
 msgid "Stale Hits"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:857, src/Modules/Cache/PageCache.php:866
+#: src/Modules/Cache/PageCache.php:859, src/Modules/Cache/PageCache.php:868
 msgid "Misses"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:858, src/Modules/Cache/PageCache.php:869
+#: src/Modules/Cache/PageCache.php:860, src/Modules/Cache/PageCache.php:871
 msgid "Bypasses"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:859
+#: src/Modules/Cache/PageCache.php:861
 msgid "Lock Waits"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:860
+#: src/Modules/Cache/PageCache.php:862
 msgid "Preload Queue Size"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:861
+#: src/Modules/Cache/PageCache.php:863
 msgid "Preload Requests"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:865
+#: src/Modules/Cache/PageCache.php:867
 msgid "Top Missed URLs"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:868
+#: src/Modules/Cache/PageCache.php:870
 msgid "Bypass Reasons"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:869
+#: src/Modules/Cache/PageCache.php:871
 msgid "Reason"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:871
+#: src/Modules/Cache/PageCache.php:873
 msgid "Slow Uncached URLs (ms)"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:872
+#: src/Modules/Cache/PageCache.php:874
 msgid "Render Time (ms)"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:888
+#: src/Modules/Cache/PageCache.php:890
 msgid "No data yet."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:893
+#: src/Modules/Cache/PageCache.php:895
 msgid "URL"
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:1038
+#: src/Modules/Cache/PageCache.php:1040
 msgid "You are not allowed to purge the page cache."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:1059
+#: src/Modules/Cache/PageCache.php:1061
 msgid "You are not allowed to export cache activity."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:1074
+#: src/Modules/Cache/PageCache.php:1076
 msgid "You are not allowed to clear cache activity."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:1101
+#: src/Modules/Cache/PageCache.php:1103
 msgid "You are not allowed to acknowledge Cloudflare cleanup."
 msgstr ""
 
-#: src/Modules/Cache/PageCache.php:1112
+#: src/Modules/Cache/PageCache.php:1114
 msgid "You are not allowed to retry Cloudflare cleanup."
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -127,7 +127,7 @@ Contributions and bug reports welcome on GitHub: https://github.com/performwp/pe
 == Upgrade Notice ==
 
 = 1.7.0 =
-Review Assets Manager, cache exclusions, Cache Stats, and runtime diagnostics after updating. Cache Stats is now under Settings > Perform; the previous administrator URL redirects there. Settings use a consistent responsive layout, and Cache Stats export and clear actions now report their progress and outcome.
+Review Assets Manager, cache exclusions, Cache Stats, and runtime diagnostics after updating. Cache Stats now appears under Settings > Perform, and its export and clear actions report progress and results.
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -15,7 +15,7 @@ Optimize WordPress performance with asset controls, page caching, CDN rewriting,
 
 Perform helps site owners reduce unnecessary frontend work in WordPress. It combines asset controls, cache features, CDN rewriting, and small cleanup modules in one settings area.
 
-Version 1.7.0 focuses on safer controls for real sites: a dashboard overview, dashboard-only runtime diagnostics, page cache exclusion and lifecycle controls, an Assets Manager reset action, and Cache Stats integrated into the main settings tabs.
+Version 1.7.0 focuses on safer, easier-to-understand controls for real sites: a dashboard overview, dashboard-only runtime diagnostics, page cache exclusion and lifecycle controls, an Assets Manager reset action, consistent settings layouts, and Cache Stats integrated into the main settings tabs.
 
 Key capabilities:
 
@@ -67,14 +67,17 @@ Contributions and bug reports welcome on GitHub: https://github.com/performwp/pe
 
 == Changelog ==
 
-= 1.7.0 - 2026-07-22 =
+= 1.7.0 - 2026-07-26 =
 - Added a dashboard overview for faster at-a-glance site status.
 - Added a dashboard-only runtime diagnostics panel for environment and plugin inspection.
 - Added page cache exclusion controls for URLs and content that should bypass cache.
 - Added an Assets Manager reset action for safer repeated scans.
+- Standardized the General, Bloat, Assets, CDN, Cache, and Advanced settings with shared responsive field layouts and consistent accessible iconography.
 - Moved Cache Stats into the main Perform settings tabs while preserving the previous URL for administrators.
+- Added clear progress, success, failure, and retry feedback for Cache Stats CSV export and activity clearing.
 - Improved full-page cache invalidation after content, comment, taxonomy, settings, theme, and plugin changes, with bounded cleanup and CDN retry handling.
 - Hardened sitemap preload traversal and CDN module load gating.
+- Improved internal module loading and Assets Manager settings persistence without changing existing setting contracts.
 - Aligned the dashboard and public metadata surfaces with version 1.7.0 and refreshed WordPress.org readme wording.
 
 = 1.6.0 - 2026-05-22 =
@@ -124,7 +127,7 @@ Contributions and bug reports welcome on GitHub: https://github.com/performwp/pe
 == Upgrade Notice ==
 
 = 1.7.0 =
-Review Assets Manager, cache exclusions, Cache Stats, and runtime diagnostics after updating. Cache Stats is now under Settings > Perform; the previous administrator URL redirects there.
+Review Assets Manager, cache exclusions, Cache Stats, and runtime diagnostics after updating. Cache Stats is now under Settings > Perform; the previous administrator URL redirects there. Settings use a consistent responsive layout, and Cache Stats export and clear actions now report their progress and outcome.
 
 == Screenshots ==
 

--- a/src/Modules/Cache/CacheActivityService.php
+++ b/src/Modules/Cache/CacheActivityService.php
@@ -53,6 +53,7 @@ class CacheActivityService {
 
 		rewind( $stream );
 		$contents = stream_get_contents( $stream );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- This closes an in-memory php://temp stream, not a filesystem path.
 		fclose( $stream );
 
 		return is_string( $contents ) ? $contents : "Metric,Item,Value\n";

--- a/src/Modules/Cache/CacheActivityService.php
+++ b/src/Modules/Cache/CacheActivityService.php
@@ -72,6 +72,9 @@ class CacheActivityService {
 			$stats  = is_array( $stored ) ? $stored : [];
 		}
 
+		// Keep the primary hit metric visible even before the first cache hit.
+		$stats = array_replace( [ 'hits' => 0 ], $stats );
+
 		$rows = [];
 		foreach ( $stats as $metric => $value ) {
 			if ( count( $rows ) >= self::MAX_EXPORT_ROWS ) {

--- a/src/Modules/Cache/PageCache.php
+++ b/src/Modules/Cache/PageCache.php
@@ -740,25 +740,27 @@ class PageCache implements ModuleInterface {
 
 	/** Register the retired URL as a hidden, capability-checked compatibility route. */
 	public function register_legacy_observability_route(): void {
-		$hook_suffix = add_submenu_page(
-			'options-general.php',
-			esc_html__( 'Perform Cache Observability', 'perform' ),
-			esc_html__( 'Perform Cache Stats', 'perform' ),
-			'manage_options',
-			'perform_cache_observability',
-			[ $this, 'maybe_redirect_legacy_observability_page' ]
-		);
-		remove_submenu_page( 'options-general.php', 'perform_cache_observability' );
+		foreach ( [ 'perform_cache_observability', 'perform_cache_stats' ] as $legacy_slug ) {
+			$hook_suffix = add_submenu_page(
+				'options-general.php',
+				esc_html__( 'Perform Cache Observability', 'perform' ),
+				esc_html__( 'Perform Cache Stats', 'perform' ),
+				'manage_options',
+				$legacy_slug,
+				[ $this, 'maybe_redirect_legacy_observability_page' ]
+			);
+			remove_submenu_page( 'options-general.php', $legacy_slug );
 
-		if ( $hook_suffix ) {
-			add_action( 'load-' . $hook_suffix, [ $this, 'maybe_redirect_legacy_observability_page' ] );
+			if ( $hook_suffix ) {
+				add_action( 'load-' . $hook_suffix, [ $this, 'maybe_redirect_legacy_observability_page' ] );
+			}
 		}
 	}
 
 	/** Redirect the retired Cache Stats submenu URL to its canonical settings tab. */
 	public function maybe_redirect_legacy_observability_page(): void {
 		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only route compatibility.
-		if ( 'perform_cache_observability' !== $page ) {
+		if ( ! in_array( $page, [ 'perform_cache_observability', 'perform_cache_stats' ], true ) ) {
 			return;
 		}
 

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -161,6 +161,12 @@ test( 'Cache Stats tab preserves legacy routing, actions, and keyboard access', 
 	await expect( page ).toHaveURL( /options-general\.php\?page=perform_settings&tab=cache-stats$/ );
 	await expect( page.getByRole( 'heading', { name: 'Perform Cache Observability' } ) ).toBeVisible();
 
+	await openAdminPage(
+		page,
+		'/wp-admin/options-general.php?page=perform_cache_stats&redirect_to=https%3A%2F%2Fattacker.example.com'
+	);
+	await expect( page ).toHaveURL( /options-general\.php\?page=perform_settings&tab=cache-stats$/ );
+
 	await page.getByRole( 'button', { name: 'Purge Site Page Cache' } ).click();
 	await expect( page ).toHaveURL( /page=perform_settings&tab=cache-stats&perform_cache_purged=1/ );
 	await expect( page.getByText( 'The local page-cache generation has been invalidated.' ) ).toBeVisible();

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -129,7 +129,9 @@ test( 'Cache Stats tab preserves legacy routing, actions, and keyboard access', 
 	expect( download.suggestedFilename() ).toMatch( /^perform-cache-activity-\d{4}-\d{2}-\d{2}\.csv$/ );
 	const csv = await readFile( await download.path(), 'utf8' );
 	expect( csv ).toContain( 'Metric,Item,Value' );
-	expect( csv ).toContain( 'Hits,,120' );
+	const hits = csv.match( /^Hits,,(\d+)$/m );
+	expect( hits ).not.toBeNull();
+	expect( Number( hits[ 1 ] ) ).toBeGreaterThanOrEqual( 120 );
 	expect( csv ).toContain( '"Top Misses",/sample-page/,3' );
 	await expect( page.getByRole( 'status' ) ).toContainText( 'Cache activity exported.' );
 

--- a/tests/unit-tests/tests-cache-activity-service.php
+++ b/tests/unit-tests/tests-cache-activity-service.php
@@ -24,10 +24,10 @@ final class Tests_Cache_Activity_Service extends TestCase {
 		$this->assertStringContainsString( '"Top Misses",/pricing/,3', $csv );
 	}
 
-	public function test_empty_export_contains_only_the_header() {
+	public function test_empty_export_contains_zero_hits() {
 		$service = new CacheActivityService();
 
-		$this->assertSame( "Metric,Item,Value\n", $service->export_csv( [] ) );
+		$this->assertSame( "Metric,Item,Value\nHits,,0\n", $service->export_csv( [] ) );
 	}
 
 	public function test_export_is_bounded_and_ignores_unsupported_values() {
@@ -57,7 +57,7 @@ final class Tests_Cache_Activity_Service extends TestCase {
 			]
 		);
 
-		$this->assertSame( '\'=HYPERLINK("https://example.com")', $rows[0][1] );
+		$this->assertSame( '\'=HYPERLINK("https://example.com")', $rows[1][1] );
 	}
 
 	public function test_clear_removes_only_cache_activity() {

--- a/tests/unit-tests/tests-page-cache.php
+++ b/tests/unit-tests/tests-page-cache.php
@@ -883,10 +883,17 @@ final class Tests_Page_Cache extends TestCase {
 		$GLOBALS['perform_test_removed_submenu_pages'] = [];
 		$page_cache->register_legacy_observability_route();
 
-		$this->assertSame( 'perform_cache_observability', $GLOBALS['perform_test_submenu_pages'][0]['menu_slug'] );
-		$this->assertSame( 'manage_options', $GLOBALS['perform_test_submenu_pages'][0]['capability'] );
-		$this->assertSame( 'perform_cache_observability', $GLOBALS['perform_test_removed_submenu_pages'][0]['submenu_slug'] );
+		$this->assertSame(
+			[ 'perform_cache_observability', 'perform_cache_stats' ],
+			array_column( $GLOBALS['perform_test_submenu_pages'], 'menu_slug' )
+		);
+		$this->assertSame( [ 'manage_options', 'manage_options' ], array_column( $GLOBALS['perform_test_submenu_pages'], 'capability' ) );
+		$this->assertSame(
+			[ 'perform_cache_observability', 'perform_cache_stats' ],
+			array_column( $GLOBALS['perform_test_removed_submenu_pages'], 'submenu_slug' )
+		);
 		$this->assertContains( 'load-options-general.php_page_perform_cache_observability', array_column( $GLOBALS['perform_test_actions'], 'hook' ) );
+		$this->assertContains( 'load-options-general.php_page_perform_cache_stats', array_column( $GLOBALS['perform_test_actions'], 'hook' ) );
 	}
 
 	public function test_cache_stats_url_is_canonical_and_drops_unapproved_arguments() {
@@ -908,6 +915,13 @@ final class Tests_Page_Cache extends TestCase {
 
 	public function test_legacy_cache_stats_url_retains_denial_for_unauthorized_users() {
 		$_GET['page'] = 'perform_cache_observability';
+
+		$this->expectException( RuntimeException::class );
+		( new PageCache() )->maybe_redirect_legacy_observability_page();
+	}
+
+	public function test_alternate_legacy_cache_stats_url_retains_denial_for_unauthorized_users() {
+		$_GET['page'] = 'perform_cache_stats';
 
 		$this->expectException( RuntimeException::class );
 		( new PageCache() )->maybe_redirect_legacy_observability_page();


### PR DESCRIPTION
## Summary

- refresh the 1.7.0 description, changelog, and upgrade notice for the settings and cache activity work merged in #220
- exclude the repository-only `DESIGN.md` from the production package and keep the upgrade notice within the WordPress.org length limit
- make the packaged cache activity smoke assertion tolerate legitimate hit-count growth from earlier cache requests
- document why the CSV exporter closes its in-memory `php://temp` stream directly

Closes #221.

## Candidate identity and package

- base: `origin/release/1.7.0` at `21f9cc4ef9ea484284d1fcb570926cf47be5f753`
- candidate: `ee488d37d285029f500debb7ef4bf733bcac8f68`
- Node: `24.16.0`
- Composer: `2.9.5`
- command: `npm run plugin-zip`
- ZIP: `perform.zip`
- SHA-256: `3895627abe3d7b4cee60772cfe9e88a0e65eb0324187faa0ff0efa55416b63ba`
- size: 1,191,926 bytes
- entries: 320

The ZIP has the canonical `perform/` root, aligned 1.7.0 version surfaces, production assets, Composer autoload files, and Freemius 2.13.0. It excludes repository metadata, `DESIGN.md`, Node modules, tests, source assets, development tools, lock/build configuration, `vendor/bin`, and `vendor/composer/installers`.

## Disposable runtime and browser proof

The exact ZIP above was installed and activated with WordPress Playground CLI 3.1.34:

- WordPress `7.0.2`
- PHP `8.3.31`
- canonical basename `perform/perform.php`
- active: `true`
- plugin header: `1.7.0`
- `PERFORM_VERSION`: `1.7.0`

Playwright ran against that packaged installation and passed 4/4 workflows:

- settings save, Assets Manager, and page-cache HIT/STALE behavior
- responsive field-row stacking across General, Bloat, Assets, CDN, Cache, and Advanced
- Cache Stats keyboard/legacy routing, CSV content/status, clear failure/retry, purge, and safe clear
- editor denial for canonical/legacy routes and protected actions

## Plugin Check

The official latest-stable Plugin Check 2.0.0 package ran in `update` mode against the exact installed ZIP.

Two actionable findings discovered during proof were resolved:

- repository-only `DESIGN.md` was present in the package
- the 1.7.0 upgrade notice exceeded 300 characters

A false positive for `fclose()` on an in-memory `php://temp` stream was narrowly documented and suppressed; `WP_Filesystem` is not appropriate for a memory stream.

The final result contains only previously assessed findings:

- two compatibility flags for `wp_is_block_theme()`; both calls are explicitly guarded by `function_exists( 'wp_is_block_theme' )`
- four nonce recommendations on read-only allowlisted notice query arguments; mutating handlers retain capability and nonce checks
- one bounded taxonomy query used for targeted cache invalidation

No final finding represents an unassessed release-blocking runtime, security, compatibility, or packaging defect.

## Validation

- `composer validate --no-check-publish`
- `composer lint` — 67 PHP files
- `composer test` — 95 tests, 234 assertions
- `composer phpstan` — 47 files, no errors
- `composer audit` — no known advisories
- targeted PHPCS for `CacheActivityService.php`
- `npm run lint`
- `npm run test:unit` — 2 suites, 10 tests
- `npm run build`
- `npm run plugin-zip`
- `git diff --check origin/release/1.7.0...HEAD`
- exact ZIP contents, exclusions, versions, install, activation, Plugin Check, and browser proof described above

The repository-wide `composer check-cs` command still scans non-PHP Playwright files and reports the pre-existing baseline violations. The hosted code-style workflow is the canonical repository gate and remains required on this PR.

## Scope boundary

No new optimization feature, tag, release, publish/deploy, WordPress.org deployment, production merge, or protected-branch push is included.
