### PR TITLE
Add evidence-bound Performance Health Dashboard

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,11 +81,11 @@ jobs:
       - name: Run Playwright smoke tests
         run: npm run test:e2e:ci
 
-      - name: Upload Site Inventory UI proof
+      - name: Upload settings UI proof
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: site-inventory-ui-proof
+          name: perform-settings-ui-proof
           path: test-results/proof/
           if-no-files-found: ignore
           retention-days: 14

--- a/assets/src/css/admin/settings.css
+++ b/assets/src/css/admin/settings.css
@@ -435,30 +435,37 @@
 
 .perform-dashboard {
 	display: grid;
-	gap: 20px;
+	gap: 24px;
 }
 
-.perform-dashboard-hero {
-	border-radius: 0;
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+.perform-dashboard > *,
+.perform-dashboard-grid > *,
+.perform-health-grid > *,
+.perform-dashboard .components-card__body {
+	min-width: 0;
 }
 
-.perform-dashboard-hero__header {
+.perform-dashboard-overview {
+	display: flex;
 	align-items: flex-start;
 	justify-content: space-between;
-	gap: 20px;
+	gap: 32px;
+	padding-bottom: 24px;
+	border-bottom: 1px solid var(--perform-color-border);
 }
 
-.perform-dashboard-hero h2 {
+.perform-dashboard-overview h2 {
 	margin: 0 0 8px;
-	font-size: 24px;
+	font-size: 28px;
 	line-height: 1.25;
 }
 
-.perform-dashboard-hero p {
+.perform-dashboard-overview p:not(.perform-dashboard-eyebrow) {
 	max-width: 720px;
 	margin: 0;
 	color: var(--perform-color-text-muted);
+	font-size: 14px;
+	line-height: 1.55;
 }
 
 .perform-dashboard-eyebrow {
@@ -473,11 +480,13 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: 8px;
+	flex-shrink: 0;
 }
 
 .perform-dashboard-grid,
 .perform-dashboard-stats,
-.perform-dashboard-metrics {
+.perform-dashboard-metrics,
+.perform-health-grid {
 	display: grid;
 	gap: 16px;
 }
@@ -487,7 +496,7 @@
 }
 
 .perform-dashboard-stats {
-	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+	grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .perform-dashboard-metrics {
@@ -496,10 +505,79 @@
 }
 
 .perform-dashboard-stat {
+	min-width: 0;
 	min-height: 84px;
 	padding: 12px 14px;
 	border-left: 4px solid var(--perform-color-brand);
 	background: #f6f7f7;
+}
+
+.perform-health-grid {
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.perform-health-card {
+	border-radius: 0;
+	border-left: 4px solid var(--perform-color-border);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.perform-health-card[data-status='ready'] {
+	border-left-color: var(--perform-color-success);
+}
+
+.perform-health-card[data-status='review'] {
+	border-left-color: var(--perform-color-warning);
+}
+
+.perform-health-card[data-status='observe'] {
+	border-left-color: var(--perform-color-brand);
+}
+
+.perform-health-card__heading {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+}
+
+.perform-health-card__heading h3 {
+	margin: 0;
+	font-size: 16px;
+	line-height: 1.35;
+}
+
+.perform-health-card__heading span {
+	display: inline-flex;
+	flex-shrink: 0;
+	align-items: center;
+	min-height: 24px;
+	padding: 2px 8px;
+	border: 1px solid var(--perform-color-border);
+	border-radius: 12px;
+	background: #f6f7f7;
+	color: var(--perform-color-text-muted);
+	font-size: 11px;
+	font-weight: 600;
+}
+
+.perform-health-card p {
+	min-height: 44px;
+	margin: 12px 0;
+	color: var(--perform-color-text-muted);
+	line-height: 1.5;
+}
+
+.perform-dashboard-measurement-note {
+	padding: 16px 20px;
+	border-left: 4px solid var(--perform-color-brand);
+	background: #f6f7f7;
+}
+
+.perform-dashboard-measurement-note p {
+	margin: 6px 0 0;
+	color: var(--perform-color-text-muted);
+	line-height: 1.5;
 }
 
 .perform-dashboard-stat span {
@@ -1007,6 +1085,29 @@
 
 	.perform-database-audit__heading {
 		flex-direction: column;
+	}
+
+	.perform-dashboard-overview {
+		flex-direction: column;
+	}
+
+	.perform-dashboard-actions,
+	.perform-dashboard-actions .components-button {
+		width: 100%;
+	}
+
+	.perform-dashboard-actions .components-button {
+		justify-content: center;
+	}
+
+	.perform-dashboard-stats,
+	.perform-health-grid,
+	.perform-dashboard-grid {
+		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.perform-health-card p {
+		min-height: 0;
 	}
 
 	.perform-site-inventory__heading {

--- a/assets/src/js/admin/DashboardPanel.jsx
+++ b/assets/src/js/admin/DashboardPanel.jsx
@@ -1,4 +1,208 @@
 import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+const STATUS_LABELS = {
+	ready: __( 'Ready', 'perform' ),
+	review: __( 'Review', 'perform' ),
+	observe: __( 'Observing', 'perform' ),
+	'not-measured': __( 'Not measured', 'perform' ),
+};
+
+const formatBytes = ( bytes ) => {
+	const value = Number( bytes );
+	if ( ! Number.isFinite( value ) || value <= 0 ) {
+		return '0 B';
+	}
+
+	if ( value >= 1024 * 1024 ) {
+		return `${ ( value / ( 1024 * 1024 ) ).toFixed( 1 ) } MB`;
+	}
+
+	if ( value >= 1024 ) {
+		return `${ ( value / 1024 ).toFixed( 1 ) } KB`;
+	}
+
+	return `${ Math.round( value ) } B`;
+};
+
+const findDiagnostic = ( diagnostics, id ) => ( diagnostics?.items || [] ).find( ( item ) => item.id === id ) || null;
+
+const buildHealthCards = ( { dashboard, diagnostics, databaseAudit, siteInventory } ) => {
+	const data = dashboard || {};
+	const cache = data.cache || {};
+	const server = data.server || {};
+	const inventory = siteInventory || {};
+	const audit = databaseAudit || {};
+	const inventoryReady = 'ready' === inventory.status;
+	const auditReady = 'ready' === audit.status;
+	const enabledModules = inventory.perform?.items || [];
+	const pageCacheEnabled = enabledModules.some( ( module ) => 'enable_page_cache' === module.id );
+	const hasDiagnostics = ( diagnostics?.items || [] ).length > 0;
+	const diagnosticSummary = diagnostics?.summary || {};
+	const runtimeAttention = ( diagnosticSummary.warning ?? 0 ) + ( diagnosticSummary[ 'needs-attention' ] ?? 0 );
+	const autoloadSize = audit.totals?.sizeBytes ?? 0;
+	const autoloadThreshold = audit.thresholdBytes ?? 0;
+	const autoloadNeedsReview = auditReady && autoloadThreshold > 0 && autoloadSize > autoloadThreshold;
+	let databaseStatus = 'not-measured';
+	if ( auditReady ) {
+		databaseStatus = autoloadNeedsReview ? 'review' : 'ready';
+	}
+
+	let runtimeStatus = 'not-measured';
+	let runtimeDescription = __( 'Runtime diagnostics are not available in the current page payload.', 'perform' );
+	if ( hasDiagnostics ) {
+		runtimeStatus = runtimeAttention > 0 ? 'review' : 'ready';
+		runtimeDescription = __( 'Local cache and delivery prerequisites currently report ready.', 'perform' );
+		if ( runtimeAttention > 0 ) {
+			runtimeDescription = sprintf(
+				/* translators: %d: diagnostic count requiring review. */
+				_n(
+					'%d cache or delivery check needs review.',
+					'%d cache or delivery checks need review.',
+					runtimeAttention,
+					'perform'
+				),
+				runtimeAttention
+			);
+		}
+	}
+
+	let cacheStatus = 'not-measured';
+	let cacheDescription = __(
+		'Page cache is disabled. Enable it only after reviewing dynamic-site exclusions.',
+		'perform'
+	);
+	if ( pageCacheEnabled ) {
+		cacheStatus = 'observe';
+		cacheDescription = __(
+			'Page cache is enabled; more local traffic is needed for a useful activity summary.',
+			'perform'
+		);
+	}
+	if ( cache.hasStats ) {
+		cacheStatus = 'ready';
+		cacheDescription = sprintf(
+			/* translators: %s: measured cache hit ratio. */
+			__( '%s%% measured cache hit ratio from local activity.', 'perform' ),
+			cache.hitRatio ?? 0
+		);
+	}
+
+	let serverStatus = 'not-measured';
+	if ( 'warning' === server.opcache?.state ) {
+		serverStatus = 'review';
+	} else if ( 'ready' === server.opcache?.state || true === audit.objectCache?.persistent ) {
+		serverStatus = 'ready';
+	}
+
+	const cards = [
+		{
+			id: 'inventory',
+			title: __( 'Site context', 'perform' ),
+			status: inventoryReady ? 'ready' : 'not-measured',
+			description: inventoryReady
+				? sprintf(
+						/* translators: 1: active plugin count, 2: registered content type count, 3: enabled Perform module count. */
+						__(
+							'%1$d active plugins, %2$d content types, and %3$d Perform modules measured locally.',
+							'perform'
+						),
+						inventory.plugins?.activeCount ?? 0,
+						inventory.postTypes?.totalCount ?? 0,
+						enabledModules.length
+				  )
+				: __( 'Generate a private local inventory before using site-specific guidance.', 'perform' ),
+			action: inventoryReady ? null : { label: __( 'Generate inventory', 'perform' ), tab: 'inventory' },
+		},
+		{
+			id: 'database',
+			title: __( 'Database pressure', 'perform' ),
+			status: databaseStatus,
+			description: auditReady
+				? sprintf(
+						/* translators: %s: measured autoloaded option size. */
+						__( '%s of autoloaded options measured against WordPress guidance.', 'perform' ),
+						formatBytes( autoloadSize )
+				  )
+				: __( 'Run the local database audit to measure autoloaded option pressure.', 'perform' ),
+			action: {
+				label: auditReady ? __( 'Review database', 'perform' ) : __( 'Run database audit', 'perform' ),
+				tab: 'database',
+			},
+		},
+		{
+			id: 'runtime',
+			title: __( 'Runtime checks', 'perform' ),
+			status: runtimeStatus,
+			description: runtimeDescription,
+			action: { label: __( 'View runtime checks', 'perform' ), target: 'perform-runtime-diagnostics' },
+		},
+		{
+			id: 'cache',
+			title: __( 'Page caching', 'perform' ),
+			status: cacheStatus,
+			description: cacheDescription,
+			action: {
+				label: cache.hasStats
+					? __( 'View cache activity', 'perform' )
+					: __( 'Review cache settings', 'perform' ),
+				tab: cache.hasStats ? 'cache-stats' : 'cache',
+			},
+		},
+		{
+			id: 'server',
+			title: __( 'Server acceleration', 'perform' ),
+			status: serverStatus,
+			description: sprintf(
+				/* translators: 1: OPcache state, 2: persistent object-cache state, 3: compression state. */
+				__( 'OPcache: %1$s. Persistent object cache: %2$s. Response compression: %3$s.', 'perform' ),
+				'ready' === server.opcache?.state ? __( 'detected', 'perform' ) : __( 'not confirmed', 'perform' ),
+				true === audit.objectCache?.persistent ? __( 'detected', 'perform' ) : __( 'not confirmed', 'perform' ),
+				'ready' === server.compression?.state
+					? __( 'detected in PHP', 'perform' )
+					: __( 'needs a separate response test', 'perform' )
+			),
+			action: { label: __( 'Review server evidence', 'perform' ), tab: 'database' },
+		},
+	];
+
+	if ( inventoryReady && inventory.patterns?.store ) {
+		const dynamicExclusions = findDiagnostic( diagnostics, 'dynamic-cache-exclusions' );
+		const needsReview = pageCacheEnabled && 'ready' !== dynamicExclusions?.status;
+
+		cards.push( {
+			id: 'store',
+			title: __( 'Store safety', 'perform' ),
+			status: needsReview ? 'review' : 'ready',
+			description: needsReview
+				? __( 'A store pattern is present. Review cart, checkout, account, and session exclusions.', 'perform' )
+				: __(
+						'A store pattern is present and current cache diagnostics show no unresolved exclusion warning.',
+						'perform'
+				  ),
+			action: { label: __( 'Review cache exclusions', 'perform' ), tab: 'cache' },
+		} );
+	}
+
+	return cards;
+};
+
+const HealthCard = ( { card, onAction } ) => (
+	<Card className="perform-health-card" data-status={ card.status }>
+		<CardBody>
+			<div className="perform-health-card__heading">
+				<h3>{ card.title }</h3>
+				<span>{ STATUS_LABELS[ card.status ] || STATUS_LABELS[ 'not-measured' ] }</span>
+			</div>
+			<p>{ card.description }</p>
+			{ card.action && (
+				<Button variant="link" onClick={ () => onAction( card.action ) }>
+					{ card.action.label }
+				</Button>
+			) }
+		</CardBody>
+	</Card>
+);
 
 const StatCard = ( { label, value, description } ) => (
 	<div className="perform-dashboard-stat">
@@ -8,122 +212,158 @@ const StatCard = ( { label, value, description } ) => (
 	</div>
 );
 
-const DashboardPanel = ( { dashboard, diagnostics } ) => {
+const DashboardPanel = ( { dashboard, diagnostics, databaseAudit, siteInventory, onNavigate } ) => {
 	const data = dashboard || {};
 	const links = data.links || {};
 	const cache = data.cache || {};
 	const assets = data.assetsManager || {};
-	const diagnosticSummary = diagnostics?.summary || {};
 	const changelog = data.changelog || [];
+	const cards = buildHealthCards( { dashboard: data, diagnostics, databaseAudit, siteInventory } );
+	const reviewCount = cards.filter( ( card ) => 'review' === card.status ).length;
+	const notMeasuredCount = cards.filter( ( card ) => 'not-measured' === card.status ).length;
+	const readyCount = cards.filter( ( card ) => 'ready' === card.status ).length;
+	const handleAction = ( action ) => {
+		if ( action.tab ) {
+			onNavigate?.( action.tab );
+			return;
+		}
+
+		if ( action.target ) {
+			document.getElementById( action.target )?.scrollIntoView( { behavior: 'smooth', block: 'start' } );
+		}
+	};
+
+	let summary = __( 'Your measured local performance checks are ready.', 'perform' );
+	if ( reviewCount > 0 ) {
+		summary = sprintf(
+			/* translators: %d: number of recommendations requiring review. */
+			_n( '%d action needs review.', '%d actions need review.', reviewCount, 'perform' ),
+			reviewCount
+		);
+	} else if ( notMeasuredCount > 0 ) {
+		summary = __( 'Finish the local diagnostics to unlock site-specific guidance.', 'perform' );
+	}
 
 	return (
 		<div className="perform-dashboard">
-			<Card className="perform-dashboard-hero">
-				<CardHeader className="perform-dashboard-hero__header">
-					<div>
-						<p className="perform-dashboard-eyebrow">Dashboard</p>
-						<h2>Perform overview</h2>
-						<p>
-							Review current plugin health, cache activity, and configured optimization rule coverage
-							before changing production settings.
-						</p>
-					</div>
-					<div className="perform-dashboard-actions">
-						<Button variant="primary" href={ links.docs || '#' } target="_blank" rel="noopener noreferrer">
-							View docs
-						</Button>
-						<Button
-							variant="secondary"
-							href={ links.support || '#' }
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							Support
-						</Button>
-					</div>
-				</CardHeader>
-				<CardBody>
-					<div className="perform-dashboard-stats">
-						<StatCard
-							label="Plugin version"
-							value={ data.version || 'Unknown' }
-							description="Bundled version loaded in this WordPress admin."
-						/>
-						<StatCard
-							label="Ready checks"
-							value={ diagnosticSummary.ready ?? 0 }
-							description="Runtime diagnostics currently marked ready."
-						/>
-						<StatCard
-							label="Warnings"
-							value={
-								( diagnosticSummary.warning ?? 0 ) + ( diagnosticSummary[ 'needs-attention' ] ?? 0 )
-							}
-							description="Review these before broad cache or CDN rollout."
-						/>
-					</div>
-				</CardBody>
-			</Card>
+			<section className="perform-dashboard-overview" aria-labelledby="perform-health-title">
+				<div>
+					<p className="perform-dashboard-eyebrow">{ __( 'Performance health', 'perform' ) }</p>
+					<h2 id="perform-health-title">{ summary }</h2>
+					<p>
+						{ __(
+							'Perform combines private local evidence into clear next steps. It never turns these checks into an unverified speed score.',
+							'perform'
+						) }
+					</p>
+				</div>
+				<div className="perform-dashboard-actions">
+					<Button variant="primary" href={ links.docs || '#' } target="_blank" rel="noopener noreferrer">
+						{ __( 'View documentation', 'perform' ) }
+					</Button>
+					<Button variant="secondary" href={ links.support || '#' } target="_blank" rel="noopener noreferrer">
+						{ __( 'Get support', 'perform' ) }
+					</Button>
+				</div>
+			</section>
+
+			<div className="perform-dashboard-stats" aria-label={ __( 'Performance health summary', 'perform' ) }>
+				<StatCard
+					label={ __( 'Ready', 'perform' ) }
+					value={ readyCount }
+					description={ __( 'Measured local areas', 'perform' ) }
+				/>
+				<StatCard
+					label={ __( 'Review', 'perform' ) }
+					value={ reviewCount }
+					description={ __( 'Actions worth checking', 'perform' ) }
+				/>
+				<StatCard
+					label={ __( 'Not measured', 'perform' ) }
+					value={ notMeasuredCount }
+					description={ __( 'Diagnostics still available', 'perform' ) }
+				/>
+			</div>
+
+			<div className="perform-health-grid">
+				{ cards.map( ( card ) => (
+					<HealthCard key={ card.id } card={ card } onAction={ handleAction } />
+				) ) }
+			</div>
+
+			<div className="perform-dashboard-measurement-note">
+				<strong>{ __( 'Core Web Vitals need a separate test', 'perform' ) }</strong>
+				<p>
+					{ __(
+						'Local WordPress diagnostics cannot prove real-user LCP, INP, or CLS. Field data and lab testing remain separate evidence sources.',
+						'perform'
+					) }
+				</p>
+			</div>
 
 			<div className="perform-dashboard-grid">
 				<Card>
 					<CardHeader>
 						<div>
-							<h3 className="perform-card-title">Cache summary</h3>
-							<p className="perform-card-description">Existing page cache stats from this site.</p>
+							<h3 className="perform-card-title">{ __( 'Cache value observed', 'perform' ) }</h3>
+							<p className="perform-card-description">
+								{ __( 'Measured requests from this site, without estimated time savings.', 'perform' ) }
+							</p>
 						</div>
 					</CardHeader>
 					<CardBody>
 						{ cache.hasStats ? (
 							<div className="perform-dashboard-metrics">
-								<StatCard label="Hit ratio" value={ `${ cache.hitRatio ?? 0 }%` } />
-								<StatCard label="Hits" value={ cache.hits ?? 0 } />
-								<StatCard label="Misses" value={ cache.misses ?? 0 } />
-								<StatCard label="Stale hits" value={ cache.staleHits ?? 0 } />
-								<StatCard label="Bypasses" value={ cache.bypasses ?? 0 } />
-								<StatCard label="Preload queue" value={ cache.preloadQueueSize ?? 0 } />
+								<StatCard
+									label={ __( 'Hit ratio', 'perform' ) }
+									value={ `${ cache.hitRatio ?? 0 }%` }
+								/>
+								<StatCard label={ __( 'Hits', 'perform' ) } value={ cache.hits ?? 0 } />
+								<StatCard label={ __( 'Misses', 'perform' ) } value={ cache.misses ?? 0 } />
+								<StatCard label={ __( 'Bypasses', 'perform' ) } value={ cache.bypasses ?? 0 } />
 							</div>
 						) : (
 							<p className="perform-dashboard-empty">
-								No cache stats have been recorded yet. Enable page cache and revisit after traffic or
-								preload runs.
+								{ __( 'No cache activity has been measured yet.', 'perform' ) }
 							</p>
 						) }
-						<a
-							className="perform-help-link"
-							href={ links.cache || '#' }
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							Read cache docs <span className="perform-help-icon">→</span>
-						</a>
+						<Button variant="link" onClick={ () => onNavigate?.( 'cache-stats' ) }>
+							{ __( 'Open cache activity', 'perform' ) }
+						</Button>
 					</CardBody>
 				</Card>
 
 				<Card>
 					<CardHeader>
 						<div>
-							<h3 className="perform-card-title">Assets Manager rule coverage</h3>
+							<h3 className="perform-card-title">{ __( 'Configured asset coverage', 'perform' ) }</h3>
 							<p className="perform-card-description">
-								Configured rules only. Perform does not store historical byte savings yet.
+								{ __( 'Configured rules only; no historical byte savings are claimed.', 'perform' ) }
 							</p>
 						</div>
 					</CardHeader>
 					<CardBody>
 						<div className="perform-dashboard-metrics">
-							<StatCard label="Disabled JS handles" value={ assets.disabledJsHandles ?? 0 } />
-							<StatCard label="Disabled CSS handles" value={ assets.disabledCssHandles ?? 0 } />
-							<StatCard label="Group rules" value={ assets.groupDisabledRules ?? 0 } />
-							<StatCard label="Current URL exceptions" value={ assets.currentPageExceptions ?? 0 } />
+							<StatCard
+								label={ __( 'Disabled JS', 'perform' ) }
+								value={ assets.disabledJsHandles ?? 0 }
+							/>
+							<StatCard
+								label={ __( 'Disabled CSS', 'perform' ) }
+								value={ assets.disabledCssHandles ?? 0 }
+							/>
+							<StatCard
+								label={ __( 'Group rules', 'perform' ) }
+								value={ assets.groupDisabledRules ?? 0 }
+							/>
+							<StatCard
+								label={ __( 'URL exceptions', 'perform' ) }
+								value={ assets.currentPageExceptions ?? 0 }
+							/>
 						</div>
-						<a
-							className="perform-help-link"
-							href={ links.assetsManager || '#' }
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							Read Assets Manager docs <span className="perform-help-icon">→</span>
-						</a>
+						<Button variant="link" onClick={ () => onNavigate?.( 'assets' ) }>
+							{ __( 'Open Assets Manager', 'perform' ) }
+						</Button>
 					</CardBody>
 				</Card>
 			</div>
@@ -131,8 +371,10 @@ const DashboardPanel = ( { dashboard, diagnostics } ) => {
 			<Card>
 				<CardHeader>
 					<div>
-						<h3 className="perform-card-title">Release notes</h3>
-						<p className="perform-card-description">Local release-candidate notes for owner review.</p>
+						<h3 className="perform-card-title">{ __( 'What this build includes', 'perform' ) }</h3>
+						<p className="perform-card-description">
+							{ __( 'Evidence-bound product updates included in the current code.', 'perform' ) }
+						</p>
 					</div>
 				</CardHeader>
 				<CardBody>
@@ -141,18 +383,11 @@ const DashboardPanel = ( { dashboard, diagnostics } ) => {
 							<li key={ item }>{ item }</li>
 						) ) }
 					</ul>
-					<a
-						className="perform-help-link"
-						href={ links.releaseNotes || '#' }
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						View release updates <span className="perform-help-icon">→</span>
-					</a>
 				</CardBody>
 			</Card>
 		</div>
 	);
 };
 
+export { buildHealthCards, findDiagnostic, formatBytes };
 export default DashboardPanel;

--- a/assets/src/js/admin/DashboardPanel.test.jsx
+++ b/assets/src/js/admin/DashboardPanel.test.jsx
@@ -1,0 +1,109 @@
+/* eslint-env jest */
+
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import DashboardPanel, { buildHealthCards } from './DashboardPanel';
+
+const dashboard = {
+	links: {
+		docs: 'https://performwp.com/docs/',
+		support: 'https://wordpress.org/support/plugin/perform/',
+	},
+	cache: { hasStats: false },
+	assetsManager: {},
+	server: {
+		opcache: { state: 'not-available', enabled: null },
+		compression: { state: 'needs-separate-test', phpEnabled: false },
+	},
+	changelog: [ 'Measured product update.' ],
+};
+
+const diagnostics = {
+	summary: { ready: 5, warning: 1, 'needs-attention': 0 },
+	items: [
+		{
+			id: 'dynamic-cache-exclusions',
+			status: 'warning',
+			label: 'Dynamic request exclusions',
+		},
+	],
+};
+
+const readyInventory = {
+	status: 'ready',
+	plugins: { activeCount: 3 },
+	postTypes: { totalCount: 8 },
+	perform: { items: [ { id: 'enable_page_cache' }, { id: 'enable_cdn' } ] },
+	patterns: { store: false },
+};
+
+describe( 'DashboardPanel', () => {
+	it( 'fails closed when local evidence is unavailable', () => {
+		const cards = buildHealthCards( {
+			dashboard,
+			diagnostics: {},
+			databaseAudit: { status: 'not-run' },
+			siteInventory: { status: 'not-run' },
+		} );
+
+		expect( cards.find( ( card ) => 'inventory' === card.id ).status ).toBe( 'not-measured' );
+		expect( cards.find( ( card ) => 'database' === card.id ).status ).toBe( 'not-measured' );
+		expect( cards.find( ( card ) => 'runtime' === card.id ).status ).toBe( 'not-measured' );
+		expect( cards.find( ( card ) => 'server' === card.id ).status ).toBe( 'not-measured' );
+	} );
+
+	it( 'uses measured local evidence for status and avoids an invented score', () => {
+		render(
+			<DashboardPanel
+				dashboard={ dashboard }
+				diagnostics={ diagnostics }
+				databaseAudit={ {
+					status: 'ready',
+					totals: { sizeBytes: 900000 },
+					thresholdBytes: 800000,
+					objectCache: { persistent: false },
+				} }
+				siteInventory={ readyInventory }
+			/>
+		);
+
+		expect( screen.getByText( /3 active plugins, 8 content types, and 2 Perform modules/ ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Core Web Vitals need a separate test' ) ).toBeInTheDocument();
+		expect( screen.getByText( /never turns these checks into an unverified speed score/i ) ).toBeInTheDocument();
+		expect( screen.getByText( /Response compression: needs a separate response test/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows store-safety guidance only when a store pattern is measured', () => {
+		const absent = buildHealthCards( {
+			dashboard,
+			diagnostics,
+			databaseAudit: { status: 'not-run' },
+			siteInventory: readyInventory,
+		} );
+		const present = buildHealthCards( {
+			dashboard,
+			diagnostics,
+			databaseAudit: { status: 'not-run' },
+			siteInventory: { ...readyInventory, patterns: { store: true } },
+		} );
+
+		expect( absent.find( ( card ) => 'store' === card.id ) ).toBeUndefined();
+		expect( present.find( ( card ) => 'store' === card.id ).status ).toBe( 'review' );
+	} );
+
+	it( 'routes internal recommendations without making an automatic request', () => {
+		const onNavigate = jest.fn();
+		render(
+			<DashboardPanel
+				dashboard={ dashboard }
+				diagnostics={ diagnostics }
+				databaseAudit={ { status: 'not-run' } }
+				siteInventory={ { status: 'not-run' } }
+				onNavigate={ onNavigate }
+			/>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Generate inventory' } ) );
+		expect( onNavigate ).toHaveBeenCalledWith( 'inventory' );
+	} );
+} );

--- a/assets/src/js/admin/DiagnosticsPanel.jsx
+++ b/assets/src/js/admin/DiagnosticsPanel.jsx
@@ -1,9 +1,10 @@
 import { Card, CardBody, CardHeader } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 const STATUS_LABELS = {
-	ready: 'Ready',
-	warning: 'Warning',
-	'needs-attention': 'Needs attention',
+	ready: __( 'Ready', 'perform' ),
+	warning: __( 'Warning', 'perform' ),
+	'needs-attention': __( 'Needs attention', 'perform' ),
 };
 
 const DiagnosticsPanel = ( { diagnostics } ) => {
@@ -14,12 +15,12 @@ const DiagnosticsPanel = ( { diagnostics } ) => {
 	}
 
 	return (
-		<Card className="perform-diagnostics-panel">
+		<Card id="perform-runtime-diagnostics" className="perform-diagnostics-panel">
 			<CardHeader className="perform-diagnostics-panel__header">
 				<div>
-					<h3 className="perform-card-title">Runtime Diagnostics</h3>
+					<h3 className="perform-card-title">{ __( 'Runtime Diagnostics', 'perform' ) }</h3>
 					<p className="perform-card-description">
-						Read-only checks for cache, CDN, and optimization prerequisites.
+						{ __( 'Read-only checks for cache, CDN, and optimization prerequisites.', 'perform' ) }
 					</p>
 				</div>
 			</CardHeader>
@@ -29,11 +30,15 @@ const DiagnosticsPanel = ( { diagnostics } ) => {
 						const status = item.status || 'warning';
 
 						return (
-							<div className="perform-diagnostics-item" data-status={ status } key={ item.label }>
+							<div
+								className="perform-diagnostics-item"
+								data-status={ status }
+								key={ item.id || item.label }
+							>
 								<div className="perform-diagnostics-item__heading">
 									<strong>{ item.label }</strong>
 									<span className="perform-diagnostics-badge">
-										{ STATUS_LABELS[ status ] || 'Warning' }
+										{ STATUS_LABELS[ status ] || STATUS_LABELS.warning }
 									</span>
 								</div>
 								<p>{ item.message }</p>

--- a/assets/src/js/admin/SettingsApp.jsx
+++ b/assets/src/js/admin/SettingsApp.jsx
@@ -183,7 +183,7 @@ const SettingsApp = () => {
 				onFieldChange={ handleFieldChange }
 			/>
 			{ 'dashboard' === activeTab && <DiagnosticsPanel diagnostics={ diagnostics } /> }
-			{ ! [ 'cache-stats', 'database', 'inventory' ].includes( activeTab ) && (
+			{ ! [ 'dashboard', 'cache-stats', 'database', 'inventory' ].includes( activeTab ) && (
 				<Footer dirty={ isDirty } saving={ saving } message={ message } onSave={ handleSave } />
 			) }
 		</>

--- a/assets/src/js/admin/SettingsNav.jsx
+++ b/assets/src/js/admin/SettingsNav.jsx
@@ -101,7 +101,15 @@ const SettingsNav = ( {
 					);
 
 					if ( 'dashboard' === selectedTabName ) {
-						content = <DashboardPanel dashboard={ dashboard } diagnostics={ diagnostics } />;
+						content = (
+							<DashboardPanel
+								dashboard={ dashboard }
+								diagnostics={ diagnostics }
+								databaseAudit={ databaseAudit }
+								siteInventory={ siteInventory }
+								onNavigate={ onTabChange }
+							/>
+						);
 					} else if ( 'database' === selectedTabName ) {
 						content = <DatabaseAuditPanel initialAudit={ databaseAudit } />;
 					} else if ( 'inventory' === selectedTabName ) {

--- a/languages/perform.pot
+++ b/languages/perform.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: PerformWP <hello@performwp.com>\n"
-"POT-Creation-Date: 2026-08-11 03:15+0000\n"
+"POT-Creation-Date: 2026-08-11 03:29+0000\n"
 "Report-Msgid-Bugs-To: https://github.com/performwp/perform/issues/new\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
@@ -724,16 +724,16 @@ msgstr ""
 msgid "Database audit refreshed."
 msgstr ""
 
-#: src/Admin/Settings/DashboardPayload.php:105
-msgid "Dashboard, diagnostics, cache, and Assets Manager work in 1.7.0 remains release-candidate content until the owner approves publication."
+#: src/Admin/Settings/DashboardPayload.php:174
+msgid "Perform 1.7.0 introduced the dashboard, runtime diagnostics, cache activity reporting, and the redesigned settings experience."
 msgstr ""
 
-#: src/Admin/Settings/DashboardPayload.php:106
-msgid "Runtime diagnostics summarize cache, CDN, menu cache, and dynamic request prerequisites without writing new tracking data."
+#: src/Admin/Settings/DashboardPayload.php:175
+msgid "The 1.8.0 diagnostic foundation adds bounded database and site-inventory evidence for safer recommendations."
 msgstr ""
 
-#: src/Admin/Settings/DashboardPayload.php:107
-msgid "Assets Manager summary reports configured rule coverage, not historical byte savings."
+#: src/Admin/Settings/DashboardPayload.php:176
+msgid "Configured rules and cache activity are reported without claiming unmeasured byte or Core Web Vitals savings."
 msgstr ""
 
 #: src/Admin/Settings/Menu.php:55
@@ -756,151 +756,151 @@ msgstr ""
 msgid "Settings saved successfully."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:69, src/Admin/Settings/RuntimeDiagnostics.php:82
+#: src/Admin/Settings/RuntimeDiagnostics.php:70, src/Admin/Settings/RuntimeDiagnostics.php:84
 msgid "Page cache storage"
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:70
+#: src/Admin/Settings/RuntimeDiagnostics.php:71
 msgid "Page cache is disabled, so no cache storage is required yet."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:71
+#: src/Admin/Settings/RuntimeDiagnostics.php:72
 msgid "Enable full-page cache when you are ready to test storage prerequisites."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:84
+#: src/Admin/Settings/RuntimeDiagnostics.php:86
 msgid "Perform can use the cache storage location for generated HTML files."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:85
+#: src/Admin/Settings/RuntimeDiagnostics.php:87
 msgid "Perform cannot confirm writable cache storage for generated HTML files."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:87, src/Admin/Settings/RuntimeDiagnostics.php:108, src/Admin/Settings/RuntimeDiagnostics.php:138, src/Admin/Settings/RuntimeDiagnostics.php:205
+#: src/Admin/Settings/RuntimeDiagnostics.php:89, src/Admin/Settings/RuntimeDiagnostics.php:111, src/Admin/Settings/RuntimeDiagnostics.php:143, src/Admin/Settings/RuntimeDiagnostics.php:214
 msgid "No action needed."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:88
+#: src/Admin/Settings/RuntimeDiagnostics.php:90
 msgid "Ask your host to allow WordPress to write to its cache directory before relying on full-page cache."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:102
+#: src/Admin/Settings/RuntimeDiagnostics.php:105
 msgid "Page cache drop-in"
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:104
+#: src/Admin/Settings/RuntimeDiagnostics.php:107
 msgid "A page-cache drop-in is present, so another cache layer may already be active."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:105
+#: src/Admin/Settings/RuntimeDiagnostics.php:108
 msgid "No page-cache drop-in was detected."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:107
+#: src/Admin/Settings/RuntimeDiagnostics.php:110
 msgid "Review host or plugin-level page caching before enabling overlapping cache behavior."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:123, src/Admin/Settings/RuntimeDiagnostics.php:133
+#: src/Admin/Settings/RuntimeDiagnostics.php:127, src/Admin/Settings/RuntimeDiagnostics.php:138
 msgid "Cache preload schedule"
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:124
+#: src/Admin/Settings/RuntimeDiagnostics.php:128
 msgid "Adaptive cache preload is disabled."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:125
+#: src/Admin/Settings/RuntimeDiagnostics.php:129
 msgid "Enable preload only after page cache is working reliably."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:135
+#: src/Admin/Settings/RuntimeDiagnostics.php:140
 msgid "The cache preload event is scheduled."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:136
+#: src/Admin/Settings/RuntimeDiagnostics.php:141
 msgid "The cache preload event is not scheduled yet."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:139
+#: src/Admin/Settings/RuntimeDiagnostics.php:144
 msgid "Save settings again or confirm WordPress cron is running on this site."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:154, src/Admin/Settings/RuntimeDiagnostics.php:168
+#: src/Admin/Settings/RuntimeDiagnostics.php:160, src/Admin/Settings/RuntimeDiagnostics.php:175
 msgid "Dynamic request exclusions"
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:155
+#: src/Admin/Settings/RuntimeDiagnostics.php:161
 msgid "Page cache is disabled, so dynamic request exclusions are not required yet."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:156
+#: src/Admin/Settings/RuntimeDiagnostics.php:162
 msgid "Add exclusions before enabling page cache on sites with member areas, custom checkouts, or preview tokens."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:170
+#: src/Admin/Settings/RuntimeDiagnostics.php:177
 msgid "Site-specific cache bypass rules are configured."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:171
+#: src/Admin/Settings/RuntimeDiagnostics.php:178
 msgid "No site-specific cache bypass rules are configured."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:173
+#: src/Admin/Settings/RuntimeDiagnostics.php:180
 msgid "Review bypass rules after adding new dynamic workflows."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:174
+#: src/Admin/Settings/RuntimeDiagnostics.php:181
 msgid "Add path, query, or cookie exclusions for dynamic workflows before broad cache rollout."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:189, src/Admin/Settings/RuntimeDiagnostics.php:200
+#: src/Admin/Settings/RuntimeDiagnostics.php:197, src/Admin/Settings/RuntimeDiagnostics.php:209
 msgid "Menu cache theme support"
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:190
+#: src/Admin/Settings/RuntimeDiagnostics.php:198
 msgid "Menu cache is disabled."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:191
+#: src/Admin/Settings/RuntimeDiagnostics.php:199
 msgid "Use menu cache primarily with classic themes that render menus through wp_nav_menu()."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:202
+#: src/Admin/Settings/RuntimeDiagnostics.php:211
 msgid "The active theme is eligible for menu cache."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:203
+#: src/Admin/Settings/RuntimeDiagnostics.php:212
 msgid "The active block theme is not expected to benefit from menu cache by default."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:206
+#: src/Admin/Settings/RuntimeDiagnostics.php:215
 msgid "Leave menu cache disabled unless custom theme code opts in through the compatibility filter."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:221, src/Admin/Settings/RuntimeDiagnostics.php:234
+#: src/Admin/Settings/RuntimeDiagnostics.php:231, src/Admin/Settings/RuntimeDiagnostics.php:245
 msgid "CDN configuration"
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:222
+#: src/Admin/Settings/RuntimeDiagnostics.php:232
 msgid "CDN rewriting is disabled."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:223
+#: src/Admin/Settings/RuntimeDiagnostics.php:233
 msgid "Enable CDN rewriting only after confirming the CDN origin URL and included directories."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:236
+#: src/Admin/Settings/RuntimeDiagnostics.php:247
 msgid "CDN rewriting has a valid CDN URL."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:237
+#: src/Admin/Settings/RuntimeDiagnostics.php:248
 msgid "CDN rewriting is enabled but the CDN URL is missing or invalid."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:239
+#: src/Admin/Settings/RuntimeDiagnostics.php:250
 msgid "Confirm included directories and exclusions before broad rollout."
 msgstr ""
 
-#: src/Admin/Settings/RuntimeDiagnostics.php:240
+#: src/Admin/Settings/RuntimeDiagnostics.php:251
 msgid "Enter a full CDN URL with http or https before enabling CDN rewriting."
 msgstr ""
 

--- a/src/Admin/Settings/DashboardPayload.php
+++ b/src/Admin/Settings/DashboardPayload.php
@@ -8,6 +8,8 @@
 
 namespace Perform\Admin\Settings;
 
+use Throwable;
+
 // Bailout, if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -25,7 +27,74 @@ final class DashboardPayload {
 			'links'         => self::get_links(),
 			'cache'         => self::get_cache_summary(),
 			'assetsManager' => self::get_assets_manager_summary(),
+			'server'        => self::get_server_summary(),
 			'changelog'     => self::get_changelog_items(),
+		];
+	}
+
+	/**
+	 * Detect bounded local server capabilities without external requests.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	private static function get_server_summary() {
+		$opcache_state   = 'not-available';
+		$opcache_enabled = null;
+
+		if ( function_exists( 'opcache_get_status' ) ) {
+			try {
+				$status = opcache_get_status( false );
+				if ( is_array( $status ) ) {
+					$opcache_enabled = ! empty( $status['opcache_enabled'] );
+					$opcache_state   = $opcache_enabled ? 'ready' : 'warning';
+				}
+			} catch ( Throwable $exception ) {
+				$opcache_state   = 'not-available';
+				$opcache_enabled = null;
+			}
+		}
+
+		$zlib_value       = strtolower( trim( (string) ini_get( 'zlib.output_compression' ) ) );
+		$zlib_enabled     = in_array( $zlib_value, [ '1', 'on', 'yes', 'true' ], true );
+		$detected_summary = [
+			'opcache'     => [
+				'state'   => $opcache_state,
+				'enabled' => $opcache_enabled,
+			],
+			'compression' => [
+				'state'      => $zlib_enabled ? 'ready' : 'needs-separate-test',
+				'phpEnabled' => $zlib_enabled,
+			],
+		];
+
+		$summary = apply_filters( 'perform_dashboard_server_summary', $detected_summary );
+
+		return self::normalize_server_summary( is_array( $summary ) ? $summary : [] );
+	}
+
+	/**
+	 * Normalize filtered server signals to the public dashboard contract.
+	 *
+	 * @param array<string, mixed> $summary Filtered summary.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	private static function normalize_server_summary( array $summary ) {
+		$allowed_states = [ 'ready', 'warning', 'not-available', 'needs-separate-test' ];
+		$opcache        = is_array( $summary['opcache'] ?? null ) ? $summary['opcache'] : [];
+		$compression    = is_array( $summary['compression'] ?? null ) ? $summary['compression'] : [];
+		$opcache_state  = (string) ( $opcache['state'] ?? 'not-available' );
+		$compress_state = (string) ( $compression['state'] ?? 'needs-separate-test' );
+
+		return [
+			'opcache'     => [
+				'state'   => in_array( $opcache_state, $allowed_states, true ) ? $opcache_state : 'not-available',
+				'enabled' => isset( $opcache['enabled'] ) ? (bool) $opcache['enabled'] : null,
+			],
+			'compression' => [
+				'state'      => in_array( $compress_state, $allowed_states, true ) ? $compress_state : 'needs-separate-test',
+				'phpEnabled' => ! empty( $compression['phpEnabled'] ),
+			],
 		];
 	}
 
@@ -102,9 +171,9 @@ final class DashboardPayload {
 	 */
 	private static function get_changelog_items() {
 		return [
-			__( 'Dashboard, diagnostics, cache, and Assets Manager work in 1.7.0 remains release-candidate content until the owner approves publication.', 'perform' ),
-			__( 'Runtime diagnostics summarize cache, CDN, menu cache, and dynamic request prerequisites without writing new tracking data.', 'perform' ),
-			__( 'Assets Manager summary reports configured rule coverage, not historical byte savings.', 'perform' ),
+			__( 'Perform 1.7.0 introduced the dashboard, runtime diagnostics, cache activity reporting, and the redesigned settings experience.', 'perform' ),
+			__( 'The 1.8.0 diagnostic foundation adds bounded database and site-inventory evidence for safer recommendations.', 'perform' ),
+			__( 'Configured rules and cache activity are reported without claiming unmeasured byte or Core Web Vitals savings.', 'perform' ),
 		];
 	}
 

--- a/src/Admin/Settings/RuntimeDiagnostics.php
+++ b/src/Admin/Settings/RuntimeDiagnostics.php
@@ -65,6 +65,7 @@ final class RuntimeDiagnostics {
 	private static function diagnose_page_cache_storage( array $settings ) {
 		if ( empty( $settings['enable_page_cache'] ) ) {
 			return self::item(
+				'page-cache-storage',
 				'ready',
 				__( 'Page cache storage', 'perform' ),
 				__( 'Page cache is disabled, so no cache storage is required yet.', 'perform' ),
@@ -78,6 +79,7 @@ final class RuntimeDiagnostics {
 		$storage_status = $storage_ready ? 'ready' : 'needs-attention';
 
 		return self::item(
+			'page-cache-storage',
 			$storage_status,
 			__( 'Page cache storage', 'perform' ),
 			$storage_ready
@@ -98,6 +100,7 @@ final class RuntimeDiagnostics {
 		$dropin_exists = file_exists( trailingslashit( self::get_wp_content_dir() ) . 'advanced-cache.php' );
 
 		return self::item(
+			'page-cache-dropin',
 			$dropin_exists ? 'warning' : 'ready',
 			__( 'Page cache drop-in', 'perform' ),
 			$dropin_exists
@@ -119,6 +122,7 @@ final class RuntimeDiagnostics {
 	private static function diagnose_cache_preload_schedule( array $settings ) {
 		if ( empty( $settings['enable_cache_preload'] ) ) {
 			return self::item(
+				'cache-preload-schedule',
 				'ready',
 				__( 'Cache preload schedule', 'perform' ),
 				__( 'Adaptive cache preload is disabled.', 'perform' ),
@@ -129,6 +133,7 @@ final class RuntimeDiagnostics {
 		$scheduled = function_exists( 'wp_next_scheduled' ) && wp_next_scheduled( 'perform_cache_preload_event' );
 
 		return self::item(
+			'cache-preload-schedule',
 			$scheduled ? 'ready' : 'warning',
 			__( 'Cache preload schedule', 'perform' ),
 			$scheduled
@@ -150,6 +155,7 @@ final class RuntimeDiagnostics {
 	private static function diagnose_dynamic_cache_exclusions( array $settings ) {
 		if ( empty( $settings['enable_page_cache'] ) ) {
 			return self::item(
+				'dynamic-cache-exclusions',
 				'ready',
 				__( 'Dynamic request exclusions', 'perform' ),
 				__( 'Page cache is disabled, so dynamic request exclusions are not required yet.', 'perform' ),
@@ -164,6 +170,7 @@ final class RuntimeDiagnostics {
 			|| ! empty( $settings['cache_bypass_cookie_prefixes'] );
 
 		return self::item(
+			'dynamic-cache-exclusions',
 			$has_exclusions ? 'ready' : 'warning',
 			__( 'Dynamic request exclusions', 'perform' ),
 			$has_exclusions
@@ -185,6 +192,7 @@ final class RuntimeDiagnostics {
 	private static function diagnose_menu_cache_theme_support( array $settings ) {
 		if ( empty( $settings['enable_navigation_menu_cache'] ) ) {
 			return self::item(
+				'menu-cache-theme-support',
 				'ready',
 				__( 'Menu cache theme support', 'perform' ),
 				__( 'Menu cache is disabled.', 'perform' ),
@@ -196,6 +204,7 @@ final class RuntimeDiagnostics {
 		$supported      = (bool) apply_filters( 'perform_menu_cache_supports_current_theme', ! $is_block_theme, $is_block_theme );
 
 		return self::item(
+			'menu-cache-theme-support',
 			$supported ? 'ready' : 'warning',
 			__( 'Menu cache theme support', 'perform' ),
 			$supported
@@ -217,6 +226,7 @@ final class RuntimeDiagnostics {
 	private static function diagnose_cdn_configuration( array $settings ) {
 		if ( empty( $settings['enable_cdn'] ) ) {
 			return self::item(
+				'cdn-configuration',
 				'ready',
 				__( 'CDN configuration', 'perform' ),
 				__( 'CDN rewriting is disabled.', 'perform' ),
@@ -230,6 +240,7 @@ final class RuntimeDiagnostics {
 		$ready   = '' !== $cdn_url && in_array( $scheme, [ 'http', 'https' ], true ) && '' !== $host;
 
 		return self::item(
+			'cdn-configuration',
 			$ready ? 'ready' : 'needs-attention',
 			__( 'CDN configuration', 'perform' ),
 			$ready
@@ -244,6 +255,7 @@ final class RuntimeDiagnostics {
 	/**
 	 * Build a diagnostic item.
 	 *
+	 * @param string $id Stable diagnostic ID.
 	 * @param string $status Status.
 	 * @param string $label Label.
 	 * @param string $message Message.
@@ -251,8 +263,9 @@ final class RuntimeDiagnostics {
 	 *
 	 * @return array<string, string>
 	 */
-	private static function item( $status, $label, $message, $action ) {
+	private static function item( $id, $status, $label, $message, $action ) {
 		return [
+			'id'      => sanitize_key( $id ),
 			'status'  => $status,
 			'label'   => $label,
 			'message' => $message,

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -45,15 +45,19 @@ test( 'settings save, Assets Manager, and page cache smoke paths work', async ( 
 
 	await openAdminPage( page, '/wp-admin/options-general.php?page=perform_settings' );
 	await expect( page.locator( '#perform-settings-page' ) ).toBeVisible();
-	await expect( page.getByRole( 'button', { name: 'Save Settings' } ) ).toBeVisible();
 	await expect( page.getByRole( 'tab', { name: 'Dashboard' } ) ).toBeVisible();
-	await expect( page.getByRole( 'heading', { name: 'Perform overview' } ) ).toBeVisible();
-	await expect( page.getByText( 'Runtime diagnostics currently marked ready.' ) ).toBeVisible();
+	await expect( page.getByText( 'Performance health' ) ).toBeVisible();
+	await expect( page.getByText( 'Core Web Vitals need a separate test' ) ).toBeVisible();
+	await expect( page.getByText( /unverified speed score/ ) ).toBeVisible();
 	await expect( page.getByRole( 'heading', { name: 'Runtime Diagnostics' } ) ).toBeVisible();
+	await expect( page.getByRole( 'button', { name: 'Save Settings' } ) ).toHaveCount( 0 );
+	await mkdir( 'test-results/proof', { recursive: true } );
+	await page.screenshot( { path: 'test-results/proof/performance-health-dashboard-desktop.png', fullPage: true } );
 
 	await page.getByRole( 'tab', { name: 'General' } ).click();
 	await expect( page.getByText( 'General Settings' ) ).toBeVisible();
 	await expect( page.getByRole( 'heading', { name: 'Runtime Diagnostics' } ) ).toHaveCount( 0 );
+	await expect( page.getByRole( 'button', { name: 'Save Settings' } ) ).toBeVisible();
 	await expect( page ).toHaveURL( /[?&]tab=general(?:&|$)/ );
 
 	await page.getByRole( 'tab', { name: 'Assets' } ).click();
@@ -90,6 +94,13 @@ test( 'settings field rows stack beneath their descriptions at narrow widths', a
 	await page.setViewportSize( { width: 390, height: 844 } );
 	await login( page );
 	await openAdminPage( page, '/wp-admin/options-general.php?page=perform_settings' );
+	await expect( page.getByText( 'Core Web Vitals need a separate test' ) ).toBeVisible();
+	await mkdir( 'test-results/proof', { recursive: true } );
+	await page.screenshot( { path: 'test-results/proof/performance-health-dashboard-mobile.png', fullPage: true } );
+	const dashboardHasHorizontalOverflow = await page.evaluate(
+		() => document.documentElement.scrollWidth > document.documentElement.clientWidth
+	);
+	expect( dashboardHasHorizontalOverflow ).toBeFalsy();
 
 	for ( const tabName of [ 'General', 'Bloat', 'Assets', 'CDN', 'Cache', 'Advanced' ] ) {
 		await page.getByRole( 'tab', { name: tabName, exact: true } ).click();

--- a/tests/unit-tests/tests-dashboard-payload.php
+++ b/tests/unit-tests/tests-dashboard-payload.php
@@ -6,10 +6,11 @@ use Perform\Admin\Settings\DashboardPayload;
 final class Tests_Dashboard_Payload extends TestCase {
 	protected function setUp(): void {
 		$GLOBALS['perform_test_options'] = [];
+		$GLOBALS['perform_test_filters'] = [];
 	}
 
 	protected function tearDown(): void {
-		unset( $GLOBALS['perform_test_options'] );
+		unset( $GLOBALS['perform_test_options'], $GLOBALS['perform_test_filters'] );
 	}
 
 	public function test_cache_summary_uses_existing_stats_without_writes() {
@@ -91,6 +92,63 @@ final class Tests_Dashboard_Payload extends TestCase {
 		$this->assertSame( 0.0, $payload['cache']['hitRatio'] );
 		$this->assertSame( 0, $payload['assetsManager']['disabledJsHandles'] );
 		$this->assertSame( 0, $payload['assetsManager']['disabledCssHandles'] );
+		$this->assertContains( $payload['server']['opcache']['state'], [ 'ready', 'warning', 'not-available' ] );
+		$this->assertContains( $payload['server']['compression']['state'], [ 'ready', 'needs-separate-test' ] );
 		$this->assertNotEmpty( $payload['changelog'] );
+		$this->assertStringNotContainsString( 'release-candidate', implode( ' ', $payload['changelog'] ) );
+	}
+
+	public function test_server_summary_normalizes_filtered_local_signals() {
+		$GLOBALS['perform_test_filters']['perform_dashboard_server_summary'] = [
+			'opcache'     => [
+				'state'   => 'ready',
+				'enabled' => true,
+			],
+			'compression' => [
+				'state'      => 'ready',
+				'phpEnabled' => true,
+			],
+		];
+
+		$payload = DashboardPayload::get_data();
+
+		$this->assertSame(
+			[
+				'state'   => 'ready',
+				'enabled' => true,
+			],
+			$payload['server']['opcache']
+		);
+		$this->assertSame(
+			[
+				'state'      => 'ready',
+				'phpEnabled' => true,
+			],
+			$payload['server']['compression']
+		);
+	}
+
+	public function test_server_summary_fails_closed_for_malformed_filtered_signals() {
+		$GLOBALS['perform_test_filters']['perform_dashboard_server_summary'] = [
+			'opcache'     => [ 'state' => 'invented' ],
+			'compression' => 'invalid',
+		];
+
+		$payload = DashboardPayload::get_data();
+
+		$this->assertSame(
+			[
+				'state'   => 'not-available',
+				'enabled' => null,
+			],
+			$payload['server']['opcache']
+		);
+		$this->assertSame(
+			[
+				'state'      => 'needs-separate-test',
+				'phpEnabled' => false,
+			],
+			$payload['server']['compression']
+		);
 	}
 }

--- a/tests/unit-tests/tests-runtime-diagnostics.php
+++ b/tests/unit-tests/tests-runtime-diagnostics.php
@@ -94,6 +94,16 @@ final class Tests_Runtime_Diagnostics extends TestCase {
 		$this->assertCount( 6, $results['items'] );
 	}
 
+	public function test_diagnostic_items_have_unique_stable_ids() {
+		$results = RuntimeDiagnostics::get_results();
+		$ids     = array_column( $results['items'], 'id' );
+
+		$this->assertCount( 6, $ids );
+		$this->assertCount( 6, array_unique( $ids ) );
+		$this->assertContains( 'dynamic-cache-exclusions', $ids );
+		$this->assertNotContains( '', $ids );
+	}
+
 	private function find_item( array $results, string $label ): array {
 		foreach ( $results['items'] as $item ) {
 			if ( $label === $item['label'] ) {


### PR DESCRIPTION
Closes #178

## Summary
- combine existing local site inventory, database audit, runtime diagnostics, cache activity, asset rules, and bounded server signals into one health dashboard
- show Ready, Review, Observing, and Not measured states with plain-language next actions
- keep Core Web Vitals and response-compression claims explicitly separate from local-only evidence
- show store-safety guidance only when a store pattern is measured
- retain desktop and 390px mobile screenshots from the hosted WordPress smoke run

## Safety
- no automatic optimization or remediation
- no external requests without a user clicking documentation or support
- no synthetic performance score or estimated savings
- existing capability gate continues to protect the settings page

## Validation
- 111 PHP tests / 311 assertions
- 22 JavaScript tests
- PHP lint, scoped PHPCS, PHPStan
- JavaScript and CSS lint
- production frontend build
- Studio runtime payload check for server signals and six stable diagnostic IDs
- hosted WordPress desktop/mobile smoke and screenshot proof required before merge