### PR TITLE
Add autoloaded options and object cache audit

### DIFF
--- a/assets/src/css/admin/settings.css
+++ b/assets/src/css/admin/settings.css
@@ -531,6 +531,159 @@
 	margin-bottom: 8px;
 }
 
+.perform-database-audit {
+	display: grid;
+	gap: 24px;
+}
+
+.perform-database-audit__heading {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 24px;
+	padding-bottom: 24px;
+	border-bottom: 1px solid var(--perform-color-border);
+}
+
+.perform-database-audit__heading h2 {
+	margin: 0 0 8px;
+	font-size: 24px;
+	line-height: 1.25;
+}
+
+.perform-database-audit__heading p:not(.perform-dashboard-eyebrow) {
+	max-width: 760px;
+	margin: 0;
+	color: var(--perform-color-text-muted);
+	font-size: 14px;
+	line-height: 1.55;
+}
+
+.perform-database-audit__message {
+	padding: 12px 16px;
+	border-left: 4px solid var(--perform-color-brand);
+	background: #f6f7f7;
+}
+
+.perform-database-audit__message.is-error {
+	border-left-color: var(--perform-color-danger);
+}
+
+.perform-database-audit__message.is-success {
+	border-left-color: var(--perform-color-success);
+}
+
+.perform-database-audit__empty {
+	border-radius: 0;
+	box-shadow: none;
+}
+
+.perform-database-audit__empty h3 {
+	margin: 0 0 8px;
+	font-size: 18px;
+}
+
+.perform-database-audit__empty p {
+	max-width: 720px;
+	margin: 0;
+	color: var(--perform-color-text-muted);
+}
+
+.perform-database-audit__summary {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	border-top: 1px solid var(--perform-color-border);
+	border-bottom: 1px solid var(--perform-color-border);
+}
+
+.perform-database-audit__summary > div {
+	min-width: 0;
+	padding: 20px 24px;
+	border-right: 1px solid var(--perform-color-border);
+}
+
+.perform-database-audit__summary > div:first-child {
+	padding-left: 0;
+}
+
+.perform-database-audit__summary > div:last-child {
+	border-right: 0;
+}
+
+.perform-database-audit__summary span,
+.perform-database-audit__confidence {
+	display: block;
+	color: var(--perform-color-text-muted);
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.perform-database-audit__summary strong {
+	display: block;
+	margin-top: 8px;
+	font-size: 24px;
+	line-height: 1.2;
+}
+
+.perform-database-audit__guidance {
+	padding: 16px 20px;
+	border-left: 4px solid var(--perform-color-brand);
+	background: #f6f7f7;
+}
+
+.perform-database-audit__guidance.is-review {
+	border-left-color: var(--perform-color-warning);
+}
+
+.perform-database-audit__guidance p {
+	margin: 6px 0 0;
+	color: var(--perform-color-text-muted);
+}
+
+.perform-database-audit__table-wrap {
+	overflow-x: auto;
+}
+
+.perform-database-audit__table {
+	width: 100%;
+	border-collapse: collapse;
+	text-align: left;
+}
+
+.perform-database-audit__table th,
+.perform-database-audit__table td {
+	padding: 14px 12px;
+	border-bottom: 1px solid var(--perform-color-border);
+	vertical-align: top;
+}
+
+.perform-database-audit__table thead th {
+	color: var(--perform-color-text-muted);
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
+.perform-database-audit__table tbody th {
+	font-weight: 400;
+}
+
+.perform-database-audit__table code {
+	white-space: normal;
+	overflow-wrap: anywhere;
+}
+
+.perform-database-audit__confidence {
+	margin-top: 3px;
+	font-weight: 400;
+}
+
+.perform-database-audit__meta {
+	margin: 0;
+	color: var(--perform-color-text-muted);
+	font-size: 12px;
+}
+
 @media screen and (max-width: 782px) {
 
 	.perform-settings-page {
@@ -584,6 +737,30 @@
 
 	.perform-settings-field[data-control='toggle'] .perform-settings-field__control {
 		min-height: 32px;
+	}
+
+	.perform-database-audit__heading {
+		flex-direction: column;
+	}
+
+	.perform-database-audit__heading .components-button {
+		width: 100%;
+		justify-content: center;
+	}
+
+	.perform-database-audit__summary {
+		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.perform-database-audit__summary > div,
+	.perform-database-audit__summary > div:first-child {
+		padding: 16px 0;
+		border-right: 0;
+		border-bottom: 1px solid var(--perform-color-border);
+	}
+
+	.perform-database-audit__summary > div:last-child {
+		border-bottom: 0;
 	}
 
 	.perform-cache-activity-actions {

--- a/assets/src/js/admin/DatabaseAuditPanel.jsx
+++ b/assets/src/js/admin/DatabaseAuditPanel.jsx
@@ -1,0 +1,227 @@
+import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const SETTINGS = window.performwpSettings || {};
+
+const formatBytes = ( value ) => {
+	const bytes = Number( value ) || 0;
+	if ( bytes < 1024 ) {
+		return `${ bytes } B`;
+	}
+
+	if ( bytes < 1024 * 1024 ) {
+		return `${ ( bytes / 1024 ).toFixed( 1 ) } KB`;
+	}
+
+	return `${ ( bytes / ( 1024 * 1024 ) ).toFixed( 2 ) } MB`;
+};
+
+const DatabaseAuditPanel = ( { initialAudit = SETTINGS.databaseAudit || {} } ) => {
+	const [ audit, setAudit ] = useState( initialAudit );
+	const [ refreshing, setRefreshing ] = useState( false );
+	const [ message, setMessage ] = useState( null );
+	const hasAudit = 'ready' === audit.status;
+	const totals = audit.totals || {};
+	const largestOptions = audit.largestOptions || [];
+	const needsReview = hasAudit && ( totals.sizeBytes || 0 ) > ( audit.thresholdBytes || 800000 );
+	let refreshLabel = hasAudit ? __( 'Refresh audit', 'perform' ) : __( 'Run audit', 'perform' );
+	if ( refreshing ) {
+		refreshLabel = __( 'Running audit…', 'perform' );
+	}
+
+	const refreshAudit = async () => {
+		setRefreshing( true );
+		setMessage( { type: 'status', text: __( 'Running the database audit…', 'perform' ) } );
+
+		try {
+			const response = await fetch( window.ajaxurl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+				},
+				body: new URLSearchParams( {
+					action: 'perform_refresh_autoload_options_audit',
+					nonce: SETTINGS.databaseAuditNonce || '',
+				} ),
+			} );
+			const result = await response.json();
+
+			if ( ! response.ok || ! result?.success || ! result.data?.audit ) {
+				throw new Error(
+					result?.data?.message || __( 'The database audit could not be refreshed.', 'perform' )
+				);
+			}
+
+			setAudit( result.data.audit );
+			setMessage( {
+				type: 'success',
+				text: result.data.message || __( 'Database audit refreshed.', 'perform' ),
+			} );
+		} catch ( error ) {
+			setMessage( {
+				type: 'error',
+				text: error?.message || __( 'The database audit could not be refreshed. Please try again.', 'perform' ),
+			} );
+		} finally {
+			setRefreshing( false );
+		}
+	};
+
+	return (
+		<div className="perform-database-audit">
+			<div className="perform-database-audit__heading">
+				<div>
+					<p className="perform-dashboard-eyebrow">{ __( 'Database health', 'perform' ) }</p>
+					<h2>{ __( 'Autoloaded options audit', 'perform' ) }</h2>
+					<p>
+						{ __(
+							'Review how much option data WordPress loads on every request. Perform shows names and sizes, never stored values, and does not change third-party data.',
+							'perform'
+						) }
+					</p>
+				</div>
+				<Button variant="primary" onClick={ refreshAudit } disabled={ refreshing } isBusy={ refreshing }>
+					{ refreshLabel }
+				</Button>
+			</div>
+
+			{ message && (
+				<div
+					className={ `perform-database-audit__message is-${ message.type }` }
+					role={ 'error' === message.type ? 'alert' : 'status' }
+					aria-live="polite"
+				>
+					{ message.text }
+				</div>
+			) }
+
+			{ ! hasAudit ? (
+				<Card className="perform-database-audit__empty">
+					<CardBody>
+						<h3>{ __( 'Run the first local audit', 'perform' ) }</h3>
+						<p>
+							{ __(
+								'The scan runs only when requested, stores a bounded snapshot for this site, and makes no external requests.',
+								'perform'
+							) }
+						</p>
+					</CardBody>
+				</Card>
+			) : (
+				<>
+					<div
+						className="perform-database-audit__summary"
+						aria-label={ __( 'Autoloaded options summary', 'perform' ) }
+					>
+						<div>
+							<span>{ __( 'Total autoloaded size', 'perform' ) }</span>
+							<strong>{ formatBytes( totals.sizeBytes ) }</strong>
+						</div>
+						<div>
+							<span>{ __( 'Autoloaded options', 'perform' ) }</span>
+							<strong>{ totals.count || 0 }</strong>
+						</div>
+						<div>
+							<span>{ __( 'Persistent object cache', 'perform' ) }</span>
+							<strong>
+								{ audit.objectCache?.persistent
+									? __( 'Detected', 'perform' )
+									: __( 'Not detected', 'perform' ) }
+							</strong>
+						</div>
+					</div>
+
+					<div
+						className={ `perform-database-audit__guidance ${
+							needsReview ? 'is-review' : 'is-informational'
+						}` }
+					>
+						<strong>
+							{ needsReview ? __( 'Review recommended', 'perform' ) : __( 'Informational', 'perform' ) }
+						</strong>
+						<p>
+							{ needsReview
+								? __(
+										'The measured total is above WordPress Site Health’s guidance threshold. Review the largest entries with the extension owner before changing autoload behavior.',
+										'perform'
+								  )
+								: __(
+										'The measured total is below WordPress Site Health’s guidance threshold. Size alone does not prove that an option is unnecessary.',
+										'perform'
+								  ) }
+						</p>
+					</div>
+
+					<Card>
+						<CardHeader>
+							<div>
+								<h3 className="perform-card-title">
+									{ __( 'Largest autoloaded options', 'perform' ) }
+								</h3>
+								<p className="perform-card-description">
+									{ __(
+										'Showing up to 20 option names and stored sizes. Values remain private.',
+										'perform'
+									) }
+								</p>
+							</div>
+						</CardHeader>
+						<CardBody>
+							<div className="perform-database-audit__table-wrap">
+								<table className="perform-database-audit__table">
+									<thead>
+										<tr>
+											<th scope="col">{ __( 'Option', 'perform' ) }</th>
+											<th scope="col">{ __( 'Size', 'perform' ) }</th>
+											<th scope="col">{ __( 'Autoload state', 'perform' ) }</th>
+											<th scope="col">{ __( 'Likely owner', 'perform' ) }</th>
+										</tr>
+									</thead>
+									<tbody>
+										{ 0 === largestOptions.length && (
+											<tr>
+												<td colSpan="4">
+													{ __(
+														'No autoloaded options were returned for this site.',
+														'perform'
+													) }
+												</td>
+											</tr>
+										) }
+										{ largestOptions.map( ( option ) => (
+											<tr key={ option.name }>
+												<th scope="row">
+													<code>{ option.name }</code>
+												</th>
+												<td>{ formatBytes( option.sizeBytes ) }</td>
+												<td>{ option.autoload }</td>
+												<td>
+													{ option.ownership?.label || __( 'Unknown', 'perform' ) }
+													<span className="perform-database-audit__confidence">
+														{ option.ownership?.confidence || __( 'unknown', 'perform' ) }{ ' ' }
+														{ __( 'confidence', 'perform' ) }
+													</span>
+												</td>
+											</tr>
+										) ) }
+									</tbody>
+								</table>
+							</div>
+						</CardBody>
+					</Card>
+
+					<p className="perform-database-audit__meta">
+						{ __( 'Snapshot generated', 'perform' ) }{ ' ' }
+						{ new Date( ( audit.generatedAt || 0 ) * 1000 ).toLocaleString() }
+						{ audit.isStale ? ` · ${ __( 'Refresh recommended', 'perform' ) }` : '' }
+						{ audit.isMultisite ? ` · ${ __( 'Current site only', 'perform' ) }` : '' }
+					</p>
+				</>
+			) }
+		</div>
+	);
+};
+
+export { formatBytes };
+export default DatabaseAuditPanel;

--- a/assets/src/js/admin/DatabaseAuditPanel.test.jsx
+++ b/assets/src/js/admin/DatabaseAuditPanel.test.jsx
@@ -1,0 +1,87 @@
+/* eslint-env jest */
+
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+window.performwpSettings = {
+	databaseAuditNonce: 'audit-nonce',
+};
+
+const DatabaseAuditPanel = require( './DatabaseAuditPanel' ).default;
+
+const readyAudit = {
+	status: 'ready',
+	generatedAt: 1700000000,
+	expiresAt: 1700086400,
+	isStale: false,
+	isMultisite: false,
+	totals: { count: 42, sizeBytes: 912345 },
+	thresholdBytes: 800000,
+	objectCache: { persistent: true },
+	largestOptions: [
+		{
+			name: 'perform_settings',
+			sizeBytes: 2048,
+			autoload: 'auto-on',
+			ownership: { label: 'Perform', confidence: 'high' },
+		},
+	],
+};
+
+describe( 'DatabaseAuditPanel', () => {
+	afterEach( () => {
+		delete global.fetch;
+		jest.restoreAllMocks();
+	} );
+
+	it( 'explains the manual and privacy-safe empty state', () => {
+		render( <DatabaseAuditPanel initialAudit={ { status: 'not-run' } } /> );
+
+		expect( screen.getByRole( 'button', { name: 'Run audit' } ) ).toBeEnabled();
+		expect( screen.getByText( 'Run the first local audit' ) ).toBeInTheDocument();
+		expect( screen.getByText( /makes no external requests/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows bounded results without option values or automatic actions', () => {
+		render( <DatabaseAuditPanel initialAudit={ readyAudit } /> );
+
+		expect( screen.getByText( '891.0 KB' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'perform_settings' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Review recommended' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /delete/i ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'announces progress and replaces the snapshot after refresh', async () => {
+		global.fetch = jest.fn().mockResolvedValue( {
+			ok: true,
+			json: async () => ( {
+				success: true,
+				data: {
+					message: 'Database audit refreshed.',
+					audit: { ...readyAudit, totals: { count: 50, sizeBytes: 700000 } },
+				},
+			} ),
+		} );
+
+		render( <DatabaseAuditPanel initialAudit={ readyAudit } /> );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Refresh audit' } ) );
+
+		expect( screen.getByRole( 'button', { name: 'Running audit…' } ) ).toBeDisabled();
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Running the database audit…' );
+		await waitFor( () => expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Database audit refreshed.' ) );
+		expect( screen.getByText( '50' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows a recoverable error when refresh fails', async () => {
+		global.fetch = jest.fn().mockResolvedValue( {
+			ok: false,
+			json: async () => ( { success: false, data: { message: 'Synthetic audit failure.' } } ),
+		} );
+
+		render( <DatabaseAuditPanel initialAudit={ readyAudit } /> );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Refresh audit' } ) );
+
+		expect( await screen.findByRole( 'alert' ) ).toHaveTextContent( 'Synthetic audit failure.' );
+		expect( screen.getByRole( 'button', { name: 'Refresh audit' } ) ).toBeEnabled();
+	} );
+} );

--- a/assets/src/js/admin/SettingsApp.jsx
+++ b/assets/src/js/admin/SettingsApp.jsx
@@ -10,6 +10,7 @@ const SETTINGS_FIELDS = SETTINGS.fields || {};
 const SAVED_SETTINGS = SETTINGS.saved || {};
 const INITIAL_DIAGNOSTICS = SETTINGS.diagnostics || {};
 const DASHBOARD = SETTINGS.dashboard || {};
+const DATABASE_AUDIT = SETTINGS.databaseAudit || {};
 const TAB_KEYS = [ 'dashboard', ...Object.keys( SETTINGS_TABS ) ];
 
 const normalizeTab = ( tab ) => ( TAB_KEYS.includes( tab ) ? tab : 'dashboard' );
@@ -173,13 +174,14 @@ const SettingsApp = () => {
 				tabs={ tabs }
 				dashboard={ DASHBOARD }
 				diagnostics={ diagnostics }
+				databaseAudit={ DATABASE_AUDIT }
 				activeTab={ activeTab }
 				onTabChange={ handleTabChange }
 				fieldValues={ fieldValues }
 				onFieldChange={ handleFieldChange }
 			/>
 			{ 'dashboard' === activeTab && <DiagnosticsPanel diagnostics={ diagnostics } /> }
-			{ 'cache-stats' !== activeTab && (
+			{ ! [ 'cache-stats', 'database' ].includes( activeTab ) && (
 				<Footer dirty={ isDirty } saving={ saving } message={ message } onSave={ handleSave } />
 			) }
 		</>

--- a/assets/src/js/admin/SettingsNav.jsx
+++ b/assets/src/js/admin/SettingsNav.jsx
@@ -2,6 +2,7 @@ import { TabPanel } from '@wordpress/components';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import CacheStatsPanel from './CacheStatsPanel';
 import DashboardPanel from './DashboardPanel';
+import DatabaseAuditPanel from './DatabaseAuditPanel';
 import SettingsFieldRow from './settings/SettingsFieldRow';
 
 const SETTINGS = window.performwpSettings || {};
@@ -11,6 +12,7 @@ const SettingsNav = ( {
 	fields: propFields,
 	dashboard,
 	diagnostics,
+	databaseAudit,
 	activeTab: propActiveTab,
 	onTabChange: propOnTabChange,
 	fieldValues: propFieldValues,
@@ -98,6 +100,8 @@ const SettingsNav = ( {
 
 					if ( 'dashboard' === selectedTabName ) {
 						content = <DashboardPanel dashboard={ dashboard } diagnostics={ diagnostics } />;
+					} else if ( 'database' === selectedTabName ) {
+						content = <DatabaseAuditPanel initialAudit={ databaseAudit } />;
 					} else if ( 'cache-stats' === selectedTabName ) {
 						content = <CacheStatsPanel />;
 					}

--- a/languages/perform.pot
+++ b/languages/perform.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: PerformWP <hello@performwp.com>\n"
-"POT-Creation-Date: 2026-07-26 06:25+0000\n"
+"POT-Creation-Date: 2026-08-07 10:29+0000\n"
 "Report-Msgid-Bugs-To: https://github.com/performwp/perform/issues/new\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
@@ -16,63 +16,63 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/Admin/Actions.php:82
+#: src/Admin/Actions.php:85
 msgid "Activity actions"
 msgstr ""
 
-#: src/Admin/Actions.php:83
+#: src/Admin/Actions.php:86
 msgid "Export cache activity for review or clear the collected metrics."
 msgstr ""
 
-#: src/Admin/Actions.php:84
+#: src/Admin/Actions.php:87
 msgid "Export CSV"
 msgstr ""
 
-#: src/Admin/Actions.php:85
+#: src/Admin/Actions.php:88
 msgid "Exporting…"
 msgstr ""
 
-#: src/Admin/Actions.php:86
+#: src/Admin/Actions.php:89
 msgid "Cache activity exported."
 msgstr ""
 
-#: src/Admin/Actions.php:87
+#: src/Admin/Actions.php:90
 msgid "Cache activity could not be exported."
 msgstr ""
 
-#: src/Admin/Actions.php:88
+#: src/Admin/Actions.php:91
 msgid "Clear activity"
 msgstr ""
 
-#: src/Admin/Actions.php:89
+#: src/Admin/Actions.php:92
 msgid "Clearing…"
 msgstr ""
 
-#: src/Admin/Actions.php:90
+#: src/Admin/Actions.php:93
 msgid "Clear all collected cache activity? This does not clear cached pages."
 msgstr ""
 
-#: src/Admin/Actions.php:91, src/Modules/Cache/PageCache.php:828, src/Modules/Cache/PageCache.php:1090
+#: src/Admin/Actions.php:94, src/Modules/Cache/PageCache.php:828, src/Modules/Cache/PageCache.php:1090
 msgid "Cache activity cleared."
 msgstr ""
 
-#: src/Admin/Actions.php:92
+#: src/Admin/Actions.php:95
 msgid "Cache activity could not be cleared."
 msgstr ""
 
-#: src/Admin/Actions.php:121
+#: src/Admin/Actions.php:124
 msgid "Close Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:118, src/Modules/Assets/AssetsManager.php:274
+#: src/Admin/Actions.php:121, src/Modules/Assets/AssetsManager.php:274
 msgid "Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:128, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:254
+#: src/Admin/Actions.php:131, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:254
 msgid "Perform"
 msgstr ""
 
-#: src/Admin/Actions.php:148
+#: src/Admin/Actions.php:151
 msgid "Support Forum"
 msgstr ""
 
@@ -692,6 +692,38 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
+#: src/Admin/Settings/AutoloadOptionsAudit.php:55
+msgid "The options table is unavailable."
+msgstr ""
+
+#: src/Admin/Settings/AutoloadOptionsAudit.php:81
+msgid "The options audit could not be completed."
+msgstr ""
+
+#: src/Admin/Settings/AutoloadOptionsAudit.php:107
+msgid "The audit result could not be saved."
+msgstr ""
+
+#: src/Admin/Settings/AutoloadOptionsAudit.php:180
+msgid "Unknown"
+msgstr ""
+
+#: src/Admin/Settings/AutoloadOptionsAuditController.php:38, src/Admin/Settings/Menu.php:110
+msgid "Insufficient permissions."
+msgstr ""
+
+#: src/Admin/Settings/AutoloadOptionsAuditController.php:48, src/Admin/Settings/Menu.php:121
+msgid "Security check failed."
+msgstr ""
+
+#: src/Admin/Settings/AutoloadOptionsAuditController.php:59
+msgid "The database audit could not be refreshed. Please try again."
+msgstr ""
+
+#: src/Admin/Settings/AutoloadOptionsAuditController.php:67
+msgid "Database audit refreshed."
+msgstr ""
+
 #: src/Admin/Settings/DashboardPayload.php:105
 msgid "Dashboard, diagnostics, cache, and Assets Manager work in 1.7.0 remains release-candidate content until the owner approves publication."
 msgstr ""
@@ -705,22 +737,18 @@ msgid "Assets Manager summary reports configured rule coverage, not historical b
 msgstr ""
 
 #: src/Admin/Settings/Menu.php:55
+msgid "Database"
+msgstr ""
+
+#: src/Admin/Settings/Menu.php:56
 msgid "Cache Stats"
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:109
-msgid "Insufficient permissions."
-msgstr ""
-
-#: src/Admin/Settings/Menu.php:120
-msgid "Security check failed."
-msgstr ""
-
-#: src/Admin/Settings/Menu.php:236
+#: src/Admin/Settings/Menu.php:237
 msgid "Unable to save the settings. Please try again."
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:228
+#: src/Admin/Settings/Menu.php:229
 msgid "Settings saved successfully."
 msgstr ""
 

--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -12,6 +12,7 @@ namespace Perform\Admin;
 
 use Perform\Includes\Helpers;
 use Perform\Admin\Settings\ClientPayload;
+use Perform\Admin\Settings\AutoloadOptionsAudit;
 use Perform\Admin\Settings\DashboardPayload;
 use Perform\Admin\Settings\Menu;
 use Perform\Admin\Settings\RuntimeDiagnostics;
@@ -62,19 +63,21 @@ class Actions {
 				'perform-admin',
 				'performwpSettings',
 				[
-					'version'           => defined( 'PERFORM_VERSION' ) ? PERFORM_VERSION : '',
-					'docsUrl'           => defined( 'PERFORM_PLUGIN_DOCS_URL' ) ? PERFORM_PLUGIN_DOCS_URL : 'https://performwp.com/docs/',
-					'logoUrl'           => plugins_url( 'assets/dist/images/logo.png', PERFORM_PLUGIN_FILE ),
-					'nonce'             => wp_create_nonce( 'perform_save_settings' ),
-					'saved'             => ClientPayload::sanitize_for_client( (array) \Perform\Includes\Helpers::get_settings() ),
-					'dashboard'         => DashboardPayload::get_data(),
-					'diagnostics'       => RuntimeDiagnostics::get_results(),
-					'sensitiveKeys'     => ClientPayload::get_sensitive_keys(),
-					'maskedSecretValue' => ClientPayload::MASKED_SECRET,
-					'tabs'              => Menu::get_navigation_tabs(),
-					'activeTab'         => Menu::get_requested_tab(),
-					'fields'            => \Perform\Includes\Helpers::get_settings_fields(), // Expose fields to JS
-					'cacheActivity'     => [
+					'version'            => defined( 'PERFORM_VERSION' ) ? PERFORM_VERSION : '',
+					'docsUrl'            => defined( 'PERFORM_PLUGIN_DOCS_URL' ) ? PERFORM_PLUGIN_DOCS_URL : 'https://performwp.com/docs/',
+					'logoUrl'            => plugins_url( 'assets/dist/images/logo.png', PERFORM_PLUGIN_FILE ),
+					'nonce'              => wp_create_nonce( 'perform_save_settings' ),
+					'saved'              => ClientPayload::sanitize_for_client( (array) \Perform\Includes\Helpers::get_settings() ),
+					'dashboard'          => DashboardPayload::get_data(),
+					'diagnostics'        => RuntimeDiagnostics::get_results(),
+					'databaseAudit'      => AutoloadOptionsAudit::get_cached_snapshot(),
+					'databaseAuditNonce' => wp_create_nonce( 'perform_refresh_autoload_options_audit' ),
+					'sensitiveKeys'      => ClientPayload::get_sensitive_keys(),
+					'maskedSecretValue'  => ClientPayload::MASKED_SECRET,
+					'tabs'               => Menu::get_navigation_tabs(),
+					'activeTab'          => Menu::get_requested_tab(),
+					'fields'             => \Perform\Includes\Helpers::get_settings_fields(), // Expose fields to JS
+					'cacheActivity'      => [
 						'actionUrl'         => admin_url( 'admin-post.php' ),
 						'exportNonce'       => wp_create_nonce( 'perform_export_cache_activity' ),
 						'clearNonce'        => wp_create_nonce( 'perform_clear_cache_activity' ),

--- a/src/Admin/Settings/AutoloadOptionsAudit.php
+++ b/src/Admin/Settings/AutoloadOptionsAudit.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Perform - Autoloaded options audit.
+ *
+ * @package Perform
+ * @subpackage Admin/Settings
+ */
+
+namespace Perform\Admin\Settings;
+
+use RuntimeException;
+
+// Bailout, if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Collects a bounded, read-only snapshot of autoloaded option pressure.
+ */
+final class AutoloadOptionsAudit {
+	const OPTION_NAME    = 'perform_autoload_options_audit';
+	const SCHEMA_VERSION = 1;
+	const CACHE_TTL      = 86400;
+	const RESULT_LIMIT   = 20;
+	const SIZE_THRESHOLD = 800000;
+
+	/**
+	 * Get the cached audit without performing database work.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function get_cached_snapshot() {
+		$snapshot = get_option( self::OPTION_NAME, [] );
+
+		if ( ! is_array( $snapshot ) || self::SCHEMA_VERSION !== (int) ( $snapshot['schemaVersion'] ?? 0 ) ) {
+			return self::get_empty_snapshot();
+		}
+
+		$snapshot['isStale'] = time() >= (int) ( $snapshot['expiresAt'] ?? 0 );
+
+		return $snapshot;
+	}
+
+	/**
+	 * Run and persist a fresh audit for the current site.
+	 *
+	 * @return array<string, mixed>
+	 * @throws RuntimeException When the database audit cannot be completed.
+	 */
+	public static function refresh() {
+		global $wpdb;
+
+		if ( ! is_object( $wpdb ) || empty( $wpdb->options ) ) {
+			throw new RuntimeException( __( 'The options table is unavailable.', 'perform' ) );
+		}
+
+		$autoload_values = self::get_autoload_values();
+		$placeholders    = implode( ', ', array_fill( 0, count( $autoload_values ), '%s' ) );
+		$table           = $wpdb->options;
+
+		// The table is the wpdb-owned options table and every autoload value is
+		// passed through prepare. PHPCS cannot infer the dynamic placeholder list.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$summary_query = $wpdb->prepare(
+			"SELECT COUNT(*) AS option_count, COALESCE(SUM(LENGTH(option_value)), 0) AS total_size FROM {$table} WHERE autoload IN ({$placeholders})",
+			$autoload_values
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$summary = $wpdb->get_row( $summary_query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Prepared above; manual diagnostic persisted below.
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$options_query = $wpdb->prepare(
+			"SELECT option_name, autoload, LENGTH(option_value) AS size_bytes FROM {$table} WHERE autoload IN ({$placeholders}) ORDER BY size_bytes DESC, option_name ASC LIMIT %d",
+			array_merge( $autoload_values, [ self::RESULT_LIMIT ] )
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$options = $wpdb->get_results( $options_query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Prepared above; manual diagnostic persisted below.
+
+		if ( ! is_array( $summary ) || ! is_array( $options ) || ! empty( $wpdb->last_error ) ) {
+			throw new RuntimeException( __( 'The options audit could not be completed.', 'perform' ) );
+		}
+
+		$generated_at = time();
+		$snapshot     = [
+			'schemaVersion'  => self::SCHEMA_VERSION,
+			'status'         => 'ready',
+			'generatedAt'    => $generated_at,
+			'expiresAt'      => $generated_at + self::CACHE_TTL,
+			'isStale'        => false,
+			'isMultisite'    => is_multisite(),
+			'siteId'         => get_current_blog_id(),
+			'autoloadValues' => $autoload_values,
+			'thresholdBytes' => self::SIZE_THRESHOLD,
+			'totals'         => [
+				'count'     => max( 0, (int) ( $summary['option_count'] ?? 0 ) ),
+				'sizeBytes' => max( 0, (int) ( $summary['total_size'] ?? 0 ) ),
+			],
+			'objectCache'    => [
+				'persistent' => wp_using_ext_object_cache(),
+			],
+			'largestOptions' => self::normalize_options( $options ),
+		];
+
+		$is_saved = update_option( self::OPTION_NAME, $snapshot, false );
+		if ( ! $is_saved && get_option( self::OPTION_NAME ) !== $snapshot ) {
+			throw new RuntimeException( __( 'The audit result could not be saved.', 'perform' ) );
+		}
+
+		return $snapshot;
+	}
+
+	/**
+	 * Get the values WordPress treats as autoload-enabled.
+	 *
+	 * @return array<int, string>
+	 */
+	private static function get_autoload_values() {
+		if ( function_exists( 'wp_autoload_values_to_autoload' ) ) {
+			$values = wp_autoload_values_to_autoload();
+			if ( is_array( $values ) && ! empty( $values ) ) {
+				return array_values( array_unique( array_map( 'strval', $values ) ) );
+			}
+		}
+
+		return [ 'yes', 'on', 'auto-on', 'auto' ];
+	}
+
+	/**
+	 * Normalize database rows without exposing option values.
+	 *
+	 * @param array<int, mixed> $options Database rows.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function normalize_options( array $options ) {
+		$normalized = [];
+
+		foreach ( array_slice( $options, 0, self::RESULT_LIMIT ) as $option ) {
+			if ( ! is_array( $option ) || empty( $option['option_name'] ) ) {
+				continue;
+			}
+
+			$name         = sanitize_text_field( (string) $option['option_name'] );
+			$normalized[] = [
+				'name'      => $name,
+				'sizeBytes' => max( 0, (int) ( $option['size_bytes'] ?? 0 ) ),
+				'autoload'  => sanitize_key( (string) ( $option['autoload'] ?? '' ) ),
+				'ownership' => self::get_ownership_hint( $name ),
+			];
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Provide conservative ownership hints for names with reliable prefixes.
+	 *
+	 * @param string $option_name Option name.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function get_ownership_hint( $option_name ) {
+		if ( 0 === strpos( $option_name, 'perform_' ) ) {
+			return [
+				'label'      => 'Perform',
+				'confidence' => 'high',
+			];
+		}
+
+		$core_names = [ 'active_plugins', 'cron', 'rewrite_rules', 'sidebars_widgets' ];
+		if ( in_array( $option_name, $core_names, true ) || 0 === strpos( $option_name, 'widget_' ) || 0 === strpos( $option_name, 'wp_user_roles' ) ) {
+			return [
+				'label'      => 'WordPress',
+				'confidence' => 'high',
+			];
+		}
+
+		return [
+			'label'      => __( 'Unknown', 'perform' ),
+			'confidence' => 'unknown',
+		];
+	}
+
+	/**
+	 * Get the safe client shape before the first audit.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function get_empty_snapshot() {
+		return [
+			'schemaVersion'  => self::SCHEMA_VERSION,
+			'status'         => 'not-run',
+			'generatedAt'    => 0,
+			'expiresAt'      => 0,
+			'isStale'        => false,
+			'isMultisite'    => is_multisite(),
+			'siteId'         => get_current_blog_id(),
+			'autoloadValues' => self::get_autoload_values(),
+			'thresholdBytes' => self::SIZE_THRESHOLD,
+			'totals'         => [
+				'count'     => 0,
+				'sizeBytes' => 0,
+			],
+			'objectCache'    => [
+				'persistent' => wp_using_ext_object_cache(),
+			],
+			'largestOptions' => [],
+		];
+	}
+}

--- a/src/Admin/Settings/AutoloadOptionsAuditController.php
+++ b/src/Admin/Settings/AutoloadOptionsAuditController.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Perform - Autoloaded options audit controller.
+ *
+ * @package Perform
+ * @subpackage Admin/Settings
+ */
+
+namespace Perform\Admin\Settings;
+
+use Throwable;
+
+// Bailout, if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles authorized manual audit refresh requests.
+ */
+final class AutoloadOptionsAuditController {
+	/**
+	 * Register WordPress hooks.
+	 */
+	public function __construct() {
+		add_action( 'wp_ajax_perform_refresh_autoload_options_audit', [ $this, 'refresh' ] );
+	}
+
+	/**
+	 * Refresh the audit for the current site.
+	 *
+	 * @return void
+	 */
+	public function refresh() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error(
+				[
+					'message' => esc_html__( 'Insufficient permissions.', 'perform' ),
+				],
+				403
+			);
+		}
+
+		$nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['nonce'] ) ) : '';
+		if ( ! wp_verify_nonce( $nonce, 'perform_refresh_autoload_options_audit' ) ) {
+			wp_send_json_error(
+				[
+					'message' => esc_html__( 'Security check failed.', 'perform' ),
+				],
+				403
+			);
+		}
+
+		try {
+			$audit = AutoloadOptionsAudit::refresh();
+		} catch ( Throwable $exception ) {
+			wp_send_json_error(
+				[
+					'message' => esc_html__( 'The database audit could not be refreshed. Please try again.', 'perform' ),
+				],
+				500
+			);
+		}
+
+		wp_send_json_success(
+			[
+				'message' => esc_html__( 'Database audit refreshed.', 'perform' ),
+				'audit'   => $audit,
+			]
+		);
+	}
+}

--- a/src/Admin/Settings/Menu.php
+++ b/src/Admin/Settings/Menu.php
@@ -52,6 +52,7 @@ class Menu {
 	 */
 	public static function get_navigation_tabs() {
 		$tabs                = Helpers::get_settings_tabs();
+		$tabs['database']    = esc_html__( 'Database', 'perform' );
 		$tabs['cache-stats'] = esc_html__( 'Cache Stats', 'perform' );
 
 		return $tabs;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -52,6 +52,7 @@ final class Plugin {
 
 		// Load Admin Files.
 		new Settings\Menu();
+		new Settings\AutoloadOptionsAuditController();
 		new Admin\Actions();
 		new Admin\Filters();
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,6 +19,10 @@ if ( ! defined( 'PHP_URL_HOST' ) ) {
 	define( 'PHP_URL_HOST', 1 );
 }
 
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+
 if ( ! function_exists( 'plugin_basename' ) ) {
 	function plugin_basename( $file ) {
 		$basename = basename( (string) $file );
@@ -560,6 +564,24 @@ if ( ! function_exists( 'wp_verify_nonce' ) ) {
 if ( ! function_exists( 'get_current_blog_id' ) ) {
 	function get_current_blog_id() {
 		return isset( $GLOBALS['perform_test_blog_id'] ) ? (int) $GLOBALS['perform_test_blog_id'] : 1;
+	}
+}
+
+if ( ! function_exists( 'is_multisite' ) ) {
+	function is_multisite() {
+		return ! empty( $GLOBALS['perform_test_is_multisite'] );
+	}
+}
+
+if ( ! function_exists( 'wp_using_ext_object_cache' ) ) {
+	function wp_using_ext_object_cache() {
+		return ! empty( $GLOBALS['perform_test_ext_object_cache'] );
+	}
+}
+
+if ( ! function_exists( 'wp_autoload_values_to_autoload' ) ) {
+	function wp_autoload_values_to_autoload() {
+		return $GLOBALS['perform_test_autoload_values'] ?? [ 'yes', 'on', 'auto-on', 'auto' ];
 	}
 }
 

--- a/tests/unit-tests/tests-autoload-options-audit.php
+++ b/tests/unit-tests/tests-autoload-options-audit.php
@@ -1,0 +1,165 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Perform\Admin\Settings\AutoloadOptionsAudit;
+use Perform\Admin\Settings\AutoloadOptionsAuditController;
+
+final class Tests_Autoload_Options_Audit extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['perform_test_options']          = [];
+		$GLOBALS['perform_test_current_user_can'] = [ 'manage_options' => true ];
+		$GLOBALS['perform_test_nonce_valid']      = true;
+		$GLOBALS['perform_test_ext_object_cache'] = true;
+		$GLOBALS['perform_test_is_multisite']     = false;
+		$GLOBALS['perform_test_blog_id']          = 1;
+		$GLOBALS['perform_test_autoload_values']  = [ 'yes', 'on', 'auto-on', 'auto' ];
+		$GLOBALS['wpdb']                          = new Perform_Test_Autoload_Wpdb();
+		$_POST                                    = [];
+	}
+
+	protected function tearDown(): void {
+		unset(
+			$GLOBALS['perform_test_options'],
+			$GLOBALS['perform_test_current_user_can'],
+			$GLOBALS['perform_test_nonce_valid'],
+			$GLOBALS['perform_test_ext_object_cache'],
+			$GLOBALS['perform_test_is_multisite'],
+			$GLOBALS['perform_test_blog_id'],
+			$GLOBALS['perform_test_autoload_values'],
+			$GLOBALS['perform_test_json_response'],
+			$GLOBALS['wpdb']
+		);
+		$_POST = [];
+	}
+
+	public function test_refresh_collects_bounded_names_and_sizes_without_values() {
+		$GLOBALS['wpdb']->summary = [
+			'option_count' => 45,
+			'total_size'   => 912345,
+		];
+
+		for ( $index = 0; $index < 25; ++$index ) {
+			$GLOBALS['wpdb']->options_rows[] = [
+				'option_name'  => 0 === $index ? 'perform_settings' : 'plugin_' . $index,
+				'autoload'     => 'auto-on',
+				'size_bytes'   => 50000 - $index,
+				'option_value' => 'must-not-leak',
+			];
+		}
+
+		$snapshot = AutoloadOptionsAudit::refresh();
+
+		$this->assertSame( 45, $snapshot['totals']['count'] );
+		$this->assertSame( 912345, $snapshot['totals']['sizeBytes'] );
+		$this->assertTrue( $snapshot['objectCache']['persistent'] );
+		$this->assertSame( [ 'yes', 'on', 'auto-on', 'auto' ], $snapshot['autoloadValues'] );
+		$this->assertCount( 20, $snapshot['largestOptions'] );
+		$this->assertSame( 'Perform', $snapshot['largestOptions'][0]['ownership']['label'] );
+		$this->assertArrayNotHasKey( 'option_value', $snapshot['largestOptions'][0] );
+		$this->assertStringContainsString( 'LIMIT %d', $GLOBALS['wpdb']->queries[1] );
+		$this->assertSame( AutoloadOptionsAudit::RESULT_LIMIT, end( $GLOBALS['wpdb']->prepare_args[1] ) );
+		$this->assertSame( $snapshot, $GLOBALS['perform_test_options'][ AutoloadOptionsAudit::OPTION_NAME ] );
+	}
+
+	public function test_cached_snapshot_is_marked_stale_without_refreshing_database() {
+		$GLOBALS['perform_test_options'][ AutoloadOptionsAudit::OPTION_NAME ] = [
+			'schemaVersion' => AutoloadOptionsAudit::SCHEMA_VERSION,
+			'status'        => 'ready',
+			'expiresAt'     => time() - 1,
+		];
+
+		$snapshot = AutoloadOptionsAudit::get_cached_snapshot();
+
+		$this->assertTrue( $snapshot['isStale'] );
+		$this->assertSame( [], $GLOBALS['wpdb']->queries );
+	}
+
+	public function test_empty_snapshot_is_per_site_and_does_not_run_a_query() {
+		$GLOBALS['perform_test_is_multisite'] = true;
+		$GLOBALS['perform_test_blog_id']      = 7;
+
+		$snapshot = AutoloadOptionsAudit::get_cached_snapshot();
+
+		$this->assertSame( 'not-run', $snapshot['status'] );
+		$this->assertTrue( $snapshot['isMultisite'] );
+		$this->assertSame( 7, $snapshot['siteId'] );
+		$this->assertSame( [], $GLOBALS['wpdb']->queries );
+	}
+
+	public function test_refresh_endpoint_requires_manage_options() {
+		$GLOBALS['perform_test_current_user_can']['manage_options'] = false;
+
+		$this->run_controller_request();
+
+		$this->assertFalse( $GLOBALS['perform_test_json_response']['success'] );
+		$this->assertSame( 'Insufficient permissions.', $GLOBALS['perform_test_json_response']['data']['message'] );
+		$this->assertSame( [], $GLOBALS['wpdb']->queries );
+	}
+
+	public function test_refresh_endpoint_requires_valid_nonce() {
+		$GLOBALS['perform_test_nonce_valid'] = false;
+		$_POST['nonce']                      = 'invalid';
+
+		$this->run_controller_request();
+
+		$this->assertFalse( $GLOBALS['perform_test_json_response']['success'] );
+		$this->assertSame( 'Security check failed.', $GLOBALS['perform_test_json_response']['data']['message'] );
+		$this->assertSame( [], $GLOBALS['wpdb']->queries );
+	}
+
+	public function test_refresh_endpoint_returns_the_safe_snapshot() {
+		$_POST['nonce'] = 'valid';
+
+		$this->run_controller_request();
+
+		$this->assertTrue( $GLOBALS['perform_test_json_response']['success'] );
+		$this->assertSame( 'ready', $GLOBALS['perform_test_json_response']['data']['audit']['status'] );
+	}
+
+	private function run_controller_request() {
+		try {
+			( new AutoloadOptionsAuditController() )->refresh();
+			$this->fail( 'Expected the JSON response to end the request.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'perform_test_json_response', $exception->getMessage() );
+		}
+	}
+}
+
+// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound -- Focused database fixture for this service.
+final class Perform_Test_Autoload_Wpdb {
+	/** @var string */
+	public $options = 'wp_options';
+
+	/** @var string */
+	public $last_error = '';
+
+	/** @var array<string, int> */
+	public $summary = [
+		'option_count' => 0,
+		'total_size'   => 0,
+	];
+
+	/** @var array<int, array<string, mixed>> */
+	public $options_rows = [];
+
+	/** @var array<int, string> */
+	public $queries = [];
+
+	/** @var array<int, array<int, mixed>> */
+	public $prepare_args = [];
+
+	public function prepare( $query, $args ) {
+		$this->queries[]      = $query;
+		$this->prepare_args[] = $args;
+		return $query;
+	}
+
+	public function get_row( $query, $output ) {
+		return $this->summary;
+	}
+
+	public function get_results( $query, $output ) {
+		return $this->options_rows;
+	}
+}

--- a/tests/unit-tests/tests-settings-menu.php
+++ b/tests/unit-tests/tests-settings-menu.php
@@ -40,6 +40,7 @@ final class Tests_Settings_Menu extends TestCase {
 
 	public function test_cache_stats_is_a_known_canonical_tab_and_unknown_tabs_fall_back() {
 		$this->assertArrayHasKey( 'cache-stats', Menu::get_navigation_tabs() );
+		$this->assertArrayHasKey( 'database', Menu::get_navigation_tabs() );
 
 		$_GET['tab'] = 'cache-stats';
 		$this->assertSame( 'cache-stats', Menu::get_requested_tab() );

--- a/uninstall.php
+++ b/uninstall.php
@@ -18,7 +18,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
  */
 function perform_handle_plugin_uninstall() {
 
-	$option_keys = array(
+	$option_keys = [
 		'perform_settings',
 		'perform_common',
 		'perform_ssl',
@@ -30,7 +30,8 @@ function perform_handle_plugin_uninstall() {
 		'perform_assets_manager_options',
 		'perform_cache_preload_queue',
 		'perform_cache_stats',
-	);
+		'perform_autoload_options_audit',
+	];
 
 	$remove_data_on_uninstall = false;
 
@@ -44,7 +45,7 @@ function perform_handle_plugin_uninstall() {
 	if ( $remove_data_on_uninstall ) {
 
 		if ( is_multisite() ) {
-			$sites = get_sites( array( 'deleted' => 0 ) );
+			$sites = get_sites( [ 'deleted' => 0 ] );
 
 			if ( ! empty( $sites ) ) {
 				foreach ( $sites as $site ) {


### PR DESCRIPTION
## Summary

- add a manual, read-only autoloaded-options audit under a new Database tab
- report bounded totals, top option names/sizes, conservative ownership hints, and persistent object-cache status
- cache one per-site snapshot for 24 hours and never expose option values or mutate third-party options
- add capability/nonce protection, progress/error feedback, multisite-aware metadata, and uninstall cleanup

Related to #140.

## Product and safety contract

- Audit runs only when an administrator requests it.
- Results are capped at 20 option names and contain no option values.
- No automatic cleanup or autoload-state mutation is introduced.
- The snapshot is stored with autoload disabled and refreshes explicitly.
- Database queries use the WordPress-owned options-table identifier and prepared dynamic values.

## Validation

- `composer validate --strict`
- PHPUnit: 102 tests, 264 assertions
- PHP parallel lint: 70 files
- PHPStan: no errors
- PHPCS on all changed PHP files: pass
- React unit tests: 3 suites, 14 tests
- JS and CSS lint: pass
- production asset build: pass
- Composer audit: no advisories
- npm production dependency audit: 0 vulnerabilities
- `git diff --check`

## Runtime proof

Validated on the existing local Perform WordPress Studio site:

- Database tab is present and keyboard-accessible in the native tab flow.
- Manual audit completed successfully against the site's options table.
- UI reported total autoloaded size/count, largest option names/sizes, and object-cache status.
- No option values were rendered.
- At 390 px, the page had no document-level horizontal overflow (`scrollWidth === clientWidth`).
- Refresh action and success status were visible and recoverable.

## Known repository baseline

The repository-wide `composer check-cs` command also scans non-PHP fixtures and reports pre-existing style failures outside this PR. The hosted code-style workflow scopes PHPCS to changed PHP files; that exact changed-file set passes locally.
