### PR TITLE
Add bounded admin performance monitor

### DIFF
--- a/assets/src/css/admin/settings.css
+++ b/assets/src/css/admin/settings.css
@@ -1271,7 +1271,66 @@
 	}
 
 	.perform-admin-monitor__table-wrap {
+		overflow: visible;
+	}
+
+	.perform-admin-monitor__table,
+	.perform-admin-monitor__table tbody,
+	.perform-admin-monitor__table tr,
+	.perform-admin-monitor__table th,
+	.perform-admin-monitor__table td {
+		display: block;
+		width: 100%;
+	}
+
+	.perform-admin-monitor__table thead {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	.perform-admin-monitor__table tbody tr {
+		margin-top: 16px;
 		border: 1px solid var(--perform-color-border);
+		border-radius: 4px;
+	}
+
+	.perform-admin-monitor__table tbody tr:first-child {
+		margin-top: 0;
+	}
+
+	.perform-admin-monitor__table tbody th,
+	.perform-admin-monitor__table tbody td {
+		box-sizing: border-box;
+		padding: 12px 14px;
+	}
+
+	.perform-admin-monitor__table tbody th {
+		background: #f6f7f7;
+	}
+
+	.perform-admin-monitor__table tbody td {
+		display: grid;
+		grid-template-columns: minmax(92px, 0.45fr) minmax(0, 1fr);
+		gap: 12px;
+	}
+
+	.perform-admin-monitor__table tbody td::before {
+		content: attr(data-label);
+		color: var(--perform-color-text-muted);
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+	}
+
+	.perform-admin-monitor__table tbody tr > :last-child {
+		border-bottom: 0;
 	}
 
 	.perform-database-audit__heading .components-button {

--- a/assets/src/css/admin/settings.css
+++ b/assets/src/css/admin/settings.css
@@ -1028,6 +1028,153 @@
 	font-size: 12px;
 }
 
+.perform-admin-monitor {
+	display: grid;
+	gap: 24px;
+}
+
+.perform-admin-monitor > *,
+.perform-admin-monitor .components-card__body {
+	min-width: 0;
+}
+
+.perform-admin-monitor__heading {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 24px;
+	padding-bottom: 24px;
+	border-bottom: 1px solid var(--perform-color-border);
+}
+
+.perform-admin-monitor__heading h2 {
+	margin: 0 0 8px;
+	font-size: 24px;
+	line-height: 1.25;
+}
+
+.perform-admin-monitor__heading p:not(.perform-dashboard-eyebrow) {
+	max-width: 760px;
+	margin: 0;
+	color: var(--perform-color-text-muted);
+	font-size: 14px;
+	line-height: 1.55;
+}
+
+.perform-admin-monitor__privacy,
+.perform-admin-monitor__message {
+	padding: 16px 20px;
+	border-left: 4px solid var(--perform-color-brand);
+	background: #f6f7f7;
+}
+
+.perform-admin-monitor__privacy p {
+	margin: 6px 0 0;
+	color: var(--perform-color-text-muted);
+	line-height: 1.5;
+}
+
+.perform-admin-monitor__privacy .perform-admin-monitor__thresholds {
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.perform-admin-monitor__message.is-error {
+	border-left-color: var(--perform-color-danger);
+}
+
+.perform-admin-monitor__message.is-success {
+	border-left-color: var(--perform-color-success);
+}
+
+.perform-admin-monitor__empty {
+	border-radius: 0;
+	box-shadow: none;
+}
+
+.perform-admin-monitor__empty h3 {
+	margin: 0 0 8px;
+	font-size: 18px;
+}
+
+.perform-admin-monitor__empty p {
+	max-width: 720px;
+	margin: 0;
+	color: var(--perform-color-text-muted);
+}
+
+.perform-admin-monitor__table-wrap {
+	max-width: 100%;
+	overflow-x: auto;
+}
+
+.perform-admin-monitor__guidance {
+	margin-bottom: 16px;
+	padding: 12px 16px;
+	border-left: 4px solid var(--perform-color-warning);
+	background: #fcf9e8;
+}
+
+.perform-admin-monitor__guidance p {
+	margin: 6px 0 0;
+	color: var(--perform-color-text-muted);
+}
+
+.perform-admin-monitor__table {
+	width: 100%;
+	border-collapse: collapse;
+	text-align: left;
+}
+
+.perform-admin-monitor__table th,
+.perform-admin-monitor__table td {
+	padding: 14px 12px;
+	border-bottom: 1px solid var(--perform-color-border);
+	vertical-align: top;
+}
+
+.perform-admin-monitor__table thead th {
+	color: var(--perform-color-text-muted);
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
+.perform-admin-monitor__table tbody th {
+	font-weight: 600;
+}
+
+.perform-admin-monitor__table code {
+	white-space: normal;
+	overflow-wrap: anywhere;
+}
+
+.perform-admin-monitor__table small {
+	display: block;
+	margin-top: 4px;
+	color: var(--perform-color-text-muted);
+	font-weight: 400;
+}
+
+.perform-admin-monitor__state {
+	display: inline-flex;
+	align-items: center;
+	min-height: 24px;
+	padding: 2px 8px;
+	border: 1px solid var(--perform-color-border);
+	border-radius: 12px;
+	background: #f6f7f7;
+	color: var(--perform-color-text-muted);
+	font-size: 11px;
+	font-weight: 600;
+}
+
+.perform-admin-monitor__table tr[data-status='review'] .perform-admin-monitor__state {
+	border-color: #dba617;
+	background: #fcf9e8;
+	color: var(--perform-color-warning);
+}
+
 @media screen and (max-width: 782px) {
 
 	.perform-settings-page {
@@ -1112,6 +1259,19 @@
 
 	.perform-site-inventory__heading {
 		flex-direction: column;
+	}
+
+	.perform-admin-monitor__heading {
+		flex-direction: column;
+	}
+
+	.perform-admin-monitor__heading .components-button {
+		width: 100%;
+		justify-content: center;
+	}
+
+	.perform-admin-monitor__table-wrap {
+		border: 1px solid var(--perform-color-border);
 	}
 
 	.perform-database-audit__heading .components-button {

--- a/assets/src/js/admin/AdminPerformanceMonitorPanel.jsx
+++ b/assets/src/js/admin/AdminPerformanceMonitorPanel.jsx
@@ -209,16 +209,18 @@ const AdminPerformanceMonitorPanel = ( { initialSnapshot = SETTINGS.adminPerform
 													{ context.capabilityBucket }
 												</small>
 											</th>
-											<td>{ context.count }</td>
-											<td>
+											<td data-label={ __( 'Requests', 'perform' ) }>{ context.count }</td>
+											<td data-label={ __( 'Duration', 'perform' ) }>
 												<strong>{ context.maxDurationMs } ms</strong>
 												<small>
 													{ context.averageDurationMs } ms { __( 'average', 'perform' ) }
 												</small>
 											</td>
-											<td>{ formatBytes( context.maxMemoryBytes ) }</td>
-											<td>{ context.maxQueryCount }</td>
-											<td>
+											<td data-label={ __( 'Peak memory', 'perform' ) }>
+												{ formatBytes( context.maxMemoryBytes ) }
+											</td>
+											<td data-label={ __( 'Queries', 'perform' ) }>{ context.maxQueryCount }</td>
+											<td data-label={ __( 'Guidance', 'perform' ) }>
 												<span className="perform-admin-monitor__state">
 													{ 'review' === context.status
 														? __( 'Review', 'perform' )

--- a/assets/src/js/admin/AdminPerformanceMonitorPanel.jsx
+++ b/assets/src/js/admin/AdminPerformanceMonitorPanel.jsx
@@ -1,0 +1,248 @@
+import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+const SETTINGS = window.performwpSettings || {};
+
+const formatBytes = ( bytes ) => {
+	const value = Number( bytes );
+	if ( ! Number.isFinite( value ) || value <= 0 ) {
+		return '0 B';
+	}
+	if ( value >= 1024 * 1024 ) {
+		return `${ ( value / ( 1024 * 1024 ) ).toFixed( 1 ) } MB`;
+	}
+	if ( value >= 1024 ) {
+		return `${ ( value / 1024 ).toFixed( 1 ) } KB`;
+	}
+
+	return `${ Math.round( value ) } B`;
+};
+
+const TYPE_LABELS = {
+	'admin-page': __( 'Admin page', 'perform' ),
+	ajax: __( 'AJAX', 'perform' ),
+	rest: __( 'REST', 'perform' ),
+	'cron-adjacent': __( 'Cron-adjacent', 'perform' ),
+};
+
+const REASON_LABELS = {
+	'slow-request': __( 'Slow request', 'perform' ),
+	'high-memory': __( 'High memory', 'perform' ),
+	'high-query-count': __( 'High query count', 'perform' ),
+};
+
+const AdminPerformanceMonitorPanel = ( { initialSnapshot = SETTINGS.adminPerformance || {}, onNavigate } ) => {
+	const [ snapshot, setSnapshot ] = useState( initialSnapshot );
+	const [ clearing, setClearing ] = useState( false );
+	const [ message, setMessage ] = useState( null );
+	const contexts = snapshot.contexts || [];
+	const thresholds = snapshot.thresholds || { durationMs: 1000, memoryBytes: 134217728, queryCount: 100 };
+
+	const clearData = async () => {
+		// eslint-disable-next-line no-alert -- Aggregate removal requires explicit administrator confirmation.
+		if ( ! window.confirm( __( 'Clear all collected admin performance aggregates?', 'perform' ) ) ) {
+			return;
+		}
+
+		setClearing( true );
+		setMessage( { type: 'status', text: __( 'Clearing admin performance data…', 'perform' ) } );
+		try {
+			const response = await fetch( window.ajaxurl, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+				body: new URLSearchParams( {
+					action: 'perform_clear_admin_performance_monitor',
+					nonce: SETTINGS.adminMonitorNonce || '',
+				} ),
+			} );
+			const result = await response.json();
+			if ( ! response.ok || ! result?.success || ! result.data?.snapshot ) {
+				throw new Error(
+					result?.data?.message || __( 'Admin performance data could not be cleared.', 'perform' )
+				);
+			}
+
+			setSnapshot( result.data.snapshot );
+			setMessage( {
+				type: 'success',
+				text: result.data.message || __( 'Admin performance data cleared.', 'perform' ),
+			} );
+		} catch ( error ) {
+			setMessage( {
+				type: 'error',
+				text: error?.message || __( 'Admin performance data could not be cleared.', 'perform' ),
+			} );
+		} finally {
+			setClearing( false );
+		}
+	};
+
+	return (
+		<div className="perform-admin-monitor">
+			<div className="perform-admin-monitor__heading">
+				<div>
+					<p className="perform-dashboard-eyebrow">{ __( 'Private admin diagnostics', 'perform' ) }</p>
+					<h2>{ __( 'Admin Performance Monitor', 'perform' ) }</h2>
+					<p>
+						{ __(
+							'Find repeated slow WordPress admin contexts using bounded aggregate timing, peak memory, and query-count evidence.',
+							'perform'
+						) }
+					</p>
+				</div>
+				{ snapshot.enabled ? (
+					<Button
+						variant="secondary"
+						onClick={ clearData }
+						disabled={ clearing || 0 === contexts.length }
+						isBusy={ clearing }
+					>
+						{ clearing ? __( 'Clearing…', 'perform' ) : __( 'Clear collected data', 'perform' ) }
+					</Button>
+				) : (
+					<Button variant="primary" onClick={ () => onNavigate?.( 'advanced' ) }>
+						{ __( 'Enable in Advanced', 'perform' ) }
+					</Button>
+				) }
+			</div>
+
+			<div className="perform-admin-monitor__privacy">
+				<strong>{ __( 'Aggregate-only and per site', 'perform' ) }</strong>
+				<p>
+					{ __(
+						'Perform keeps up to 50 contexts for 14 days. It does not store full URLs, query arguments, request payloads, IP addresses, usernames, emails, or query text, and it does not enable SAVEQUERIES.',
+						'perform'
+					) }
+				</p>
+				<p className="perform-admin-monitor__thresholds">
+					{ sprintf(
+						/* translators: 1: duration in milliseconds, 2: memory size, 3: query count. */
+						__( 'Review thresholds: %1$s ms duration, %2$s peak memory, or %3$s queries.', 'perform' ),
+						thresholds.durationMs,
+						formatBytes( thresholds.memoryBytes ),
+						thresholds.queryCount
+					) }
+				</p>
+			</div>
+
+			{ message && (
+				<div
+					className={ `perform-admin-monitor__message is-${ message.type }` }
+					role={ 'error' === message.type ? 'alert' : 'status' }
+					aria-live="polite"
+				>
+					{ message.text }
+				</div>
+			) }
+
+			{ ! snapshot.enabled && (
+				<Card className="perform-admin-monitor__empty">
+					<CardBody>
+						<h3>{ __( 'Monitoring is off', 'perform' ) }</h3>
+						<p>
+							{ __(
+								'Disabled mode registers no request-capture hooks and performs no report writes.',
+								'perform'
+							) }
+						</p>
+					</CardBody>
+				</Card>
+			) }
+
+			{ snapshot.enabled && 0 === contexts.length && (
+				<Card className="perform-admin-monitor__empty">
+					<CardBody>
+						<h3>{ __( 'Collecting the first admin contexts', 'perform' ) }</h3>
+						<p>
+							{ __(
+								'Use WordPress admin normally, then return here to review aggregate evidence.',
+								'perform'
+							) }
+						</p>
+					</CardBody>
+				</Card>
+			) }
+
+			{ contexts.length > 0 && (
+				<Card>
+					<CardHeader>
+						<div>
+							<h3 className="perform-card-title">{ __( 'Measured admin contexts', 'perform' ) }</h3>
+							<p className="perform-card-description">
+								{ __(
+									'Sorted by worst observed duration. A threshold is a review signal, not a root-cause diagnosis.',
+									'perform'
+								) }
+							</p>
+						</div>
+					</CardHeader>
+					<CardBody>
+						<div className="perform-admin-monitor__guidance">
+							<strong>{ __( 'How to investigate', 'perform' ) }</strong>
+							<p>
+								{ __(
+									'Reproduce the same workflow, compare repeated samples, and use a dedicated profiler before changing plugin or query behavior.',
+									'perform'
+								) }
+							</p>
+						</div>
+						<div className="perform-admin-monitor__table-wrap">
+							<table className="perform-admin-monitor__table">
+								<thead>
+									<tr>
+										<th scope="col">{ __( 'Context', 'perform' ) }</th>
+										<th scope="col">{ __( 'Requests', 'perform' ) }</th>
+										<th scope="col">{ __( 'Duration', 'perform' ) }</th>
+										<th scope="col">{ __( 'Peak memory', 'perform' ) }</th>
+										<th scope="col">{ __( 'Queries', 'perform' ) }</th>
+										<th scope="col">{ __( 'Guidance', 'perform' ) }</th>
+									</tr>
+								</thead>
+								<tbody>
+									{ contexts.map( ( context ) => (
+										<tr key={ context.key } data-status={ context.status }>
+											<th scope="row">
+												<code>{ context.identifier }</code>
+												<small>
+													{ TYPE_LABELS[ context.type ] || __( 'Unknown', 'perform' ) } ·{ ' ' }
+													{ context.capabilityBucket }
+												</small>
+											</th>
+											<td>{ context.count }</td>
+											<td>
+												<strong>{ context.maxDurationMs } ms</strong>
+												<small>
+													{ context.averageDurationMs } ms { __( 'average', 'perform' ) }
+												</small>
+											</td>
+											<td>{ formatBytes( context.maxMemoryBytes ) }</td>
+											<td>{ context.maxQueryCount }</td>
+											<td>
+												<span className="perform-admin-monitor__state">
+													{ 'review' === context.status
+														? __( 'Review', 'perform' )
+														: __( 'Observing', 'perform' ) }
+												</span>
+												<small>
+													{ context.reasons?.length
+														? context.reasons
+																.map( ( reason ) => REASON_LABELS[ reason ] || reason )
+																.join( ', ' )
+														: __( 'Below current review thresholds', 'perform' ) }
+												</small>
+											</td>
+										</tr>
+									) ) }
+								</tbody>
+							</table>
+						</div>
+					</CardBody>
+				</Card>
+			) }
+		</div>
+	);
+};
+
+export { formatBytes };
+export default AdminPerformanceMonitorPanel;

--- a/assets/src/js/admin/AdminPerformanceMonitorPanel.test.jsx
+++ b/assets/src/js/admin/AdminPerformanceMonitorPanel.test.jsx
@@ -1,0 +1,99 @@
+/* eslint-env jest */
+
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+window.performwpSettings = {
+	adminMonitorNonce: 'monitor-nonce',
+};
+
+const AdminPerformanceMonitorPanel = require( './AdminPerformanceMonitorPanel' ).default;
+
+const readySnapshot = {
+	enabled: true,
+	status: 'ready',
+	contexts: [
+		{
+			key: 'ajax:heartbeat:edit-content',
+			type: 'ajax',
+			identifier: 'heartbeat',
+			capabilityBucket: 'edit-content',
+			count: 4,
+			maxDurationMs: 1400,
+			averageDurationMs: 900,
+			maxMemoryBytes: 140000000,
+			maxQueryCount: 120,
+			status: 'review',
+			reasons: [ 'slow-request', 'high-memory', 'high-query-count' ],
+		},
+	],
+};
+
+describe( 'AdminPerformanceMonitorPanel', () => {
+	afterEach( () => {
+		delete global.fetch;
+		jest.restoreAllMocks();
+	} );
+
+	it( 'explains disabled zero-overhead mode and routes to Advanced', () => {
+		const onNavigate = jest.fn();
+		render(
+			<AdminPerformanceMonitorPanel
+				initialSnapshot={ { enabled: false, contexts: [] } }
+				onNavigate={ onNavigate }
+			/>
+		);
+
+		expect( screen.getByText( 'Monitoring is off' ) ).toBeInTheDocument();
+		expect( screen.getByText( /registers no request-capture hooks/ ) ).toBeInTheDocument();
+		fireEvent.click( screen.getByRole( 'button', { name: 'Enable in Advanced' } ) );
+		expect( onNavigate ).toHaveBeenCalledWith( 'advanced' );
+	} );
+
+	it( 'shows aggregate-only metrics and actionable threshold reasons', () => {
+		render( <AdminPerformanceMonitorPanel initialSnapshot={ readySnapshot } /> );
+
+		expect( screen.getByText( 'heartbeat' ) ).toBeInTheDocument();
+		expect( screen.getByText( /Slow request, High memory, High query count/ ) ).toBeInTheDocument();
+		expect( screen.getByText( /does not store full URLs/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /SAVEQUERIES enabled/i ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'requires confirmation and announces clear progress', async () => {
+		jest.spyOn( window, 'confirm' ).mockReturnValue( true );
+		global.fetch = jest.fn().mockResolvedValue( {
+			ok: true,
+			json: async () => ( {
+				success: true,
+				data: {
+					message: 'Admin performance data cleared.',
+					snapshot: { enabled: true, status: 'empty', contexts: [] },
+				},
+			} ),
+		} );
+
+		render( <AdminPerformanceMonitorPanel initialSnapshot={ readySnapshot } /> );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Clear collected data' } ) );
+
+		expect( screen.getByRole( 'button', { name: 'Clearing…' } ) ).toBeDisabled();
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Clearing admin performance data…' );
+		await waitFor( () =>
+			expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Admin performance data cleared.' )
+		);
+		expect( screen.getByText( 'Collecting the first admin contexts' ) ).toBeInTheDocument();
+	} );
+
+	it( 'restores the clear action after a request failure', async () => {
+		jest.spyOn( window, 'confirm' ).mockReturnValue( true );
+		global.fetch = jest.fn().mockResolvedValue( {
+			ok: false,
+			json: async () => ( { success: false, data: { message: 'Synthetic clear failure.' } } ),
+		} );
+
+		render( <AdminPerformanceMonitorPanel initialSnapshot={ readySnapshot } /> );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Clear collected data' } ) );
+
+		expect( await screen.findByRole( 'alert' ) ).toHaveTextContent( 'Synthetic clear failure.' );
+		expect( screen.getByRole( 'button', { name: 'Clear collected data' } ) ).toBeEnabled();
+	} );
+} );

--- a/assets/src/js/admin/SettingsApp.jsx
+++ b/assets/src/js/admin/SettingsApp.jsx
@@ -12,6 +12,7 @@ const INITIAL_DIAGNOSTICS = SETTINGS.diagnostics || {};
 const DASHBOARD = SETTINGS.dashboard || {};
 const DATABASE_AUDIT = SETTINGS.databaseAudit || {};
 const SITE_INVENTORY = SETTINGS.siteInventory || {};
+const ADMIN_PERFORMANCE = SETTINGS.adminPerformance || {};
 const TAB_KEYS = [ 'dashboard', ...Object.keys( SETTINGS_TABS ) ];
 
 const normalizeTab = ( tab ) => ( TAB_KEYS.includes( tab ) ? tab : 'dashboard' );
@@ -177,13 +178,14 @@ const SettingsApp = () => {
 				diagnostics={ diagnostics }
 				databaseAudit={ DATABASE_AUDIT }
 				siteInventory={ SITE_INVENTORY }
+				adminPerformance={ ADMIN_PERFORMANCE }
 				activeTab={ activeTab }
 				onTabChange={ handleTabChange }
 				fieldValues={ fieldValues }
 				onFieldChange={ handleFieldChange }
 			/>
 			{ 'dashboard' === activeTab && <DiagnosticsPanel diagnostics={ diagnostics } /> }
-			{ ! [ 'dashboard', 'cache-stats', 'database', 'inventory' ].includes( activeTab ) && (
+			{ ! [ 'dashboard', 'cache-stats', 'database', 'inventory', 'admin-monitor' ].includes( activeTab ) && (
 				<Footer dirty={ isDirty } saving={ saving } message={ message } onSave={ handleSave } />
 			) }
 		</>

--- a/assets/src/js/admin/SettingsNav.jsx
+++ b/assets/src/js/admin/SettingsNav.jsx
@@ -1,6 +1,7 @@
 import { TabPanel } from '@wordpress/components';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import CacheStatsPanel from './CacheStatsPanel';
+import AdminPerformanceMonitorPanel from './AdminPerformanceMonitorPanel';
 import DashboardPanel from './DashboardPanel';
 import DatabaseAuditPanel from './DatabaseAuditPanel';
 import SiteInventoryPanel from './SiteInventoryPanel';
@@ -15,6 +16,7 @@ const SettingsNav = ( {
 	diagnostics,
 	databaseAudit,
 	siteInventory,
+	adminPerformance,
 	activeTab: propActiveTab,
 	onTabChange: propOnTabChange,
 	fieldValues: propFieldValues,
@@ -114,6 +116,13 @@ const SettingsNav = ( {
 						content = <DatabaseAuditPanel initialAudit={ databaseAudit } />;
 					} else if ( 'inventory' === selectedTabName ) {
 						content = <SiteInventoryPanel initialInventory={ siteInventory } />;
+					} else if ( 'admin-monitor' === selectedTabName ) {
+						content = (
+							<AdminPerformanceMonitorPanel
+								initialSnapshot={ adminPerformance }
+								onNavigate={ onTabChange }
+							/>
+						);
 					} else if ( 'cache-stats' === selectedTabName ) {
 						content = <CacheStatsPanel />;
 					}

--- a/docs/admin-performance-monitor.md
+++ b/docs/admin-performance-monitor.md
@@ -1,0 +1,27 @@
+# Admin Performance Monitor
+
+The Admin Performance Monitor is an opt-in, per-site diagnostic for WordPress admin requests. Enable it under **Perform > Advanced**, use wp-admin normally, and review the aggregate report under **Perform > Admin Monitor**.
+
+## What it measures
+
+- request context type: admin page, AJAX, REST, or cron-adjacent;
+- a bounded WordPress screen ID or safe AJAX action identifier;
+- request count, average and maximum duration;
+- maximum observed peak memory and query count;
+- a non-identifying capability bucket.
+
+The report highlights contexts that cross review thresholds. A threshold is evidence worth investigating, not a root-cause diagnosis or an automatic optimization recommendation.
+
+## Privacy and overhead boundaries
+
+- Monitoring is disabled by default. Disabled mode registers no capture hooks and writes no report data.
+- Perform does not enable `SAVEQUERIES` or store query text.
+- Perform does not store full URLs, query arguments, request payloads, cookies, nonces, IP addresses, usernames, or email addresses.
+- Invalid, unregistered, or potentially sensitive AJAX action identifiers are grouped as `unknown-action`.
+- Storage is a non-autoloaded per-site option capped at 50 aggregate contexts with 14-day retention.
+- Multisite collection remains per site. No network-wide report is implemented.
+- The administrator can clear the current site's aggregates from the report.
+
+## Interpreting the report
+
+Review a context when its worst observed duration, memory, or query count crosses the displayed threshold. Reproduce the workflow, compare repeated samples, and use a dedicated profiler when query-level attribution is required. Perform does not automatically disable plugins, remove dashboard widgets, rewrite queries, or change frontend behavior from this report.

--- a/languages/perform.pot
+++ b/languages/perform.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: PerformWP <hello@performwp.com>\n"
-"POT-Creation-Date: 2026-08-11 03:29+0000\n"
+"POT-Creation-Date: 2026-08-11 03:45+0000\n"
 "Report-Msgid-Bugs-To: https://github.com/performwp/perform/issues/new\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
@@ -16,63 +16,63 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/Admin/Actions.php:89
+#: src/Admin/Actions.php:92
 msgid "Activity actions"
 msgstr ""
 
-#: src/Admin/Actions.php:90
+#: src/Admin/Actions.php:93
 msgid "Export cache activity for review or clear the collected metrics."
 msgstr ""
 
-#: src/Admin/Actions.php:91
+#: src/Admin/Actions.php:94
 msgid "Export CSV"
 msgstr ""
 
-#: src/Admin/Actions.php:92
+#: src/Admin/Actions.php:95
 msgid "Exporting…"
 msgstr ""
 
-#: src/Admin/Actions.php:93
+#: src/Admin/Actions.php:96
 msgid "Cache activity exported."
 msgstr ""
 
-#: src/Admin/Actions.php:94
+#: src/Admin/Actions.php:97
 msgid "Cache activity could not be exported."
 msgstr ""
 
-#: src/Admin/Actions.php:95
+#: src/Admin/Actions.php:98
 msgid "Clear activity"
 msgstr ""
 
-#: src/Admin/Actions.php:96
+#: src/Admin/Actions.php:99
 msgid "Clearing…"
 msgstr ""
 
-#: src/Admin/Actions.php:97
+#: src/Admin/Actions.php:100
 msgid "Clear all collected cache activity? This does not clear cached pages."
 msgstr ""
 
-#: src/Admin/Actions.php:98, src/Modules/Cache/PageCache.php:828, src/Modules/Cache/PageCache.php:1090
+#: src/Admin/Actions.php:101, src/Modules/Cache/PageCache.php:828, src/Modules/Cache/PageCache.php:1090
 msgid "Cache activity cleared."
 msgstr ""
 
-#: src/Admin/Actions.php:99
+#: src/Admin/Actions.php:102
 msgid "Cache activity could not be cleared."
 msgstr ""
 
-#: src/Admin/Actions.php:128
+#: src/Admin/Actions.php:131
 msgid "Close Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:125, src/Modules/Assets/AssetsManager.php:274
+#: src/Admin/Actions.php:128, src/Modules/Assets/AssetsManager.php:274
 msgid "Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:135, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:254
+#: src/Admin/Actions.php:138, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:254
 msgid "Perform"
 msgstr ""
 
-#: src/Admin/Actions.php:155
+#: src/Admin/Actions.php:158
 msgid "Support Forum"
 msgstr ""
 
@@ -649,35 +649,55 @@ msgid "Settings for advanced configurations."
 msgstr ""
 
 #: src/Includes/Helpers.php:953
-msgid "Remove Data on Uninstall"
+msgid "Admin Performance Monitor"
 msgstr ""
 
 #: src/Includes/Helpers.php:954
+msgid "Collect bounded, private aggregate timing, memory, and query-count diagnostics for WordPress admin requests."
+msgstr ""
+
+#: src/Includes/Helpers.php:959
+msgid "Remove Data on Uninstall"
+msgstr ""
+
+#: src/Includes/Helpers.php:960
 msgid "Enabling this will remove all plugin data upon uninstallation."
 msgstr ""
 
-#: src/Includes/Helpers.php:967
+#: src/Includes/Helpers.php:973
 msgid "WooCommerce Settings"
 msgstr ""
 
-#: src/Includes/Helpers.php:968
+#: src/Includes/Helpers.php:974
 msgid "Settings specific to WooCommerce."
 msgstr ""
 
-#: src/Includes/Helpers.php:973
+#: src/Includes/Helpers.php:979
 msgid "Enable WooCommerce Manager"
 msgstr ""
 
-#: src/Includes/Helpers.php:974
+#: src/Includes/Helpers.php:980
 msgid "Enabling this will allow you to manage WooCommerce specific settings."
 msgstr ""
 
-#: src/Includes/Helpers.php:985
+#: src/Includes/Helpers.php:991
 msgid "Enable WooCommerce Cache"
 msgstr ""
 
-#: src/Includes/Helpers.php:986
+#: src/Includes/Helpers.php:992
 msgid "Enabling this will cache WooCommerce pages for better performance."
+msgstr ""
+
+#: src/Admin/Settings/AdminPerformanceMonitorController.php:31
+msgid "You are not allowed to clear admin performance data."
+msgstr ""
+
+#: src/Admin/Settings/AdminPerformanceMonitorController.php:36, src/Admin/Settings/AutoloadOptionsAuditController.php:48, src/Admin/Settings/Menu.php:123
+msgid "Security check failed."
+msgstr ""
+
+#: src/Admin/Settings/AdminPerformanceMonitorController.php:42
+msgid "Admin performance data cleared."
 msgstr ""
 
 #: src/Admin/Settings/Api.php:48
@@ -708,12 +728,8 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: src/Admin/Settings/AutoloadOptionsAuditController.php:38, src/Admin/Settings/Menu.php:111, src/Admin/Settings/SiteInventoryController.php:59
+#: src/Admin/Settings/AutoloadOptionsAuditController.php:38, src/Admin/Settings/Menu.php:112, src/Admin/Settings/SiteInventoryController.php:59
 msgid "Insufficient permissions."
-msgstr ""
-
-#: src/Admin/Settings/AutoloadOptionsAuditController.php:48, src/Admin/Settings/Menu.php:122
-msgid "Security check failed."
 msgstr ""
 
 #: src/Admin/Settings/AutoloadOptionsAuditController.php:59
@@ -745,14 +761,18 @@ msgid "Database"
 msgstr ""
 
 #: src/Admin/Settings/Menu.php:57
+msgid "Admin Monitor"
+msgstr ""
+
+#: src/Admin/Settings/Menu.php:58
 msgid "Cache Stats"
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:238
+#: src/Admin/Settings/Menu.php:239
 msgid "Unable to save the settings. Please try again."
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:230
+#: src/Admin/Settings/Menu.php:231
 msgid "Settings saved successfully."
 msgstr ""
 

--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -13,6 +13,7 @@ namespace Perform\Admin;
 use Perform\Includes\Helpers;
 use Perform\Admin\Settings\ClientPayload;
 use Perform\Admin\Settings\AutoloadOptionsAudit;
+use Perform\Admin\Settings\AdminPerformanceMonitor;
 use Perform\Admin\Settings\DashboardPayload;
 use Perform\Admin\Settings\Menu;
 use Perform\Admin\Settings\RuntimeDiagnostics;
@@ -72,6 +73,8 @@ class Actions {
 					'dashboard'          => DashboardPayload::get_data(),
 					'diagnostics'        => RuntimeDiagnostics::get_results(),
 					'databaseAudit'      => AutoloadOptionsAudit::get_cached_snapshot(),
+					'adminPerformance'   => AdminPerformanceMonitor::get_snapshot(),
+					'adminMonitorNonce'  => wp_create_nonce( 'perform_clear_admin_performance_monitor' ),
 					'databaseAuditNonce' => wp_create_nonce( 'perform_refresh_autoload_options_audit' ),
 					'siteInventory'      => SiteInventory::get_cached_snapshot(),
 					'siteInventoryUrl'   => esc_url_raw( rest_url( 'perform/v1/site-inventory' ) ),

--- a/src/Admin/Settings/AdminPerformanceMonitor.php
+++ b/src/Admin/Settings/AdminPerformanceMonitor.php
@@ -1,0 +1,418 @@
+<?php
+/**
+ * Perform - Admin Performance Monitor.
+ *
+ * @package Perform
+ * @subpackage Admin/Settings
+ */
+
+namespace Perform\Admin\Settings;
+
+use Perform\Includes\Helpers;
+
+// Bailout, if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Captures bounded aggregate request metrics when explicitly enabled.
+ */
+final class AdminPerformanceMonitor {
+	const OPTION_NAME       = 'perform_admin_performance_monitor';
+	const SCHEMA_VERSION    = 1;
+	const RETENTION_DAYS    = 14;
+	const MAX_CONTEXTS      = 50;
+	const SLOW_DURATION_MS  = 1000;
+	const HIGH_MEMORY_BYTES = 134217728;
+	const HIGH_QUERY_COUNT  = 100;
+
+	/**
+	 * Approximate request start time.
+	 *
+	 * @var float
+	 */
+	private $start_time;
+
+	/**
+	 * Current wp-admin screen ID when available.
+	 *
+	 * @var string
+	 */
+	private $screen_id = '';
+
+	/**
+	 * Register monitoring only when explicitly enabled.
+	 *
+	 * @param array<string, mixed>|null $settings Optional already-loaded settings.
+	 */
+	public function __construct( $settings = null ) {
+		$settings = is_array( $settings ) ? $settings : Helpers::get_settings();
+		$settings = is_array( $settings ) ? $settings : [];
+		if ( empty( $settings['enable_admin_performance_monitor'] ) ) {
+			return;
+		}
+
+		$request_start    = isset( $_SERVER['REQUEST_TIME_FLOAT'] ) && is_numeric( $_SERVER['REQUEST_TIME_FLOAT'] ) ? (float) $_SERVER['REQUEST_TIME_FLOAT'] : microtime( true );
+		$this->start_time = min( microtime( true ), $request_start );
+
+		add_action( 'current_screen', [ $this, 'capture_screen' ] );
+		add_action( 'shutdown', [ $this, 'capture_request' ], PHP_INT_MAX );
+	}
+
+	/**
+	 * Remember the stable WordPress screen ID without storing the request URL.
+	 *
+	 * @param mixed $screen Current screen object.
+	 *
+	 * @return void
+	 */
+	public function capture_screen( $screen ) {
+		if ( is_object( $screen ) && isset( $screen->id ) && is_scalar( $screen->id ) ) {
+			$this->screen_id = sanitize_key( (string) $screen->id );
+		}
+	}
+
+	/**
+	 * Capture the completed request as one bounded aggregate sample.
+	 *
+	 * @return void
+	 */
+	public function capture_request() {
+		$settings = Helpers::get_settings();
+		if ( ! is_array( $settings ) || empty( $settings['enable_admin_performance_monitor'] ) ) {
+			return;
+		}
+
+		$context = $this->get_request_context();
+		if ( empty( $context ) || $this->should_skip_request( $context ) ) {
+			return;
+		}
+
+		global $wpdb;
+
+		$query_count = is_object( $wpdb ) && isset( $wpdb->num_queries ) ? (int) $wpdb->num_queries : 0;
+		$duration_ms = max( 0, ( microtime( true ) - $this->start_time ) * 1000 );
+
+		self::record_sample(
+			[
+				'type'             => $context['type'],
+				'identifier'       => $context['identifier'],
+				'capabilityBucket' => self::get_capability_bucket(),
+				'durationMs'       => round( $duration_ms, 2 ),
+				'peakMemoryBytes'  => max( 0, (int) memory_get_peak_usage( true ) ),
+				'queryCount'       => max( 0, $query_count ),
+			]
+		);
+	}
+
+	/**
+	 * Record one privacy-filtered sample into bounded per-site aggregates.
+	 *
+	 * @param array<string, mixed> $sample Raw sample.
+	 * @param int|null             $now Optional Unix timestamp for tests.
+	 *
+	 * @return array<string, mixed> Updated snapshot.
+	 */
+	public static function record_sample( array $sample, $now = null ) {
+		$now        = null === $now ? time() : max( 0, (int) $now );
+		$type       = self::normalize_type( $sample['type'] ?? '' );
+		$identifier = self::normalize_identifier( $type, $sample['identifier'] ?? '' );
+
+		if ( '' === $type || '' === $identifier ) {
+			return self::get_snapshot();
+		}
+
+		$snapshot = self::get_stored_snapshot();
+		$contexts = is_array( $snapshot['contexts'] ?? null ) ? $snapshot['contexts'] : [];
+		$cutoff   = $now - ( self::RETENTION_DAYS * 86400 );
+		$contexts = array_values(
+			array_filter(
+				$contexts,
+				static function ( $context ) use ( $cutoff ) {
+					return is_array( $context ) && (int) ( $context['lastSeen'] ?? 0 ) >= $cutoff;
+				}
+			)
+		);
+
+		$capability_bucket = self::normalize_capability_bucket( $sample['capabilityBucket'] ?? '' );
+		$key               = $type . ':' . $identifier . ':' . $capability_bucket;
+		$duration_ms       = min( 3600000, max( 0, (float) ( $sample['durationMs'] ?? 0 ) ) );
+		$memory_bytes      = min( PHP_INT_MAX, max( 0, (int) ( $sample['peakMemoryBytes'] ?? 0 ) ) );
+		$query_count       = min( 1000000, max( 0, (int) ( $sample['queryCount'] ?? 0 ) ) );
+		$matched           = false;
+
+		foreach ( $contexts as &$context ) {
+			if ( (string) ( $context['key'] ?? '' ) !== $key ) {
+				continue;
+			}
+
+			$count                       = max( 0, (int) ( $context['count'] ?? 0 ) );
+			$context['count']            = $count + 1;
+			$context['totalDurationMs']  = round( max( 0, (float) ( $context['totalDurationMs'] ?? 0 ) ) + $duration_ms, 2 );
+			$context['maxDurationMs']    = round( max( (float) ( $context['maxDurationMs'] ?? 0 ), $duration_ms ), 2 );
+			$context['maxMemoryBytes']   = max( (int) ( $context['maxMemoryBytes'] ?? 0 ), $memory_bytes );
+			$context['maxQueryCount']    = max( (int) ( $context['maxQueryCount'] ?? 0 ), $query_count );
+			$context['slowRequestCount'] = max( 0, (int) ( $context['slowRequestCount'] ?? 0 ) ) + ( $duration_ms >= self::SLOW_DURATION_MS ? 1 : 0 );
+			$context['lastSeen']         = $now;
+			$matched                     = true;
+			break;
+		}
+		unset( $context );
+
+		if ( ! $matched ) {
+			$contexts[] = [
+				'key'              => $key,
+				'type'             => $type,
+				'identifier'       => $identifier,
+				'capabilityBucket' => $capability_bucket,
+				'count'            => 1,
+				'totalDurationMs'  => round( $duration_ms, 2 ),
+				'maxDurationMs'    => round( $duration_ms, 2 ),
+				'maxMemoryBytes'   => $memory_bytes,
+				'maxQueryCount'    => $query_count,
+				'slowRequestCount' => $duration_ms >= self::SLOW_DURATION_MS ? 1 : 0,
+				'lastSeen'         => $now,
+			];
+		}
+
+		usort(
+			$contexts,
+			static function ( $left, $right ) {
+				return (int) ( $right['lastSeen'] ?? 0 ) <=> (int) ( $left['lastSeen'] ?? 0 );
+			}
+		);
+
+		$snapshot = [
+			'schemaVersion' => self::SCHEMA_VERSION,
+			'updatedAt'     => $now,
+			'contexts'      => array_slice( $contexts, 0, self::MAX_CONTEXTS ),
+		];
+
+		update_option( self::OPTION_NAME, $snapshot, false );
+
+		return self::prepare_snapshot( $snapshot );
+	}
+
+	/**
+	 * Get the current bounded report payload.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function get_snapshot() {
+		return self::prepare_snapshot( self::get_stored_snapshot() );
+	}
+
+	/**
+	 * Get the normalized stored shape without derived display fields.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function get_stored_snapshot() {
+		$snapshot = get_option( self::OPTION_NAME, [] );
+		if ( ! is_array( $snapshot ) || self::SCHEMA_VERSION !== (int) ( $snapshot['schemaVersion'] ?? 0 ) ) {
+			$snapshot = [
+				'schemaVersion' => self::SCHEMA_VERSION,
+				'updatedAt'     => 0,
+				'contexts'      => [],
+			];
+		}
+
+		return $snapshot;
+	}
+
+	/**
+	 * Delete all aggregate metrics for the current site.
+	 *
+	 * @return bool
+	 */
+	public static function clear() {
+		return delete_option( self::OPTION_NAME );
+	}
+
+	/**
+	 * Add derived display fields without storing more data.
+	 *
+	 * @param array<string, mixed> $snapshot Stored snapshot.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function prepare_snapshot( array $snapshot ) {
+		$contexts = [];
+		foreach ( (array) ( $snapshot['contexts'] ?? [] ) as $context ) {
+			if ( ! is_array( $context ) ) {
+				continue;
+			}
+
+			$count                        = max( 1, (int) ( $context['count'] ?? 1 ) );
+			$context['averageDurationMs'] = round( max( 0, (float) ( $context['totalDurationMs'] ?? 0 ) ) / $count, 2 );
+			$context['reasons']           = self::get_review_reasons( $context );
+			$context['status']            = empty( $context['reasons'] ) ? 'observing' : 'review';
+			$contexts[]                   = $context;
+		}
+
+		usort(
+			$contexts,
+			static function ( $left, $right ) {
+				return (float) ( $right['maxDurationMs'] ?? 0 ) <=> (float) ( $left['maxDurationMs'] ?? 0 );
+			}
+		);
+
+		$settings = Helpers::get_settings();
+
+		return [
+			'schemaVersion' => self::SCHEMA_VERSION,
+			'enabled'       => ! empty( $settings['enable_admin_performance_monitor'] ),
+			'status'        => empty( $contexts ) ? 'empty' : 'ready',
+			'updatedAt'     => max( 0, (int) ( $snapshot['updatedAt'] ?? 0 ) ),
+			'retentionDays' => self::RETENTION_DAYS,
+			'maxContexts'   => self::MAX_CONTEXTS,
+			'thresholds'    => [
+				'durationMs'  => self::SLOW_DURATION_MS,
+				'memoryBytes' => self::HIGH_MEMORY_BYTES,
+				'queryCount'  => self::HIGH_QUERY_COUNT,
+			],
+			'contexts'      => $contexts,
+		];
+	}
+
+	/**
+	 * Get threshold reasons for one aggregate.
+	 *
+	 * @param array<string, mixed> $context Aggregate context.
+	 *
+	 * @return array<int, string>
+	 */
+	private static function get_review_reasons( array $context ) {
+		$reasons = [];
+		if ( (float) ( $context['maxDurationMs'] ?? 0 ) >= self::SLOW_DURATION_MS ) {
+			$reasons[] = 'slow-request';
+		}
+		if ( (int) ( $context['maxMemoryBytes'] ?? 0 ) >= self::HIGH_MEMORY_BYTES ) {
+			$reasons[] = 'high-memory';
+		}
+		if ( (int) ( $context['maxQueryCount'] ?? 0 ) >= self::HIGH_QUERY_COUNT ) {
+			$reasons[] = 'high-query-count';
+		}
+
+		return $reasons;
+	}
+
+	/**
+	 * Resolve a privacy-safe request context.
+	 *
+	 * @return array<string, string>
+	 */
+	private function get_request_context() {
+		if ( function_exists( 'wp_doing_cron' ) && wp_doing_cron() ) {
+			return [
+				'type'       => 'cron-adjacent',
+				'identifier' => 'wp-cron',
+			];
+		}
+
+		if ( function_exists( 'wp_doing_ajax' ) && wp_doing_ajax() ) {
+			$action = isset( $_REQUEST['action'] ) && is_scalar( $_REQUEST['action'] ) ? wp_unslash( $_REQUEST['action'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Identifier only; no action is executed here.
+			$action = self::normalize_identifier( 'ajax', $action );
+			if ( 'unknown-action' !== $action && ! has_action( 'wp_ajax_' . $action ) && ! has_action( 'wp_ajax_nopriv_' . $action ) ) {
+				$action = 'unknown-action';
+			}
+
+			return [
+				'type'       => 'ajax',
+				'identifier' => $action,
+			];
+		}
+
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			return [
+				'type'       => 'rest',
+				'identifier' => 'rest-api',
+			];
+		}
+
+		if ( is_admin() ) {
+			return [
+				'type'       => 'admin-page',
+				'identifier' => '' !== $this->screen_id ? $this->screen_id : 'admin-page',
+			];
+		}
+
+		return [];
+	}
+
+	/**
+	 * Avoid immediately recreating data during the clear request.
+	 *
+	 * @param array<string, string> $context Request context.
+	 *
+	 * @return bool
+	 */
+	private function should_skip_request( array $context ) {
+		return 'ajax' === $context['type'] && 'perform_clear_admin_performance_monitor' === $context['identifier'];
+	}
+
+	/**
+	 * Normalize request type.
+	 *
+	 * @param mixed $type Request type.
+	 *
+	 * @return string
+	 */
+	private static function normalize_type( $type ) {
+		$type = is_scalar( $type ) ? sanitize_key( (string) $type ) : '';
+
+		return in_array( $type, [ 'admin-page', 'ajax', 'rest', 'cron-adjacent' ], true ) ? $type : '';
+	}
+
+	/**
+	 * Normalize an identifier without retaining payloads or query data.
+	 *
+	 * @param string $type Request type.
+	 * @param mixed  $identifier Raw identifier.
+	 *
+	 * @return string
+	 */
+	private static function normalize_identifier( $type, $identifier ) {
+		$raw = is_scalar( $identifier ) ? strtolower( trim( (string) $identifier ) ) : '';
+		if ( 'ajax' === $type && ! preg_match( '/^[a-z0-9_-]{1,80}$/', $raw ) ) {
+			return 'unknown-action';
+		}
+
+		$identifier = substr( sanitize_key( $raw ), 0, 80 );
+
+		return '' !== $identifier ? $identifier : ( 'ajax' === $type ? 'unknown-action' : '' );
+	}
+
+	/**
+	 * Resolve a non-identifying capability bucket.
+	 *
+	 * @return string
+	 */
+	private static function get_capability_bucket() {
+		if ( current_user_can( 'manage_options' ) ) {
+			return 'manage-options';
+		}
+		if ( current_user_can( 'edit_posts' ) ) {
+			return 'edit-content';
+		}
+		if ( is_user_logged_in() ) {
+			return 'authenticated';
+		}
+
+		return 'system';
+	}
+
+	/**
+	 * Normalize a caller-supplied capability bucket.
+	 *
+	 * @param mixed $bucket Capability bucket.
+	 *
+	 * @return string
+	 */
+	private static function normalize_capability_bucket( $bucket ) {
+		$bucket = is_scalar( $bucket ) ? sanitize_key( (string) $bucket ) : '';
+
+		return in_array( $bucket, [ 'manage-options', 'edit-content', 'authenticated', 'system' ], true ) ? $bucket : 'system';
+	}
+}

--- a/src/Admin/Settings/AdminPerformanceMonitorController.php
+++ b/src/Admin/Settings/AdminPerformanceMonitorController.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Perform - Admin Performance Monitor Controller.
+ *
+ * @package Perform
+ * @subpackage Admin/Settings
+ */
+
+namespace Perform\Admin\Settings;
+
+// Bailout, if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class AdminPerformanceMonitorController {
+	/**
+	 * Register protected report actions.
+	 */
+	public function __construct() {
+		add_action( 'wp_ajax_perform_clear_admin_performance_monitor', [ $this, 'clear' ] );
+	}
+
+	/**
+	 * Clear aggregate metrics for the current site.
+	 *
+	 * @return void
+	 */
+	public function clear() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'You are not allowed to clear admin performance data.', 'perform' ) ], 403 );
+		}
+
+		$nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['nonce'] ) ) : '';
+		if ( ! wp_verify_nonce( $nonce, 'perform_clear_admin_performance_monitor' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Security check failed.', 'perform' ) ], 403 );
+		}
+		AdminPerformanceMonitor::clear();
+
+		wp_send_json_success(
+			[
+				'message'  => __( 'Admin performance data cleared.', 'perform' ),
+				'snapshot' => AdminPerformanceMonitor::get_snapshot(),
+			]
+		);
+	}
+}

--- a/src/Admin/Settings/Menu.php
+++ b/src/Admin/Settings/Menu.php
@@ -51,10 +51,11 @@ class Menu {
 	 * @return array<string, string>
 	 */
 	public static function get_navigation_tabs() {
-		$tabs                = Helpers::get_settings_tabs();
-		$tabs['inventory']   = esc_html__( 'Site Inventory', 'perform' );
-		$tabs['database']    = esc_html__( 'Database', 'perform' );
-		$tabs['cache-stats'] = esc_html__( 'Cache Stats', 'perform' );
+		$tabs                  = Helpers::get_settings_tabs();
+		$tabs['inventory']     = esc_html__( 'Site Inventory', 'perform' );
+		$tabs['database']      = esc_html__( 'Database', 'perform' );
+		$tabs['admin-monitor'] = esc_html__( 'Admin Monitor', 'perform' );
+		$tabs['cache-stats']   = esc_html__( 'Cache Stats', 'perform' );
 
 		return $tabs;
 	}

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -948,6 +948,12 @@ class Helpers {
 					'description' => esc_html__( 'Settings for advanced configurations.', 'perform' ),
 					'fields'      => [
 						[
+							'id'   => 'enable_admin_performance_monitor',
+							'type' => 'toggle',
+							'name' => esc_html__( 'Admin Performance Monitor', 'perform' ),
+							'desc' => esc_html__( 'Collect bounded, private aggregate timing, memory, and query-count diagnostics for WordPress admin requests.', 'perform' ),
+						],
+						[
 							'id'        => 'remove_data_on_uninstall',
 							'type'      => 'toggle',
 							'name'      => esc_html__( 'Remove Data on Uninstall', 'perform' ),

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -54,6 +54,7 @@ final class Plugin {
 		new Settings\Menu();
 		new Settings\AutoloadOptionsAuditController();
 		new Settings\SiteInventoryController();
+		new Settings\AdminPerformanceMonitorController();
 		new Admin\Actions();
 		new Admin\Filters();
 
@@ -66,6 +67,7 @@ final class Plugin {
 		// supporting new modules implementing ModuleInterface.
 		$settings = Helpers::get_settings();
 		$settings = is_array( $settings ) ? $settings : [];
+		new Settings\AdminPerformanceMonitor( $settings );
 
 		$loader = new Modules\Loader( $settings );
 

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -145,6 +145,45 @@ test( 'Site Inventory refresh is private, bounded, and responsive', async ( { pa
 	expect( hasHorizontalOverflow ).toBeFalsy();
 } );
 
+test( 'Admin Performance Monitor is opt-in, bounded, private, clearable, and responsive', async ( { page } ) => {
+	await login( page );
+	await openAdminPage( page, '/wp-admin/options-general.php?page=perform_settings&tab=advanced' );
+
+	const monitorToggle = page.getByRole( 'checkbox', { name: 'Admin Performance Monitor' } );
+	if ( ! ( await monitorToggle.isChecked() ) ) {
+		await monitorToggle.check();
+	}
+	await page.getByRole( 'button', { name: 'Save Settings' } ).click();
+	await expect( page.getByText( /Settings saved/ ) ).toBeVisible();
+
+	await page.goto( '/wp-admin/edit.php' );
+	await openAdminPage( page, '/wp-admin/options-general.php?page=perform_settings&tab=admin-monitor' );
+	await expect( page.getByRole( 'tab', { name: 'Admin Monitor' } ) ).toHaveAttribute( 'aria-selected', 'true' );
+	await expect( page.getByText( 'Aggregate-only and per site' ) ).toBeVisible();
+	await expect( page.getByText( /does not store full URLs, query arguments, request payloads/ ) ).toBeVisible();
+	await expect( page.getByText( 'edit-post' ) ).toBeVisible();
+	await expect( page.getByRole( 'button', { name: 'Save Settings' } ) ).toHaveCount( 0 );
+
+	await mkdir( 'test-results/proof', { recursive: true } );
+	await page.screenshot( { path: 'test-results/proof/admin-performance-monitor-desktop.png', fullPage: true } );
+	await page.setViewportSize( { width: 390, height: 844 } );
+	await page.screenshot( { path: 'test-results/proof/admin-performance-monitor-mobile.png', fullPage: true } );
+	const hasHorizontalOverflow = await page.evaluate(
+		() => document.documentElement.scrollWidth > document.documentElement.clientWidth
+	);
+	expect( hasHorizontalOverflow ).toBeFalsy();
+
+	page.once( 'dialog', ( dialog ) => dialog.accept() );
+	await page.getByRole( 'button', { name: 'Clear collected data' } ).click();
+	await expect( page.getByRole( 'status' ) ).toContainText( 'Admin performance data cleared.' );
+	await expect( page.getByText( 'Collecting the first admin contexts' ) ).toBeVisible();
+
+	await page.getByRole( 'tab', { name: 'Advanced' } ).click();
+	await page.getByRole( 'checkbox', { name: 'Admin Performance Monitor' } ).uncheck();
+	await page.getByRole( 'button', { name: 'Save Settings' } ).click();
+	await expect( page.getByText( /Settings saved/ ) ).toBeVisible();
+} );
+
 test( 'Cache Stats tab preserves legacy routing, actions, and keyboard access', async ( { page } ) => {
 	await login( page );
 
@@ -252,4 +291,13 @@ test( 'lower-privilege users cannot access the legacy or canonical Cache Stats r
 		expect( response.status() ).not.toBe( 302 );
 		expect( await response.text() ).toContain( denialMessage );
 	}
+
+	const adminMonitorResponse = await page.request.post( '/wp-admin/admin-ajax.php', {
+		form: {
+			action: 'perform_clear_admin_performance_monitor',
+			nonce: 'invalid-for-editor-capability-check',
+		},
+	} );
+	expect( adminMonitorResponse.status() ).toBe( 403 );
+	expect( await adminMonitorResponse.json() ).toMatchObject( { success: false } );
 } );

--- a/tests/unit-tests/tests-admin-performance-monitor.php
+++ b/tests/unit-tests/tests-admin-performance-monitor.php
@@ -1,0 +1,198 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Perform\Admin\Settings\AdminPerformanceMonitor;
+use Perform\Admin\Settings\AdminPerformanceMonitorController;
+
+final class Tests_Admin_Performance_Monitor extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['perform_test_options']          = [];
+		$GLOBALS['perform_test_actions']          = [];
+		$GLOBALS['perform_test_current_user_can'] = [ 'manage_options' => true ];
+		$GLOBALS['perform_test_nonce_valid']      = true;
+		$_POST                                    = [];
+	}
+
+	protected function tearDown(): void {
+		unset(
+			$GLOBALS['perform_test_options'],
+			$GLOBALS['perform_test_actions'],
+			$GLOBALS['perform_test_current_user_can'],
+			$GLOBALS['perform_test_nonce_valid'],
+			$GLOBALS['perform_test_json_response']
+		);
+		$_POST = [];
+	}
+
+	public function test_disabled_mode_registers_no_capture_hooks() {
+		$monitor = new AdminPerformanceMonitor( [ 'enable_admin_performance_monitor' => 0 ] );
+		$monitor->capture_request();
+
+		$this->assertSame( [], $GLOBALS['perform_test_actions'] );
+		$this->assertArrayNotHasKey( AdminPerformanceMonitor::OPTION_NAME, $GLOBALS['perform_test_options'] );
+	}
+
+	public function test_enabled_mode_registers_only_screen_and_shutdown_capture_hooks() {
+		new AdminPerformanceMonitor( [ 'enable_admin_performance_monitor' => 1 ] );
+
+		$this->assertSame( [ 'current_screen', 'shutdown' ], array_column( $GLOBALS['perform_test_actions'], 'hook' ) );
+	}
+
+	public function test_aggregate_metrics_are_bounded_and_privacy_filtered() {
+		$this->enable_monitor();
+		$now = 1700000000;
+
+		AdminPerformanceMonitor::record_sample(
+			[
+				'type'             => 'admin-page',
+				'identifier'       => 'edit-book',
+				'capabilityBucket' => 'manage-options',
+				'durationMs'       => 1200,
+				'peakMemoryBytes'  => 140000000,
+				'queryCount'       => 140,
+			],
+			$now
+		);
+		$snapshot = AdminPerformanceMonitor::record_sample(
+			[
+				'type'             => 'admin-page',
+				'identifier'       => 'edit-book',
+				'capabilityBucket' => 'manage-options',
+				'durationMs'       => 800,
+				'peakMemoryBytes'  => 100000000,
+				'queryCount'       => 80,
+			],
+			$now + 1
+		);
+		AdminPerformanceMonitor::record_sample(
+			[
+				'type'             => 'ajax',
+				'identifier'       => 'user@example.com?nonce=secret',
+				'capabilityBucket' => 'edit-content',
+				'durationMs'       => 50,
+			],
+			$now + 2
+		);
+
+		$context = $snapshot['contexts'][0];
+		$this->assertSame( 2, $context['count'] );
+		$this->assertSame( 1000.0, $context['averageDurationMs'] );
+		$this->assertSame( 'review', $context['status'] );
+		$this->assertSame( [ 'slow-request', 'high-memory', 'high-query-count' ], $context['reasons'] );
+
+		$stored = wp_json_encode( $GLOBALS['perform_test_options'][ AdminPerformanceMonitor::OPTION_NAME ] );
+		$this->assertStringNotContainsString( 'example.com', $stored );
+		$this->assertStringNotContainsString( 'secret', $stored );
+		$this->assertStringContainsString( 'unknown-action', $stored );
+		$this->assertStringNotContainsString( 'username', $stored );
+		$this->assertStringNotContainsString( 'queryText', $stored );
+	}
+
+	public function test_retention_and_context_limit_are_enforced() {
+		$this->enable_monitor();
+		$now = 1700000000;
+
+		AdminPerformanceMonitor::record_sample(
+			[
+				'type'       => 'admin-page',
+				'identifier' => 'expired-screen',
+			],
+			$now - ( 15 * 86400 )
+		);
+
+		for ( $index = 0; $index < 55; ++$index ) {
+			AdminPerformanceMonitor::record_sample(
+				[
+					'type'       => 'admin-page',
+					'identifier' => 'screen-' . $index,
+					'durationMs' => $index,
+				],
+				$now + $index
+			);
+		}
+
+		$snapshot    = AdminPerformanceMonitor::get_snapshot();
+		$identifiers = array_column( $snapshot['contexts'], 'identifier' );
+
+		$this->assertCount( AdminPerformanceMonitor::MAX_CONTEXTS, $snapshot['contexts'] );
+		$this->assertNotContains( 'expired-screen', $identifiers );
+		$this->assertContains( 'screen-54', $identifiers );
+		$this->assertNotContains( 'screen-0', $identifiers );
+	}
+
+	public function test_report_distinguishes_supported_request_types() {
+		$this->enable_monitor();
+		$types = [
+			'admin-page'    => 'dashboard',
+			'ajax'          => 'heartbeat',
+			'rest'          => 'rest-api',
+			'cron-adjacent' => 'wp-cron',
+		];
+
+		foreach ( $types as $type => $identifier ) {
+			AdminPerformanceMonitor::record_sample(
+				[
+					'type'       => $type,
+					'identifier' => $identifier,
+				],
+				1700000000
+			);
+		}
+
+		$this->assertEqualsCanonicalizing( array_keys( $types ), array_column( AdminPerformanceMonitor::get_snapshot()['contexts'], 'type' ) );
+	}
+
+	public function test_clear_endpoint_requires_manage_options_and_valid_nonce() {
+		$this->enable_monitor();
+		AdminPerformanceMonitor::record_sample(
+			[
+				'type'       => 'admin-page',
+				'identifier' => 'dashboard',
+			],
+			1700000000
+		);
+		$GLOBALS['perform_test_current_user_can']['manage_options'] = false;
+
+		$this->run_clear_request();
+		$this->assertFalse( $GLOBALS['perform_test_json_response']['success'] );
+		$this->assertArrayHasKey( AdminPerformanceMonitor::OPTION_NAME, $GLOBALS['perform_test_options'] );
+
+		$GLOBALS['perform_test_current_user_can']['manage_options'] = true;
+		$GLOBALS['perform_test_nonce_valid']                        = false;
+		$_POST['nonce'] = 'invalid';
+		$this->run_clear_request();
+		$this->assertFalse( $GLOBALS['perform_test_json_response']['success'] );
+		$this->assertArrayHasKey( AdminPerformanceMonitor::OPTION_NAME, $GLOBALS['perform_test_options'] );
+	}
+
+	public function test_clear_endpoint_removes_current_site_aggregates() {
+		$this->enable_monitor();
+		AdminPerformanceMonitor::record_sample(
+			[
+				'type'       => 'admin-page',
+				'identifier' => 'dashboard',
+			],
+			1700000000
+		);
+		$_POST['nonce'] = 'valid';
+
+		$this->run_clear_request();
+
+		$this->assertTrue( $GLOBALS['perform_test_json_response']['success'] );
+		$this->assertSame( [], $GLOBALS['perform_test_json_response']['data']['snapshot']['contexts'] );
+		$this->assertArrayNotHasKey( AdminPerformanceMonitor::OPTION_NAME, $GLOBALS['perform_test_options'] );
+	}
+
+	private function enable_monitor() {
+		$GLOBALS['perform_test_options']['perform_settings'] = [ 'enable_admin_performance_monitor' => 1 ];
+	}
+
+	private function run_clear_request() {
+		try {
+			( new AdminPerformanceMonitorController() )->clear();
+			$this->fail( 'Expected the JSON response to end the request.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'perform_test_json_response', $exception->getMessage() );
+		}
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -32,6 +32,7 @@ function perform_handle_plugin_uninstall() {
 		'perform_cache_stats',
 		'perform_autoload_options_audit',
 		'perform_site_inventory',
+		'perform_admin_performance_monitor',
 	];
 
 	$remove_data_on_uninstall = false;


### PR DESCRIPTION
Closes #139

## Summary
- add an opt-in Admin Performance Monitor toggle and dedicated report
- aggregate admin page, registered AJAX, REST, and cron-adjacent timing, peak memory, and query counts
- show repeated contexts with explicit review thresholds and next-step guidance
- provide an administrator-only, nonce-protected clear action
- retain desktop and 390px report screenshots in hosted WordPress smoke proof

## Privacy and overhead boundaries
- disabled by default; disabled mode registers no capture hooks and performs no report writes
- no SAVEQUERIES, query text, full URLs, query arguments, payloads, IPs, usernames, emails, or nonces
- invalid or unregistered AJAX action identifiers become `unknown-action`
- per-site non-autoloaded storage, 14-day retention, hard cap of 50 aggregate contexts
- no frontend/cache behavior changes or automatic remediation

## Validation
- 118 PHP tests / 338 assertions
- 26 JavaScript tests
- PHP lint and scoped PHPCS
- PHPStan
- JavaScript and CSS lint
- production frontend build
- Studio read-only proof: disabled, zero contexts, 14-day/50-context contract, no storage option created
- hosted WordPress desktop/mobile, clear, disabled/enabled, and lower-privilege proof required before merge