### PR TITLE
Add actionable system health recommendations

### DIFF
--- a/assets/src/css/admin/settings.css
+++ b/assets/src/css/admin/settings.css
@@ -926,6 +926,90 @@
 	color: var(--perform-color-warning);
 }
 
+.perform-system-health__summary,
+.perform-system-health__status {
+	display: inline-flex;
+	align-items: center;
+	min-height: 26px;
+	padding: 2px 9px;
+	border: 1px solid #9ecda8;
+	border-radius: 14px;
+	background: #f0f8f1;
+	color: var(--perform-color-success);
+	font-size: 11px;
+	font-weight: 600;
+	white-space: nowrap;
+}
+
+.perform-system-health__summary.has-review,
+.perform-system-health__status.is-review {
+	border-color: #dba617;
+	background: #fcf9e8;
+	color: var(--perform-color-warning);
+}
+
+.perform-system-health__status.is-action-recommended {
+	border-color: #d63638;
+	background: #fcf0f1;
+	color: var(--perform-color-danger);
+}
+
+.perform-system-health__status.is-unavailable {
+	border-color: var(--perform-color-border);
+	background: #f6f7f7;
+	color: var(--perform-color-text-muted);
+}
+
+.perform-system-health__grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 0 24px;
+}
+
+.perform-system-health__signal {
+	min-width: 0;
+	padding: 16px 0;
+	border-bottom: 1px solid var(--perform-color-border);
+}
+
+.perform-system-health__signal-heading {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+}
+
+.perform-system-health__signal-heading span:first-child,
+.perform-system-health__signal-heading strong {
+	display: block;
+}
+
+.perform-system-health__signal-heading span:first-child {
+	color: var(--perform-color-text-muted);
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.perform-system-health__signal-heading strong {
+	margin-top: 5px;
+	font-size: 16px;
+}
+
+.perform-system-health__signal p {
+	margin: 10px 0 0;
+	color: var(--perform-color-text-muted);
+	font-size: 13px;
+	line-height: 1.5;
+}
+
+.perform-system-health__privacy {
+	margin: 16px 0 0;
+	padding-top: 16px;
+	border-top: 1px solid var(--perform-color-border);
+	color: var(--perform-color-text-muted);
+	font-size: 12px;
+}
+
 .perform-site-inventory__grid {
 	display: grid;
 	grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1349,8 +1433,14 @@
 
 	.perform-site-inventory__summary,
 	.perform-site-inventory__facts,
-	.perform-site-inventory__grid {
+	.perform-site-inventory__grid,
+	.perform-system-health__grid {
 		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.perform-system-health .components-card__header {
+		align-items: flex-start;
+		flex-direction: column;
 	}
 
 	.perform-database-audit__summary > div,

--- a/assets/src/js/admin/SettingsApp.jsx
+++ b/assets/src/js/admin/SettingsApp.jsx
@@ -12,6 +12,7 @@ const INITIAL_DIAGNOSTICS = SETTINGS.diagnostics || {};
 const DASHBOARD = SETTINGS.dashboard || {};
 const DATABASE_AUDIT = SETTINGS.databaseAudit || {};
 const SITE_INVENTORY = SETTINGS.siteInventory || {};
+const SYSTEM_HEALTH = SETTINGS.systemHealth || {};
 const ADMIN_PERFORMANCE = SETTINGS.adminPerformance || {};
 const TAB_KEYS = [ 'dashboard', ...Object.keys( SETTINGS_TABS ) ];
 
@@ -178,6 +179,7 @@ const SettingsApp = () => {
 				diagnostics={ diagnostics }
 				databaseAudit={ DATABASE_AUDIT }
 				siteInventory={ SITE_INVENTORY }
+				systemHealth={ SYSTEM_HEALTH }
 				adminPerformance={ ADMIN_PERFORMANCE }
 				activeTab={ activeTab }
 				onTabChange={ handleTabChange }

--- a/assets/src/js/admin/SettingsNav.jsx
+++ b/assets/src/js/admin/SettingsNav.jsx
@@ -16,6 +16,7 @@ const SettingsNav = ( {
 	diagnostics,
 	databaseAudit,
 	siteInventory,
+	systemHealth,
 	adminPerformance,
 	activeTab: propActiveTab,
 	onTabChange: propOnTabChange,
@@ -115,7 +116,9 @@ const SettingsNav = ( {
 					} else if ( 'database' === selectedTabName ) {
 						content = <DatabaseAuditPanel initialAudit={ databaseAudit } />;
 					} else if ( 'inventory' === selectedTabName ) {
-						content = <SiteInventoryPanel initialInventory={ siteInventory } />;
+						content = (
+							<SiteInventoryPanel initialInventory={ siteInventory } systemHealth={ systemHealth } />
+						);
 					} else if ( 'admin-monitor' === selectedTabName ) {
 						content = (
 							<AdminPerformanceMonitorPanel

--- a/assets/src/js/admin/SiteInventoryPanel.jsx
+++ b/assets/src/js/admin/SiteInventoryPanel.jsx
@@ -1,6 +1,7 @@
 import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import SystemHealthPanel from './SystemHealthPanel';
 
 const SETTINGS = window.performwpSettings || {};
 
@@ -41,7 +42,10 @@ const getFrontPageLabel = ( value ) => {
 	return __( 'Unavailable', 'perform' );
 };
 
-const SiteInventoryPanel = ( { initialInventory = SETTINGS.siteInventory || {} } ) => {
+const SiteInventoryPanel = ( {
+	initialInventory = SETTINGS.siteInventory || {},
+	systemHealth = SETTINGS.systemHealth || {},
+} ) => {
 	const [ inventory, setInventory ] = useState( initialInventory );
 	const [ refreshing, setRefreshing ] = useState( false );
 	const [ message, setMessage ] = useState( null );
@@ -125,6 +129,8 @@ const SiteInventoryPanel = ( { initialInventory = SETTINGS.siteInventory || {} }
 					{ message.text }
 				</div>
 			) }
+
+			<SystemHealthPanel health={ systemHealth } />
 
 			{ ! hasInventory ? (
 				<Card className="perform-site-inventory__empty">

--- a/assets/src/js/admin/SystemHealthPanel.jsx
+++ b/assets/src/js/admin/SystemHealthPanel.jsx
@@ -1,0 +1,70 @@
+import { Card, CardBody, CardHeader } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+const STATUS_LABELS = {
+	good: __( 'Good', 'perform' ),
+	review: __( 'Review', 'perform' ),
+	'action-recommended': __( 'Action recommended', 'perform' ),
+	unavailable: __( 'Unavailable', 'perform' ),
+};
+
+const SystemHealthPanel = ( { health = {} } ) => {
+	const summary = health.summary || {};
+	const signals = Array.isArray( health.signals ) ? health.signals : [];
+	const reviewCount = Number( summary.review || 0 ) + Number( summary.actionRecommended || 0 );
+
+	return (
+		<Card className="perform-system-health">
+			<CardHeader>
+				<div>
+					<h3 className="perform-card-title">{ __( 'System health', 'perform' ) }</h3>
+					<p className="perform-card-description">
+						{ __(
+							'Local runtime signals with practical guidance. Perform does not change server configuration.',
+							'perform'
+						) }
+					</p>
+				</div>
+				<span className={ `perform-system-health__summary ${ reviewCount > 0 ? 'has-review' : '' }` }>
+					{ reviewCount > 0
+						? sprintf(
+								/* translators: %d: number of system signals to review. */
+								__( '%d to review', 'perform' ),
+								reviewCount
+						  )
+						: __( 'No actions suggested', 'perform' ) }
+				</span>
+			</CardHeader>
+			<CardBody>
+				{ 0 === signals.length ? (
+					<p>{ __( 'System health signals are unavailable in this environment.', 'perform' ) }</p>
+				) : (
+					<div className="perform-system-health__grid">
+						{ signals.map( ( signal ) => (
+							<div className="perform-system-health__signal" key={ signal.id }>
+								<div className="perform-system-health__signal-heading">
+									<div>
+										<span>{ signal.label }</span>
+										<strong>{ signal.value || __( 'Unavailable', 'perform' ) }</strong>
+									</div>
+									<span className={ `perform-system-health__status is-${ signal.status }` }>
+										{ STATUS_LABELS[ signal.status ] || STATUS_LABELS.unavailable }
+									</span>
+								</div>
+								<p>{ signal.recommendation }</p>
+							</div>
+						) ) }
+					</div>
+				) }
+				<p className="perform-system-health__privacy">
+					{ __(
+						'Paths, credentials, request data, log contents, and private configuration values are intentionally excluded.',
+						'perform'
+					) }
+				</p>
+			</CardBody>
+		</Card>
+	);
+};
+
+export default SystemHealthPanel;

--- a/assets/src/js/admin/SystemHealthPanel.test.jsx
+++ b/assets/src/js/admin/SystemHealthPanel.test.jsx
@@ -1,0 +1,51 @@
+/* eslint-env jest */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import SystemHealthPanel from './SystemHealthPanel';
+
+const health = {
+	summary: { good: 1, review: 1, actionRecommended: 1, unavailable: 0 },
+	signals: [
+		{
+			id: 'php-version',
+			label: 'PHP version',
+			value: '8.3.0',
+			status: 'good',
+			recommendation: 'Actively tested.',
+		},
+		{
+			id: 'memory-limit',
+			label: 'WordPress memory limit',
+			value: '128M',
+			status: 'review',
+			recommendation: 'Review memory pressure first.',
+		},
+		{
+			id: 'uploads',
+			label: 'Uploads directory',
+			value: 'Needs review',
+			status: 'action-recommended',
+			recommendation: 'Review storage permissions.',
+		},
+	],
+};
+
+describe( 'SystemHealthPanel', () => {
+	it( 'shows actionable local status without exposing server configuration', () => {
+		render( <SystemHealthPanel health={ health } /> );
+
+		expect( screen.getByText( '2 to review' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'PHP version' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Good' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Action recommended' ) ).toBeInTheDocument();
+		expect( screen.getByText( /Paths, credentials, request data/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'handles unavailable signal data', () => {
+		render( <SystemHealthPanel health={ {} } /> );
+
+		expect( screen.getByText( 'No actions suggested' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'System health signals are unavailable in this environment.' ) ).toBeInTheDocument();
+	} );
+} );

--- a/docs/system-health.md
+++ b/docs/system-health.md
@@ -1,0 +1,16 @@
+# System health recommendations
+
+Perform shows a compact, read-only system health report inside **Settings → Perform → Site Inventory**. The report uses local WordPress and PHP runtime APIs; it does not make external requests or change hosting configuration.
+
+## Signals
+
+The report can show PHP version, WordPress memory limit, maximum execution time, OPcache, persistent object cache, database version, bounded HTTP/server hints, upload-directory writability, and debug-logging state. Each signal is marked **Good**, **Review**, **Action recommended**, or **Unavailable** with a plain-language next step.
+
+Statuses are guidance, not a root-cause diagnosis. Hosting limits and compatibility should be reviewed before production changes.
+
+## Privacy and multisite
+
+- No filesystem paths, credentials, request data, log contents, private configuration values, or telemetry are collected.
+- Server software is reduced to a known family name and does not expose its full version string.
+- Debug-log contents and paths are never read.
+- On multisite, the report describes the current site and shared runtime; it does not enumerate other sites.

--- a/languages/perform.pot
+++ b/languages/perform.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: PerformWP <hello@performwp.com>\n"
-"POT-Creation-Date: 2026-08-11 03:45+0000\n"
+"POT-Creation-Date: 2026-08-11 04:07+0000\n"
 "Report-Msgid-Bugs-To: https://github.com/performwp/perform/issues/new\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
@@ -16,63 +16,63 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/Admin/Actions.php:92
+#: src/Admin/Actions.php:94
 msgid "Activity actions"
 msgstr ""
 
-#: src/Admin/Actions.php:93
+#: src/Admin/Actions.php:95
 msgid "Export cache activity for review or clear the collected metrics."
 msgstr ""
 
-#: src/Admin/Actions.php:94
+#: src/Admin/Actions.php:96
 msgid "Export CSV"
 msgstr ""
 
-#: src/Admin/Actions.php:95
+#: src/Admin/Actions.php:97
 msgid "Exporting…"
 msgstr ""
 
-#: src/Admin/Actions.php:96
+#: src/Admin/Actions.php:98
 msgid "Cache activity exported."
 msgstr ""
 
-#: src/Admin/Actions.php:97
+#: src/Admin/Actions.php:99
 msgid "Cache activity could not be exported."
 msgstr ""
 
-#: src/Admin/Actions.php:98
+#: src/Admin/Actions.php:100
 msgid "Clear activity"
 msgstr ""
 
-#: src/Admin/Actions.php:99
+#: src/Admin/Actions.php:101
 msgid "Clearing…"
 msgstr ""
 
-#: src/Admin/Actions.php:100
+#: src/Admin/Actions.php:102
 msgid "Clear all collected cache activity? This does not clear cached pages."
 msgstr ""
 
-#: src/Admin/Actions.php:101, src/Modules/Cache/PageCache.php:828, src/Modules/Cache/PageCache.php:1090
+#: src/Admin/Actions.php:103, src/Modules/Cache/PageCache.php:828, src/Modules/Cache/PageCache.php:1090
 msgid "Cache activity cleared."
 msgstr ""
 
-#: src/Admin/Actions.php:102
+#: src/Admin/Actions.php:104
 msgid "Cache activity could not be cleared."
 msgstr ""
 
-#: src/Admin/Actions.php:131
+#: src/Admin/Actions.php:133
 msgid "Close Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:128, src/Modules/Assets/AssetsManager.php:274
+#: src/Admin/Actions.php:130, src/Modules/Assets/AssetsManager.php:274
 msgid "Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:138, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:254
+#: src/Admin/Actions.php:140, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:254
 msgid "Perform"
 msgstr ""
 
-#: src/Admin/Actions.php:158
+#: src/Admin/Actions.php:160
 msgid "Support Forum"
 msgstr ""
 
@@ -948,6 +948,166 @@ msgstr ""
 msgid "Site inventory refreshed."
 msgstr ""
 
+#: src/Admin/Settings/SystemHealth.php:107
+msgid "This runtime is newer than Perform’s current automated PHP test matrix; verify compatibility before rollout."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:105
+msgid "Review a supported PHP upgrade with your host before changing production."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:103
+msgid "This runtime matches Perform’s actively tested PHP range."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:110
+msgid "PHP version"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:122, src/Admin/Settings/SystemHealth.php:130
+msgid "WordPress memory limit"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:122, src/Admin/Settings/SystemHealth.php:171, src/Admin/Settings/SystemHealth.php:216, src/Admin/Settings/SystemHealth.php:247, src/Admin/Settings/SystemHealth.php:257
+msgid "Unavailable"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:122
+msgid "Confirm the effective WordPress memory limit with your host."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:127
+msgid "The configured limit provides reasonable headroom for typical administration."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:128
+msgid "Review memory pressure and hosting limits before increasing this value."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:141, src/Admin/Settings/SystemHealth.php:149
+msgid "Maximum execution time"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:141
+msgid "Unlimited"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:141
+msgid "PHP does not impose a request execution-time limit."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:146
+msgid "The limit supports ordinary WordPress maintenance tasks."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:147
+msgid "Short limits can interrupt imports, updates, or maintenance; review with your host."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:149
+msgid "%d seconds"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:171
+msgid "The runtime did not expose OPcache status."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:177, src/Admin/Settings/SystemHealth.php:284
+msgid "Enabled"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:177, src/Modules/Assets/AssetsManager.php:242
+msgid "Disabled"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:179
+msgid "Compiled PHP code is cached by the runtime."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:179
+msgid "Ask your host whether OPcache can be enabled safely."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:193
+msgid "Persistent object cache"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:194
+msgid "Detected"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:194
+msgid "Not detected"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:196
+msgid "WordPress is using an external object cache."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:196
+msgid "Busy or database-heavy sites may benefit; confirm support with your host first."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:215
+msgid "Database version"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:218
+msgid "Version detected locally; compatibility still depends on the database family and host."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:218
+msgid "Confirm the database version with your host."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:247
+msgid "HTTP and server"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:247
+msgid "This is a local runtime hint, not a public response-performance test."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:257, src/Admin/Settings/SystemHealth.php:266
+msgid "Uploads directory"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:257
+msgid "WordPress did not expose upload-directory status."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:267
+msgid "Writable"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:267
+msgid "Needs review"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:269
+msgid "WordPress reports that media storage is writable."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:269
+msgid "Review media storage permissions with your host; the filesystem path is intentionally hidden."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:283
+msgid "Debug logging"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:284
+msgid "Not enabled"
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:286
+msgid "Confirm logging is intentional and monitor its size on production sites."
+msgstr ""
+
+#: src/Admin/Settings/SystemHealth.php:286
+msgid "Perform does not expose or read any debug-log path or contents."
+msgstr ""
+
 #: src/Modules/Assets/AssetsManager.php:233
 msgid "Search detected assets"
 msgstr ""
@@ -982,10 +1142,6 @@ msgstr ""
 
 #: src/Modules/Assets/AssetsManager.php:241, src/Modules/Assets/AssetsManager.php:292
 msgid "CSS"
-msgstr ""
-
-#: src/Modules/Assets/AssetsManager.php:242
-msgid "Disabled"
 msgstr ""
 
 #: src/Modules/Assets/AssetsManager.php:256

--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -18,6 +18,7 @@ use Perform\Admin\Settings\DashboardPayload;
 use Perform\Admin\Settings\Menu;
 use Perform\Admin\Settings\RuntimeDiagnostics;
 use Perform\Admin\Settings\SiteInventory;
+use Perform\Admin\Settings\SystemHealth;
 
 // Bailout, if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -78,6 +79,7 @@ class Actions {
 					'databaseAuditNonce' => wp_create_nonce( 'perform_refresh_autoload_options_audit' ),
 					'siteInventory'      => SiteInventory::get_cached_snapshot(),
 					'siteInventoryUrl'   => esc_url_raw( rest_url( 'perform/v1/site-inventory' ) ),
+					'systemHealth'       => SystemHealth::get_data(),
 					'restNonce'          => wp_create_nonce( 'wp_rest' ),
 					'sensitiveKeys'      => ClientPayload::get_sensitive_keys(),
 					'maskedSecretValue'  => ClientPayload::MASKED_SECRET,

--- a/src/Admin/Settings/SystemHealth.php
+++ b/src/Admin/Settings/SystemHealth.php
@@ -1,0 +1,351 @@
+<?php
+/**
+ * Perform - Actionable local system health signals.
+ *
+ * @package Perform
+ * @subpackage Admin/Settings
+ */
+
+namespace Perform\Admin\Settings;
+
+use Throwable;
+
+// Bailout, if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Builds a bounded, read-only runtime health summary without exposing paths.
+ */
+final class SystemHealth {
+	const STATUS_GOOD        = 'good';
+	const STATUS_REVIEW      = 'review';
+	const STATUS_ACTION      = 'action-recommended';
+	const STATUS_UNAVAILABLE = 'unavailable';
+
+	/**
+	 * Get current-site system health signals.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function get_data() {
+		$signals = [
+			self::php_version_signal(),
+			self::memory_limit_signal(),
+			self::execution_time_signal(),
+			self::opcache_signal(),
+			self::object_cache_signal(),
+			self::database_signal(),
+			self::http_signal(),
+			self::upload_signal(),
+			self::debug_log_signal(),
+		];
+
+		/**
+		 * Filters detected system-health signals before they are normalized.
+		 *
+		 * @param array<int, array<string, mixed>> $signals Detected signals.
+		 */
+		$signals = apply_filters( 'perform_system_health_signals', $signals );
+		$signals = self::normalize_signals( is_array( $signals ) ? $signals : [] );
+		$summary = [
+			'good'              => 0,
+			'review'            => 0,
+			'actionRecommended' => 0,
+			'unavailable'       => 0,
+		];
+
+		foreach ( $signals as $signal ) {
+			$key = self::STATUS_ACTION === $signal['status'] ? 'actionRecommended' : $signal['status'];
+			if ( isset( $summary[ $key ] ) ) {
+				++$summary[ $key ];
+			}
+		}
+
+		return [
+			'scope'       => 'site',
+			'isMultisite' => is_multisite(),
+			'summary'     => $summary,
+			'signals'     => $signals,
+		];
+	}
+
+	/**
+	 * Create one normalized-ready signal.
+	 *
+	 * @param string $id             Stable signal id.
+	 * @param string $label          Display label.
+	 * @param string $value          Safe display value.
+	 * @param string $status         Recommendation status.
+	 * @param string $recommendation Plain-language guidance.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function signal( $id, $label, $value, $status, $recommendation ) {
+		return [
+			'id'             => $id,
+			'label'          => $label,
+			'value'          => $value,
+			'status'         => $status,
+			'recommendation' => $recommendation,
+		];
+	}
+
+	/**
+	 * Detect PHP version support signal.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function php_version_signal() {
+		$status = PHP_VERSION_ID >= 80100 && PHP_VERSION_ID < 80400 ? self::STATUS_GOOD : self::STATUS_REVIEW;
+		if ( self::STATUS_GOOD === $status ) {
+			$copy = __( 'This runtime matches Perform’s actively tested PHP range.', 'perform' );
+		} elseif ( PHP_VERSION_ID < 80100 ) {
+			$copy = __( 'Review a supported PHP upgrade with your host before changing production.', 'perform' );
+		} else {
+			$copy = __( 'This runtime is newer than Perform’s current automated PHP test matrix; verify compatibility before rollout.', 'perform' );
+		}
+
+		return self::signal( 'php-version', __( 'PHP version', 'perform' ), PHP_VERSION, $status, $copy );
+	}
+
+	/**
+	 * Detect WordPress memory-limit signal.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function memory_limit_signal() {
+		$value = defined( 'WP_MEMORY_LIMIT' ) ? (string) WP_MEMORY_LIMIT : (string) ini_get( 'memory_limit' );
+		$bytes = self::parse_bytes( $value );
+		if ( 0 >= $bytes ) {
+			return self::signal( 'memory-limit', __( 'WordPress memory limit', 'perform' ), __( 'Unavailable', 'perform' ), self::STATUS_UNAVAILABLE, __( 'Confirm the effective WordPress memory limit with your host.', 'perform' ) );
+		}
+
+		$status = $bytes >= 268435456 ? self::STATUS_GOOD : ( $bytes >= 134217728 ? self::STATUS_REVIEW : self::STATUS_ACTION );
+		$copy   = self::STATUS_GOOD === $status
+			? __( 'The configured limit provides reasonable headroom for typical administration.', 'perform' )
+			: __( 'Review memory pressure and hosting limits before increasing this value.', 'perform' );
+
+		return self::signal( 'memory-limit', __( 'WordPress memory limit', 'perform' ), sanitize_text_field( $value ), $status, $copy );
+	}
+
+	/**
+	 * Detect maximum execution-time signal.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function execution_time_signal() {
+		$seconds = (int) ini_get( 'max_execution_time' );
+		if ( 0 === $seconds ) {
+			return self::signal( 'execution-time', __( 'Maximum execution time', 'perform' ), __( 'Unlimited', 'perform' ), self::STATUS_GOOD, __( 'PHP does not impose a request execution-time limit.', 'perform' ) );
+		}
+
+		$status = $seconds >= 60 ? self::STATUS_GOOD : ( $seconds >= 30 ? self::STATUS_REVIEW : self::STATUS_ACTION );
+		$copy   = self::STATUS_GOOD === $status
+			? __( 'The limit supports ordinary WordPress maintenance tasks.', 'perform' )
+			: __( 'Short limits can interrupt imports, updates, or maintenance; review with your host.', 'perform' );
+
+		return self::signal( 'execution-time', __( 'Maximum execution time', 'perform' ), sprintf( __( '%d seconds', 'perform' ), $seconds ), $status, $copy );
+	}
+
+	/**
+	 * Detect OPcache without changing runtime state.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function opcache_signal() {
+		$enabled = null;
+		if ( function_exists( 'opcache_get_status' ) ) {
+			try {
+				$status = opcache_get_status( false );
+				if ( is_array( $status ) ) {
+					$enabled = ! empty( $status['opcache_enabled'] );
+				}
+			} catch ( Throwable $exception ) {
+				$enabled = null;
+			}
+		}
+
+		if ( null === $enabled ) {
+			return self::signal( 'opcache', 'OPcache', __( 'Unavailable', 'perform' ), self::STATUS_UNAVAILABLE, __( 'The runtime did not expose OPcache status.', 'perform' ) );
+		}
+
+		return self::signal(
+			'opcache',
+			'OPcache',
+			$enabled ? __( 'Enabled', 'perform' ) : __( 'Disabled', 'perform' ),
+			$enabled ? self::STATUS_GOOD : self::STATUS_ACTION,
+			$enabled ? __( 'Compiled PHP code is cached by the runtime.', 'perform' ) : __( 'Ask your host whether OPcache can be enabled safely.', 'perform' )
+		);
+	}
+
+	/**
+	 * Detect persistent object-cache usage.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function object_cache_signal() {
+		$enabled = function_exists( 'wp_using_ext_object_cache' ) && wp_using_ext_object_cache();
+
+		return self::signal(
+			'object-cache',
+			__( 'Persistent object cache', 'perform' ),
+			$enabled ? __( 'Detected', 'perform' ) : __( 'Not detected', 'perform' ),
+			$enabled ? self::STATUS_GOOD : self::STATUS_REVIEW,
+			$enabled ? __( 'WordPress is using an external object cache.', 'perform' ) : __( 'Busy or database-heavy sites may benefit; confirm support with your host first.', 'perform' )
+		);
+	}
+
+	/**
+	 * Detect a safe database version value.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function database_signal() {
+		global $wpdb;
+
+		$value = '';
+		if ( is_object( $wpdb ) && is_callable( [ $wpdb, 'db_version' ] ) ) {
+			$value = sanitize_text_field( (string) $wpdb->db_version() );
+		}
+
+		return self::signal(
+			'database-version',
+			__( 'Database version', 'perform' ),
+			'' !== $value ? $value : __( 'Unavailable', 'perform' ),
+			'' !== $value ? self::STATUS_GOOD : self::STATUS_UNAVAILABLE,
+			'' !== $value ? __( 'Version detected locally; compatibility still depends on the database family and host.', 'perform' ) : __( 'Confirm the database version with your host.', 'perform' )
+		);
+	}
+
+	/**
+	 * Detect bounded HTTP/server hints.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function http_signal() {
+		$protocol = isset( $_SERVER['SERVER_PROTOCOL'] ) ? strtoupper( sanitize_text_field( wp_unslash( $_SERVER['SERVER_PROTOCOL'] ) ) ) : '';
+		$protocol = preg_match( '/^HTTP\/[0-9.]+$/', $protocol ) ? $protocol : '';
+		$software = isset( $_SERVER['SERVER_SOFTWARE'] ) ? strtolower( sanitize_text_field( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) ) ) : '';
+		$family   = '';
+
+		foreach ( [
+			'litespeed' => 'LiteSpeed',
+			'nginx'     => 'nginx',
+			'apache'    => 'Apache',
+			'iis'       => 'IIS',
+		] as $needle => $label ) {
+			if ( false !== strpos( $software, $needle ) ) {
+				$family = $label;
+				break;
+			}
+		}
+
+		$value = trim( implode( ' · ', array_filter( [ $protocol, $family ] ) ) );
+
+		return self::signal( 'http-server', __( 'HTTP and server', 'perform' ), '' !== $value ? $value : __( 'Unavailable', 'perform' ), '' !== $value ? self::STATUS_GOOD : self::STATUS_UNAVAILABLE, __( 'This is a local runtime hint, not a public response-performance test.', 'perform' ) );
+	}
+
+	/**
+	 * Detect upload-directory writability without exposing the path.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function upload_signal() {
+		if ( ! function_exists( 'wp_get_upload_dir' ) ) {
+			return self::signal( 'uploads', __( 'Uploads directory', 'perform' ), __( 'Unavailable', 'perform' ), self::STATUS_UNAVAILABLE, __( 'WordPress did not expose upload-directory status.', 'perform' ) );
+		}
+
+		$uploads     = wp_get_upload_dir();
+		$has_error   = is_array( $uploads ) && ! empty( $uploads['error'] );
+		$is_writable = is_array( $uploads ) && ! empty( $uploads['basedir'] ) && function_exists( 'wp_is_writable' ) && wp_is_writable( $uploads['basedir'] );
+
+		return self::signal(
+			'uploads',
+			__( 'Uploads directory', 'perform' ),
+			$is_writable ? __( 'Writable', 'perform' ) : __( 'Needs review', 'perform' ),
+			$is_writable && ! $has_error ? self::STATUS_GOOD : self::STATUS_ACTION,
+			$is_writable && ! $has_error ? __( 'WordPress reports that media storage is writable.', 'perform' ) : __( 'Review media storage permissions with your host; the filesystem path is intentionally hidden.', 'perform' )
+		);
+	}
+
+	/**
+	 * Detect debug-log configuration without reading or exposing the file.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function debug_log_signal() {
+		$enabled = defined( 'WP_DEBUG_LOG' ) && false !== WP_DEBUG_LOG;
+
+		return self::signal(
+			'debug-log',
+			__( 'Debug logging', 'perform' ),
+			$enabled ? __( 'Enabled', 'perform' ) : __( 'Not enabled', 'perform' ),
+			$enabled ? self::STATUS_REVIEW : self::STATUS_GOOD,
+			$enabled ? __( 'Confirm logging is intentional and monitor its size on production sites.', 'perform' ) : __( 'Perform does not expose or read any debug-log path or contents.', 'perform' )
+		);
+	}
+
+	/**
+	 * Normalize filtered values to the client contract.
+	 *
+	 * @param array<int, mixed> $signals Candidate signals.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	private static function normalize_signals( array $signals ) {
+		$normalized = [];
+		$allowed    = [ self::STATUS_GOOD, self::STATUS_REVIEW, self::STATUS_ACTION, self::STATUS_UNAVAILABLE ];
+
+		foreach ( array_slice( $signals, 0, 20 ) as $signal ) {
+			if ( ! is_array( $signal ) ) {
+				continue;
+			}
+
+			$id = sanitize_key( (string) ( $signal['id'] ?? '' ) );
+			if ( '' === $id ) {
+				continue;
+			}
+
+			$status       = (string) ( $signal['status'] ?? self::STATUS_UNAVAILABLE );
+			$normalized[] = [
+				'id'             => $id,
+				'label'          => sanitize_text_field( (string) ( $signal['label'] ?? $id ) ),
+				'value'          => sanitize_text_field( (string) ( $signal['value'] ?? '' ) ),
+				'status'         => in_array( $status, $allowed, true ) ? $status : self::STATUS_UNAVAILABLE,
+				'recommendation' => sanitize_text_field( (string) ( $signal['recommendation'] ?? '' ) ),
+			];
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Convert shorthand PHP size values to bytes.
+	 *
+	 * @param string $value Shorthand value.
+	 *
+	 * @return int
+	 */
+	private static function parse_bytes( $value ) {
+		$value = trim( $value );
+		if ( '' === $value || '-1' === $value ) {
+			return '-1' === $value ? PHP_INT_MAX : 0;
+		}
+
+		$number = (float) $value;
+		$unit   = strtolower( substr( $value, -1 ) );
+		if ( 'g' === $unit ) {
+			$number *= 1024;
+		}
+		if ( in_array( $unit, [ 'g', 'm' ], true ) ) {
+			$number *= 1024;
+		}
+		if ( in_array( $unit, [ 'g', 'm', 'k' ], true ) ) {
+			$number *= 1024;
+		}
+
+		return (int) $number;
+	}
+}

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -123,6 +123,10 @@ test( 'Site Inventory refresh is private, bounded, and responsive', async ( { pa
 	await expect( page.getByRole( 'tab', { name: 'Site Inventory' } ) ).toHaveAttribute( 'aria-selected', 'true' );
 	await expect( page.getByText( 'Private and local' ) ).toBeVisible();
 	await expect( page.getByText( /no post content, option values, private URLs/i ) ).toBeVisible();
+	await expect( page.getByRole( 'heading', { name: 'System health' } ) ).toBeVisible();
+	await expect( page.getByText( 'PHP version' ) ).toBeVisible();
+	await expect( page.getByText( 'Persistent object cache' ) ).toBeVisible();
+	await expect( page.getByText( /Paths, credentials, request data/ ) ).toBeVisible();
 	await expect( page.getByRole( 'button', { name: /Generate inventory|Refresh inventory/ } ) ).toBeVisible();
 	await page.getByRole( 'button', { name: /Generate inventory|Refresh inventory/ } ).click();
 	await expect( page.getByRole( 'status' ) ).toContainText( 'Site inventory refreshed.' );

--- a/tests/unit-tests/tests-system-health.php
+++ b/tests/unit-tests/tests-system-health.php
@@ -1,0 +1,88 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Perform\Admin\Settings\SystemHealth;
+
+final class Tests_System_Health extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['perform_test_filters']          = [];
+		$GLOBALS['perform_test_is_multisite']     = false;
+		$GLOBALS['perform_test_ext_object_cache'] = false;
+	}
+
+	protected function tearDown(): void {
+		unset(
+			$GLOBALS['perform_test_filters'],
+			$GLOBALS['perform_test_is_multisite'],
+			$GLOBALS['perform_test_ext_object_cache']
+		);
+	}
+
+	public function test_filtered_signals_are_bounded_normalized_and_summarized() {
+		$GLOBALS['perform_test_filters']['perform_system_health_signals'] = [
+			[
+				'id'             => 'php-version',
+				'label'          => 'PHP version',
+				'value'          => '8.3.0',
+				'status'         => 'good',
+				'recommendation' => 'Actively tested.',
+			],
+			[
+				'id'             => 'memory-limit',
+				'label'          => 'Memory',
+				'value'          => '64M',
+				'status'         => 'action-recommended',
+				'recommendation' => 'Review pressure first.',
+			],
+			[
+				'id'             => 'unknown-state',
+				'label'          => 'Unknown state',
+				'value'          => 'Value',
+				'status'         => 'invented',
+				'recommendation' => 'Unavailable.',
+			],
+			'invalid',
+		];
+
+		$health = SystemHealth::get_data();
+
+		$this->assertSame( 'site', $health['scope'] );
+		$this->assertFalse( $health['isMultisite'] );
+		$this->assertCount( 3, $health['signals'] );
+		$this->assertSame( 1, $health['summary']['good'] );
+		$this->assertSame( 1, $health['summary']['actionRecommended'] );
+		$this->assertSame( 1, $health['summary']['unavailable'] );
+		$this->assertSame( 'unavailable', $health['signals'][2]['status'] );
+	}
+
+	public function test_default_payload_excludes_paths_and_private_runtime_values() {
+		$_SERVER['SERVER_PROTOCOL'] = 'HTTP/2.0';
+		$_SERVER['SERVER_SOFTWARE'] = 'nginx/1.27.0 private-build';
+
+		$health = SystemHealth::get_data();
+		$json   = wp_json_encode( $health );
+		$ids    = array_column( $health['signals'], 'id' );
+		$http   = $health['signals'][ array_search( 'http-server', $ids, true ) ];
+
+		$this->assertContains( 'php-version', $ids );
+		$this->assertContains( 'memory-limit', $ids );
+		$this->assertContains( 'object-cache', $ids );
+		$this->assertContains( 'database-version', $ids );
+		$this->assertContains( 'http-server', $ids );
+		$this->assertContains( 'debug-log', $ids );
+		$this->assertStringContainsString( 'HTTP/2.0', $http['value'] );
+		$this->assertStringContainsString( 'nginx', $json );
+		$this->assertStringNotContainsString( 'private-build', $json );
+		$this->assertStringNotContainsString( '/var/', $json );
+		$this->assertStringNotContainsString( 'password', strtolower( $json ) );
+	}
+
+	public function test_multisite_scope_is_current_site_only() {
+		$GLOBALS['perform_test_is_multisite'] = true;
+
+		$health = SystemHealth::get_data();
+
+		$this->assertTrue( $health['isMultisite'] );
+		$this->assertSame( 'site', $health['scope'] );
+	}
+}


### PR DESCRIPTION
## Summary

- add a read-only System Health report to Site Inventory
- explain PHP/runtime limits, OPcache, persistent object cache, database, safe HTTP/server hints, uploads, and debug logging in plain language
- classify signals as Good, Review, Action recommended, or Unavailable
- keep the payload per-site and exclude paths, credentials, request data, log contents, and private configuration values
- document the contract and extend hosted responsive smoke proof

## Safety and compatibility

- no server configuration is changed
- no external requests or telemetry
- no log file or log path is read
- upload paths and full server software strings are not exposed
- multisite reports the current site/shared runtime without enumerating sites
- filtered values are normalized and hard-capped

## Validation

- `composer test`: 121 tests / 358 assertions
- `composer phpstan`: pass
- `composer lint`: 78 PHP files pass
- scoped PHPCS: pass
- JS unit tests: 28/28
- JS lint: pass
- CSS lint: pass
- production frontend build: pass
- read-only Studio runtime proof on WordPress 7.0.3 / PHP 8.2 produced nine bounded signals and no private paths

Closes #183
