### PR TITLE
Add bounded scheduled task diagnostics

### DIFF
--- a/assets/src/css/admin/settings.css
+++ b/assets/src/css/admin/settings.css
@@ -1259,6 +1259,165 @@
 	color: var(--perform-color-warning);
 }
 
+.perform-cron-pressure {
+	display: grid;
+	gap: 24px;
+}
+
+.perform-cron-pressure > *,
+.perform-cron-pressure .components-card__body {
+	min-width: 0;
+}
+
+.perform-cron-pressure__heading {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 24px;
+	padding-bottom: 24px;
+	border-bottom: 1px solid var(--perform-color-border);
+}
+
+.perform-cron-pressure__heading h2 {
+	margin: 0 0 8px;
+	font-size: 24px;
+	line-height: 1.25;
+}
+
+.perform-cron-pressure__heading p:not(.perform-dashboard-eyebrow) {
+	max-width: 760px;
+	margin: 0;
+	color: var(--perform-color-text-muted);
+	font-size: 14px;
+	line-height: 1.55;
+}
+
+.perform-cron-pressure__actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.perform-cron-pressure__privacy,
+.perform-cron-pressure__message,
+.perform-cron-pressure__notice,
+.perform-cron-pressure__guidance {
+	padding: 16px 20px;
+	border-left: 4px solid var(--perform-color-brand);
+	background: #f6f7f7;
+}
+
+.perform-cron-pressure__privacy p,
+.perform-cron-pressure__notice p,
+.perform-cron-pressure__guidance p {
+	margin: 6px 0 0;
+	color: var(--perform-color-text-muted);
+	line-height: 1.5;
+}
+
+.perform-cron-pressure__message.is-error,
+.perform-cron-pressure__guidance.is-action-recommended {
+	border-left-color: var(--perform-color-danger);
+}
+
+.perform-cron-pressure__message.is-success,
+.perform-cron-pressure__guidance.is-good {
+	border-left-color: var(--perform-color-success);
+}
+
+.perform-cron-pressure__notice,
+.perform-cron-pressure__guidance.is-review {
+	border-left-color: var(--perform-color-warning);
+	background: #fcf9e8;
+}
+
+.perform-cron-pressure__empty {
+	border-radius: 0;
+	box-shadow: none;
+}
+
+.perform-cron-pressure__empty h3 {
+	margin: 0 0 8px;
+	font-size: 18px;
+}
+
+.perform-cron-pressure__empty p {
+	margin: 0;
+	color: var(--perform-color-text-muted);
+}
+
+.perform-cron-pressure__summary {
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	border-top: 1px solid var(--perform-color-border);
+	border-bottom: 1px solid var(--perform-color-border);
+}
+
+.perform-cron-pressure__summary > div {
+	min-width: 0;
+	padding: 20px 24px;
+	border-right: 1px solid var(--perform-color-border);
+}
+
+.perform-cron-pressure__summary > div:first-child {
+	padding-left: 0;
+}
+
+.perform-cron-pressure__summary > div:last-child {
+	border-right: 0;
+}
+
+.perform-cron-pressure__summary span,
+.perform-cron-pressure__summary small {
+	display: block;
+	color: var(--perform-color-text-muted);
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.perform-cron-pressure__summary strong {
+	display: block;
+	margin: 8px 0 4px;
+	font-size: 24px;
+	line-height: 1.2;
+}
+
+.perform-cron-pressure__table-wrap {
+	max-width: 100%;
+	overflow-x: auto;
+}
+
+.perform-cron-pressure__table {
+	width: 100%;
+	border-collapse: collapse;
+	text-align: left;
+}
+
+.perform-cron-pressure__table th,
+.perform-cron-pressure__table td {
+	padding: 14px 12px;
+	border-bottom: 1px solid var(--perform-color-border);
+	vertical-align: top;
+}
+
+.perform-cron-pressure__table thead th {
+	color: var(--perform-color-text-muted);
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
+.perform-cron-pressure__table code {
+	white-space: normal;
+	overflow-wrap: anywhere;
+}
+
+.perform-cron-pressure__meta {
+	margin: 16px 0 0;
+	color: var(--perform-color-text-muted);
+	font-size: 12px;
+}
+
 @media screen and (max-width: 782px) {
 
 	.perform-settings-page {
@@ -1352,6 +1511,35 @@
 	.perform-admin-monitor__heading .components-button {
 		width: 100%;
 		justify-content: center;
+	}
+
+	.perform-cron-pressure__heading,
+	.perform-cron-pressure__actions {
+		flex-direction: column;
+	}
+
+	.perform-cron-pressure__actions,
+	.perform-cron-pressure__actions .components-button {
+		width: 100%;
+	}
+
+	.perform-cron-pressure__actions .components-button {
+		justify-content: center;
+	}
+
+	.perform-cron-pressure__summary {
+		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.perform-cron-pressure__summary > div,
+	.perform-cron-pressure__summary > div:first-child {
+		padding: 16px 0;
+		border-right: 0;
+		border-bottom: 1px solid var(--perform-color-border);
+	}
+
+	.perform-cron-pressure__summary > div:last-child {
+		border-bottom: 0;
 	}
 
 	.perform-admin-monitor__table-wrap {

--- a/assets/src/js/admin/CronPressurePanel.jsx
+++ b/assets/src/js/admin/CronPressurePanel.jsx
@@ -1,0 +1,231 @@
+import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const SETTINGS = window.performwpSettings || {};
+
+const CronPressurePanel = ( { initialAudit = SETTINGS.cronPressure || {} } ) => {
+	const [ audit, setAudit ] = useState( initialAudit );
+	const [ working, setWorking ] = useState( '' );
+	const [ message, setMessage ] = useState( null );
+	const hasAudit = 'ready' === audit.status;
+	const totals = audit.totals || {};
+	const hooks = Array.isArray( audit.frequentHooks ) ? audit.frequentHooks : [];
+	const guidance = audit.guidance || {};
+	let refreshLabel = hasAudit ? __( 'Refresh check', 'perform' ) : __( 'Run check', 'perform' );
+
+	if ( 'refresh' === working ) {
+		refreshLabel = __( 'Checking scheduled tasks…', 'perform' );
+	}
+
+	const request = async ( action ) => {
+		const isClear = 'perform_clear_cron_pressure_audit' === action;
+		setWorking( isClear ? 'clear' : 'refresh' );
+		setMessage( {
+			type: 'status',
+			text: isClear
+				? __( 'Clearing the saved diagnostic…', 'perform' )
+				: __( 'Checking scheduled tasks…', 'perform' ),
+		} );
+
+		try {
+			const response = await fetch( window.ajaxurl, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+				body: new URLSearchParams( {
+					action,
+					nonce: SETTINGS.cronPressureNonce || '',
+				} ),
+			} );
+			const result = await response.json();
+
+			if ( ! response.ok || ! result?.success || ! result.data?.audit ) {
+				throw new Error(
+					result?.data?.message || __( 'The scheduled-task diagnostic could not be updated.', 'perform' )
+				);
+			}
+
+			setAudit( result.data.audit );
+			setMessage( { type: 'success', text: result.data.message } );
+		} catch ( error ) {
+			setMessage( {
+				type: 'error',
+				text: error?.message || __( 'The scheduled-task diagnostic could not be updated.', 'perform' ),
+			} );
+		} finally {
+			setWorking( '' );
+		}
+	};
+
+	const clearAudit = () => {
+		if (
+			// eslint-disable-next-line no-alert -- Clearing the saved aggregate requires explicit administrator confirmation.
+			window.confirm(
+				__( 'Clear the saved scheduled-task diagnostic? No cron events will be changed.', 'perform' )
+			)
+		) {
+			request( 'perform_clear_cron_pressure_audit' );
+		}
+	};
+
+	return (
+		<div className="perform-cron-pressure">
+			<div className="perform-cron-pressure__heading">
+				<div>
+					<p className="perform-dashboard-eyebrow">{ __( 'Scheduled work', 'perform' ) }</p>
+					<h2>{ __( 'Scheduled-task pressure', 'perform' ) }</h2>
+					<p>
+						{ __(
+							'Inspect overdue and clustered WP-Cron work without reading hook arguments or changing third-party schedules.',
+							'perform'
+						) }
+					</p>
+				</div>
+				<div className="perform-cron-pressure__actions">
+					<Button
+						variant="primary"
+						onClick={ () => request( 'perform_refresh_cron_pressure_audit' ) }
+						disabled={ Boolean( working ) }
+						isBusy={ 'refresh' === working }
+					>
+						{ refreshLabel }
+					</Button>
+					{ hasAudit && (
+						<Button variant="tertiary" onClick={ clearAudit } disabled={ Boolean( working ) }>
+							{ 'clear' === working ? __( 'Clearing…', 'perform' ) : __( 'Clear snapshot', 'perform' ) }
+						</Button>
+					) }
+				</div>
+			</div>
+
+			<div className="perform-cron-pressure__privacy">
+				<strong>{ __( 'Read-only and bounded', 'perform' ) }</strong>
+				<p>
+					{ __(
+						'Perform scans up to 5,000 scheduled events for this site, stores aggregate counts for one hour, and excludes hook arguments, payloads, URLs, and user data.',
+						'perform'
+					) }
+				</p>
+			</div>
+
+			{ message && (
+				<div
+					className={ `perform-cron-pressure__message is-${ message.type }` }
+					role={ 'error' === message.type ? 'alert' : 'status' }
+					aria-live="polite"
+				>
+					{ message.text }
+				</div>
+			) }
+
+			{ ! hasAudit ? (
+				<Card className="perform-cron-pressure__empty">
+					<CardBody>
+						<h3>{ __( 'Run the first scheduled-task check', 'perform' ) }</h3>
+						<p>
+							{ __(
+								'The check runs only when requested and does not delete or reschedule events.',
+								'perform'
+							) }
+						</p>
+					</CardBody>
+				</Card>
+			) : (
+				<>
+					{ audit.wpCronDisabled && (
+						<div className="perform-cron-pressure__notice">
+							<strong>{ __( 'Built-in WP-Cron spawning is disabled', 'perform' ) }</strong>
+							<p>
+								{ __(
+									'Confirm that the host or server calls wp-cron.php on a reliable schedule. Perform cannot verify an external runner from this page.',
+									'perform'
+								) }
+							</p>
+						</div>
+					) }
+
+					<div
+						className="perform-cron-pressure__summary"
+						aria-label={ __( 'Scheduled-task summary', 'perform' ) }
+					>
+						<div>
+							<span>{ __( 'Due now', 'perform' ) }</span>
+							<strong>{ totals.due || 0 }</strong>
+						</div>
+						<div>
+							<span>{ __( 'Overdue', 'perform' ) }</span>
+							<strong>{ totals.overdue || 0 }</strong>
+							<small>{ __( 'More than 5 minutes late', 'perform' ) }</small>
+						</div>
+						<div>
+							<span>{ __( 'Recurring', 'perform' ) }</span>
+							<strong>{ totals.recurring || 0 }</strong>
+						</div>
+						<div>
+							<span>{ __( 'Peak 5-minute cluster', 'perform' ) }</span>
+							<strong>{ totals.peakCluster || 0 }</strong>
+							<small>{ __( 'Within the next hour', 'perform' ) }</small>
+						</div>
+					</div>
+
+					<div className={ `perform-cron-pressure__guidance is-${ guidance.status || 'good' }` }>
+						<strong>{ guidance.heading }</strong>
+						<p>{ guidance.message }</p>
+					</div>
+
+					<Card>
+						<CardHeader>
+							<div>
+								<h3 className="perform-card-title">
+									{ __( 'Most frequent scheduled hooks', 'perform' ) }
+								</h3>
+								<p className="perform-card-description">
+									{ __(
+										'Hook names and aggregate counts only. Frequency does not prove that a hook is harmful.',
+										'perform'
+									) }
+								</p>
+							</div>
+						</CardHeader>
+						<CardBody>
+							<div className="perform-cron-pressure__table-wrap">
+								<table className="perform-cron-pressure__table">
+									<thead>
+										<tr>
+											<th scope="col">{ __( 'Hook', 'perform' ) }</th>
+											<th scope="col">{ __( 'Scheduled instances', 'perform' ) }</th>
+										</tr>
+									</thead>
+									<tbody>
+										{ 0 === hooks.length && (
+											<tr>
+												<td colSpan="2">
+													{ __( 'No scheduled hooks were returned.', 'perform' ) }
+												</td>
+											</tr>
+										) }
+										{ hooks.map( ( hook ) => (
+											<tr key={ hook.hook }>
+												<th scope="row">
+													<code>{ hook.hook }</code>
+												</th>
+												<td>{ hook.count }</td>
+											</tr>
+										) ) }
+									</tbody>
+								</table>
+							</div>
+							<p className="perform-cron-pressure__meta">
+								{ totals.truncated
+									? __( 'The scan reached its 5,000-event safety limit.', 'perform' )
+									: __( 'The bounded scan completed without reaching its event limit.', 'perform' ) }
+							</p>
+						</CardBody>
+					</Card>
+				</>
+			) }
+		</div>
+	);
+};
+
+export default CronPressurePanel;

--- a/assets/src/js/admin/CronPressurePanel.test.jsx
+++ b/assets/src/js/admin/CronPressurePanel.test.jsx
@@ -1,0 +1,65 @@
+/* eslint-env jest */
+
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+window.performwpSettings = { cronPressureNonce: 'cron-nonce' };
+
+const CronPressurePanel = require( './CronPressurePanel' ).default;
+
+const readyAudit = {
+	status: 'ready',
+	wpCronDisabled: true,
+	totals: { scanned: 12, due: 3, overdue: 2, recurring: 8, peakCluster: 4, truncated: false },
+	guidance: { status: 'review', heading: 'Some scheduled work needs review', message: 'Compare again.' },
+	frequentHooks: [ { hook: 'perform_cache_preload', count: 5 } ],
+};
+
+describe( 'CronPressurePanel', () => {
+	afterEach( () => {
+		delete global.fetch;
+		jest.restoreAllMocks();
+	} );
+
+	it( 'shows bounded aggregate evidence without claiming a harmful hook', () => {
+		render( <CronPressurePanel initialAudit={ readyAudit } /> );
+
+		expect( screen.getByText( 'Built-in WP-Cron spawning is disabled' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'perform_cache_preload' ) ).toBeInTheDocument();
+		expect( screen.getByText( /excludes hook arguments, payloads, URLs, and user data/ ) ).toBeInTheDocument();
+		expect( screen.getByText( /does not prove that a hook is harmful/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'refreshes the snapshot with visible progress', async () => {
+		global.fetch = jest.fn().mockResolvedValue( {
+			ok: true,
+			json: async () => ( { success: true, data: { message: 'Refreshed.', audit: readyAudit } } ),
+		} );
+
+		render( <CronPressurePanel initialAudit={ { status: 'not-run' } } /> );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Run check' } ) );
+
+		expect( screen.getByRole( 'button', { name: 'Checking scheduled tasks…' } ) ).toBeDisabled();
+		await waitFor( () => expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Refreshed.' ) );
+		expect( global.fetch ).toHaveBeenCalledWith( window.ajaxurl, expect.objectContaining( { method: 'POST' } ) );
+	} );
+
+	it( 'requires confirmation before clearing the saved snapshot', async () => {
+		jest.spyOn( window, 'confirm' ).mockReturnValue( true );
+		global.fetch = jest.fn().mockResolvedValue( {
+			ok: true,
+			json: async () => ( {
+				success: true,
+				data: { message: 'Cleared.', audit: { status: 'not-run' } },
+			} ),
+		} );
+
+		render( <CronPressurePanel initialAudit={ readyAudit } /> );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Clear snapshot' } ) );
+
+		expect( window.confirm ).toHaveBeenCalledWith(
+			'Clear the saved scheduled-task diagnostic? No cron events will be changed.'
+		);
+		await waitFor( () => expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Cleared.' ) );
+	} );
+} );

--- a/assets/src/js/admin/SettingsApp.jsx
+++ b/assets/src/js/admin/SettingsApp.jsx
@@ -14,6 +14,7 @@ const DATABASE_AUDIT = SETTINGS.databaseAudit || {};
 const SITE_INVENTORY = SETTINGS.siteInventory || {};
 const SYSTEM_HEALTH = SETTINGS.systemHealth || {};
 const ADMIN_PERFORMANCE = SETTINGS.adminPerformance || {};
+const CRON_PRESSURE = SETTINGS.cronPressure || {};
 const TAB_KEYS = [ 'dashboard', ...Object.keys( SETTINGS_TABS ) ];
 
 const normalizeTab = ( tab ) => ( TAB_KEYS.includes( tab ) ? tab : 'dashboard' );
@@ -181,15 +182,16 @@ const SettingsApp = () => {
 				siteInventory={ SITE_INVENTORY }
 				systemHealth={ SYSTEM_HEALTH }
 				adminPerformance={ ADMIN_PERFORMANCE }
+				cronPressure={ CRON_PRESSURE }
 				activeTab={ activeTab }
 				onTabChange={ handleTabChange }
 				fieldValues={ fieldValues }
 				onFieldChange={ handleFieldChange }
 			/>
 			{ 'dashboard' === activeTab && <DiagnosticsPanel diagnostics={ diagnostics } /> }
-			{ ! [ 'dashboard', 'cache-stats', 'database', 'inventory', 'admin-monitor' ].includes( activeTab ) && (
-				<Footer dirty={ isDirty } saving={ saving } message={ message } onSave={ handleSave } />
-			) }
+			{ ! [ 'dashboard', 'cache-stats', 'database', 'inventory', 'admin-monitor', 'scheduled-tasks' ].includes(
+				activeTab
+			) && <Footer dirty={ isDirty } saving={ saving } message={ message } onSave={ handleSave } /> }
 		</>
 	);
 };

--- a/assets/src/js/admin/SettingsNav.jsx
+++ b/assets/src/js/admin/SettingsNav.jsx
@@ -5,6 +5,7 @@ import AdminPerformanceMonitorPanel from './AdminPerformanceMonitorPanel';
 import DashboardPanel from './DashboardPanel';
 import DatabaseAuditPanel from './DatabaseAuditPanel';
 import SiteInventoryPanel from './SiteInventoryPanel';
+import CronPressurePanel from './CronPressurePanel';
 import SettingsFieldRow from './settings/SettingsFieldRow';
 
 const SETTINGS = window.performwpSettings || {};
@@ -18,6 +19,7 @@ const SettingsNav = ( {
 	siteInventory,
 	systemHealth,
 	adminPerformance,
+	cronPressure,
 	activeTab: propActiveTab,
 	onTabChange: propOnTabChange,
 	fieldValues: propFieldValues,
@@ -126,6 +128,8 @@ const SettingsNav = ( {
 								onNavigate={ onTabChange }
 							/>
 						);
+					} else if ( 'scheduled-tasks' === selectedTabName ) {
+						content = <CronPressurePanel initialAudit={ cronPressure } />;
 					} else if ( 'cache-stats' === selectedTabName ) {
 						content = <CacheStatsPanel />;
 					}

--- a/docs/scheduled-task-pressure.md
+++ b/docs/scheduled-task-pressure.md
@@ -1,0 +1,21 @@
+# Scheduled-task pressure diagnostics
+
+Perform provides a manual, read-only WP-Cron diagnostic under **Settings → Perform → Scheduled Tasks**.
+
+## What the check measures
+
+- due events and events more than five minutes overdue;
+- recurring scheduled instances;
+- the largest five-minute cluster within the next hour;
+- the most frequent hook names and aggregate instance counts;
+- whether WordPress's built-in cron spawning is disabled.
+
+The scan runs only when requested, is capped at 5,000 event instances and 20 hook rows, and stores the current site's snapshot for one hour. It never reads or stores hook arguments, request payloads, URLs, user data, or task results.
+
+## Safety
+
+Perform does not delete, run, or reschedule events. A frequent or overdue hook is a review signal, not proof that its extension is harmful. Compare repeated snapshots and consult the responsible extension or hosting provider before changing schedules.
+
+Clearing the report removes only Perform's cached diagnostic snapshot. It does not change WordPress cron data.
+
+On multisite, each site's snapshot and scheduled-event inventory remain separate. If `DISABLE_WP_CRON` is enabled, Perform can remind the administrator to verify an external runner, but it cannot confirm that runner from the WordPress request.

--- a/languages/perform.pot
+++ b/languages/perform.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: PerformWP <hello@performwp.com>\n"
-"POT-Creation-Date: 2026-08-11 04:07+0000\n"
+"POT-Creation-Date: 2026-08-11 04:23+0000\n"
 "Report-Msgid-Bugs-To: https://github.com/performwp/perform/issues/new\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
@@ -16,63 +16,63 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/Admin/Actions.php:94
+#: src/Admin/Actions.php:97
 msgid "Activity actions"
 msgstr ""
 
-#: src/Admin/Actions.php:95
+#: src/Admin/Actions.php:98
 msgid "Export cache activity for review or clear the collected metrics."
 msgstr ""
 
-#: src/Admin/Actions.php:96
+#: src/Admin/Actions.php:99
 msgid "Export CSV"
 msgstr ""
 
-#: src/Admin/Actions.php:97
+#: src/Admin/Actions.php:100
 msgid "Exporting…"
 msgstr ""
 
-#: src/Admin/Actions.php:98
+#: src/Admin/Actions.php:101
 msgid "Cache activity exported."
 msgstr ""
 
-#: src/Admin/Actions.php:99
+#: src/Admin/Actions.php:102
 msgid "Cache activity could not be exported."
 msgstr ""
 
-#: src/Admin/Actions.php:100
+#: src/Admin/Actions.php:103
 msgid "Clear activity"
 msgstr ""
 
-#: src/Admin/Actions.php:101
+#: src/Admin/Actions.php:104
 msgid "Clearing…"
 msgstr ""
 
-#: src/Admin/Actions.php:102
+#: src/Admin/Actions.php:105
 msgid "Clear all collected cache activity? This does not clear cached pages."
 msgstr ""
 
-#: src/Admin/Actions.php:103, src/Modules/Cache/PageCache.php:828, src/Modules/Cache/PageCache.php:1090
+#: src/Admin/Actions.php:106, src/Modules/Cache/PageCache.php:828, src/Modules/Cache/PageCache.php:1090
 msgid "Cache activity cleared."
 msgstr ""
 
-#: src/Admin/Actions.php:104
+#: src/Admin/Actions.php:107
 msgid "Cache activity could not be cleared."
 msgstr ""
 
-#: src/Admin/Actions.php:133
+#: src/Admin/Actions.php:136
 msgid "Close Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:130, src/Modules/Assets/AssetsManager.php:274
+#: src/Admin/Actions.php:133, src/Modules/Assets/AssetsManager.php:274
 msgid "Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:140, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:254
+#: src/Admin/Actions.php:143, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:254
 msgid "Perform"
 msgstr ""
 
-#: src/Admin/Actions.php:160
+#: src/Admin/Actions.php:163
 msgid "Support Forum"
 msgstr ""
 
@@ -692,7 +692,7 @@ msgstr ""
 msgid "You are not allowed to clear admin performance data."
 msgstr ""
 
-#: src/Admin/Settings/AdminPerformanceMonitorController.php:36, src/Admin/Settings/AutoloadOptionsAuditController.php:48, src/Admin/Settings/Menu.php:123
+#: src/Admin/Settings/AdminPerformanceMonitorController.php:36, src/Admin/Settings/AutoloadOptionsAuditController.php:48, src/Admin/Settings/CronPressureAuditController.php:84, src/Admin/Settings/Menu.php:124
 msgid "Security check failed."
 msgstr ""
 
@@ -728,7 +728,7 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: src/Admin/Settings/AutoloadOptionsAuditController.php:38, src/Admin/Settings/Menu.php:112, src/Admin/Settings/SiteInventoryController.php:59
+#: src/Admin/Settings/AutoloadOptionsAuditController.php:38, src/Admin/Settings/CronPressureAuditController.php:79, src/Admin/Settings/Menu.php:113, src/Admin/Settings/SiteInventoryController.php:59
 msgid "Insufficient permissions."
 msgstr ""
 
@@ -738,6 +738,62 @@ msgstr ""
 
 #: src/Admin/Settings/AutoloadOptionsAuditController.php:67
 msgid "Database audit refreshed."
+msgstr ""
+
+#: src/Admin/Settings/CronPressureAudit.php:153
+msgid "The scheduled-task diagnostic could not be saved."
+msgstr ""
+
+#: src/Admin/Settings/CronPressureAudit.php:223
+msgid "Large schedule detected"
+msgstr ""
+
+#: src/Admin/Settings/CronPressureAudit.php:224
+msgid "The bounded scan reached its event limit. Review the most frequent hooks with their extension owners."
+msgstr ""
+
+#: src/Admin/Settings/CronPressureAudit.php:231
+msgid "Scheduled-task pressure needs review"
+msgstr ""
+
+#: src/Admin/Settings/CronPressureAudit.php:232
+msgid "Repeated overdue work or a dense upcoming cluster can add request latency. Confirm the responsible hooks and runner configuration before changing schedules."
+msgstr ""
+
+#: src/Admin/Settings/CronPressureAudit.php:239
+msgid "Some scheduled work needs review"
+msgstr ""
+
+#: src/Admin/Settings/CronPressureAudit.php:240
+msgid "A small amount of due or clustered work can be normal. Refresh later and compare repeated snapshots before acting."
+msgstr ""
+
+#: src/Admin/Settings/CronPressureAudit.php:246
+msgid "No immediate schedule pressure detected"
+msgstr ""
+
+#: src/Admin/Settings/CronPressureAudit.php:247
+msgid "The bounded local snapshot does not show overdue or densely clustered work."
+msgstr ""
+
+#: src/Admin/Settings/CronPressureAudit.php:285
+msgid "Run the first scheduled-task check"
+msgstr ""
+
+#: src/Admin/Settings/CronPressureAudit.php:286
+msgid "The check runs only when requested and does not change scheduled events."
+msgstr ""
+
+#: src/Admin/Settings/CronPressureAuditController.php:42
+msgid "The scheduled-task diagnostic could not be refreshed. Please try again."
+msgstr ""
+
+#: src/Admin/Settings/CronPressureAuditController.php:49
+msgid "Scheduled-task diagnostic refreshed."
+msgstr ""
+
+#: src/Admin/Settings/CronPressureAuditController.php:66
+msgid "Scheduled-task diagnostic cleared."
 msgstr ""
 
 #: src/Admin/Settings/DashboardPayload.php:174
@@ -765,14 +821,18 @@ msgid "Admin Monitor"
 msgstr ""
 
 #: src/Admin/Settings/Menu.php:58
+msgid "Scheduled Tasks"
+msgstr ""
+
+#: src/Admin/Settings/Menu.php:59
 msgid "Cache Stats"
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:239
+#: src/Admin/Settings/Menu.php:240
 msgid "Unable to save the settings. Please try again."
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:231
+#: src/Admin/Settings/Menu.php:232
 msgid "Settings saved successfully."
 msgstr ""
 

--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -19,6 +19,7 @@ use Perform\Admin\Settings\Menu;
 use Perform\Admin\Settings\RuntimeDiagnostics;
 use Perform\Admin\Settings\SiteInventory;
 use Perform\Admin\Settings\SystemHealth;
+use Perform\Admin\Settings\CronPressureAudit;
 
 // Bailout, if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -80,6 +81,8 @@ class Actions {
 					'siteInventory'      => SiteInventory::get_cached_snapshot(),
 					'siteInventoryUrl'   => esc_url_raw( rest_url( 'perform/v1/site-inventory' ) ),
 					'systemHealth'       => SystemHealth::get_data(),
+					'cronPressure'       => CronPressureAudit::get_cached_snapshot(),
+					'cronPressureNonce'  => wp_create_nonce( 'perform_cron_pressure_audit' ),
 					'restNonce'          => wp_create_nonce( 'wp_rest' ),
 					'sensitiveKeys'      => ClientPayload::get_sensitive_keys(),
 					'maskedSecretValue'  => ClientPayload::MASKED_SECRET,

--- a/src/Admin/Settings/CronPressureAudit.php
+++ b/src/Admin/Settings/CronPressureAudit.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * Perform - WP-Cron pressure diagnostics.
+ *
+ * @package Perform
+ * @subpackage Admin/Settings
+ */
+
+namespace Perform\Admin\Settings;
+
+use RuntimeException;
+
+// Bailout, if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Collects a bounded, read-only scheduled-task pressure snapshot.
+ */
+final class CronPressureAudit {
+	const OPTION_NAME     = 'perform_cron_pressure_audit';
+	const SCHEMA_VERSION  = 1;
+	const CACHE_TTL       = 3600;
+	const EVENT_LIMIT     = 5000;
+	const HOOK_LIMIT      = 20;
+	const OVERDUE_GRACE   = 300;
+	const CLUSTER_WINDOW  = 300;
+	const CLUSTER_HORIZON = 3600;
+
+	/**
+	 * Get a cached snapshot without scanning scheduled tasks.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function get_cached_snapshot() {
+		$snapshot = get_option( self::OPTION_NAME, [] );
+
+		if ( ! is_array( $snapshot ) || self::SCHEMA_VERSION !== (int) ( $snapshot['schemaVersion'] ?? 0 ) ) {
+			return self::get_empty_snapshot();
+		}
+
+		$snapshot['isStale'] = time() >= (int) ( $snapshot['expiresAt'] ?? 0 );
+
+		return $snapshot;
+	}
+
+	/**
+	 * Run and persist a fresh read-only audit.
+	 *
+	 * @return array<string, mixed>
+	 * @throws RuntimeException When the snapshot cannot be persisted.
+	 */
+	public static function refresh() {
+		$events = function_exists( '_get_cron_array' ) ? _get_cron_array() : get_option( 'cron', [] );
+
+		/**
+		 * Filters the cron event array used by the diagnostic.
+		 *
+		 * @param array<string|int, mixed> $events WordPress cron array.
+		 */
+		$events = apply_filters( 'perform_cron_pressure_events', is_array( $events ) ? $events : [] );
+		$events = is_array( $events ) ? $events : [];
+
+		$now            = time();
+		$scanned        = 0;
+		$due            = 0;
+		$overdue        = 0;
+		$recurring      = 0;
+		$next_hour      = 0;
+		$hook_counts    = [];
+		$cluster_counts = [];
+		$was_truncated  = false;
+		$generated_at   = $now;
+
+		ksort( $events, SORT_NUMERIC );
+		foreach ( $events as $timestamp => $hooks ) {
+			if ( ! is_numeric( $timestamp ) || ! is_array( $hooks ) ) {
+				continue;
+			}
+
+			$timestamp = (int) $timestamp;
+			foreach ( $hooks as $hook => $instances ) {
+				if ( ! is_array( $instances ) ) {
+					continue;
+				}
+
+				$hook = self::normalize_hook( $hook );
+				if ( '' === $hook ) {
+					continue;
+				}
+
+				foreach ( $instances as $instance ) {
+					if ( self::EVENT_LIMIT <= $scanned ) {
+						$was_truncated = true;
+						break 3;
+					}
+
+					$instance = is_array( $instance ) ? $instance : [];
+					++$scanned;
+					$hook_counts[ $hook ] = isset( $hook_counts[ $hook ] ) ? $hook_counts[ $hook ] + 1 : 1;
+
+					if ( $timestamp <= $now ) {
+						++$due;
+					}
+					if ( $timestamp < $now - self::OVERDUE_GRACE ) {
+						++$overdue;
+					}
+					if ( ! empty( $instance['schedule'] ) || ! empty( $instance['interval'] ) ) {
+						++$recurring;
+					}
+					if ( $timestamp > $now && $timestamp <= $now + self::CLUSTER_HORIZON ) {
+						++$next_hour;
+						$bucket                    = (int) floor( ( $timestamp - $now ) / self::CLUSTER_WINDOW );
+						$cluster_counts[ $bucket ] = isset( $cluster_counts[ $bucket ] ) ? $cluster_counts[ $bucket ] + 1 : 1;
+					}
+				}
+			}
+		}
+
+		$peak_cluster = empty( $cluster_counts ) ? 0 : max( $cluster_counts );
+		$snapshot     = [
+			'schemaVersion'  => self::SCHEMA_VERSION,
+			'status'         => 'ready',
+			'generatedAt'    => $generated_at,
+			'expiresAt'      => $generated_at + self::CACHE_TTL,
+			'isStale'        => false,
+			'isMultisite'    => is_multisite(),
+			'siteId'         => get_current_blog_id(),
+			'wpCronDisabled' => defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON,
+			'limits'         => [
+				'eventLimit'     => self::EVENT_LIMIT,
+				'hookLimit'      => self::HOOK_LIMIT,
+				'overdueGrace'   => self::OVERDUE_GRACE,
+				'clusterWindow'  => self::CLUSTER_WINDOW,
+				'clusterHorizon' => self::CLUSTER_HORIZON,
+			],
+			'totals'         => [
+				'scanned'     => $scanned,
+				'due'         => $due,
+				'overdue'     => $overdue,
+				'recurring'   => $recurring,
+				'nextHour'    => $next_hour,
+				'peakCluster' => $peak_cluster,
+				'truncated'   => $was_truncated,
+			],
+			'frequentHooks'  => self::normalize_hook_counts( $hook_counts ),
+			'guidance'       => self::get_guidance( $due, $overdue, $peak_cluster, $was_truncated ),
+		];
+
+		$is_saved = update_option( self::OPTION_NAME, $snapshot, false );
+		if ( ! $is_saved && get_option( self::OPTION_NAME ) !== $snapshot ) {
+			throw new RuntimeException( __( 'The scheduled-task diagnostic could not be saved.', 'perform' ) );
+		}
+
+		return $snapshot;
+	}
+
+	/**
+	 * Delete only Perform's cached diagnostic snapshot.
+	 *
+	 * @return void
+	 */
+	public static function clear() {
+		delete_option( self::OPTION_NAME );
+	}
+
+	/**
+	 * Normalize a hook name without reading its arguments.
+	 *
+	 * @param mixed $hook Hook name.
+	 *
+	 * @return string
+	 */
+	private static function normalize_hook( $hook ) {
+		$hook = sanitize_key( (string) $hook );
+
+		return substr( $hook, 0, 100 );
+	}
+
+	/**
+	 * Sort and bound aggregate hook counts.
+	 *
+	 * @param array<string, int> $counts Hook counts.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function normalize_hook_counts( array $counts ) {
+		uksort(
+			$counts,
+			static function ( $left, $right ) use ( $counts ) {
+				$count_comparison = $counts[ $right ] <=> $counts[ $left ];
+
+				return 0 !== $count_comparison ? $count_comparison : strcmp( $left, $right );
+			}
+		);
+
+		$normalized = [];
+		foreach ( array_slice( $counts, 0, self::HOOK_LIMIT, true ) as $hook => $count ) {
+			$normalized[] = [
+				'hook'  => $hook,
+				'count' => max( 0, (int) $count ),
+			];
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Build evidence-bound guidance.
+	 *
+	 * @param int  $due           Due events.
+	 * @param int  $overdue       Overdue events.
+	 * @param int  $peak_cluster  Peak next-hour cluster.
+	 * @param bool $was_truncated Whether the scan hit its cap.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function get_guidance( $due, $overdue, $peak_cluster, $was_truncated ) {
+		if ( $was_truncated ) {
+			return [
+				'status'  => 'review',
+				'heading' => __( 'Large schedule detected', 'perform' ),
+				'message' => __( 'The bounded scan reached its event limit. Review the most frequent hooks with their extension owners.', 'perform' ),
+			];
+		}
+
+		if ( 20 < $overdue || 50 < $peak_cluster ) {
+			return [
+				'status'  => 'action-recommended',
+				'heading' => __( 'Scheduled-task pressure needs review', 'perform' ),
+				'message' => __( 'Repeated overdue work or a dense upcoming cluster can add request latency. Confirm the responsible hooks and runner configuration before changing schedules.', 'perform' ),
+			];
+		}
+
+		if ( 0 < $due || 10 < $peak_cluster ) {
+			return [
+				'status'  => 'review',
+				'heading' => __( 'Some scheduled work needs review', 'perform' ),
+				'message' => __( 'A small amount of due or clustered work can be normal. Refresh later and compare repeated snapshots before acting.', 'perform' ),
+			];
+		}
+
+		return [
+			'status'  => 'good',
+			'heading' => __( 'No immediate schedule pressure detected', 'perform' ),
+			'message' => __( 'The bounded local snapshot does not show overdue or densely clustered work.', 'perform' ),
+		];
+	}
+
+	/**
+	 * Get the safe client shape before the first audit.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function get_empty_snapshot() {
+		return [
+			'schemaVersion'  => self::SCHEMA_VERSION,
+			'status'         => 'not-run',
+			'generatedAt'    => 0,
+			'expiresAt'      => 0,
+			'isStale'        => false,
+			'isMultisite'    => is_multisite(),
+			'siteId'         => get_current_blog_id(),
+			'wpCronDisabled' => defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON,
+			'limits'         => [
+				'eventLimit'     => self::EVENT_LIMIT,
+				'hookLimit'      => self::HOOK_LIMIT,
+				'overdueGrace'   => self::OVERDUE_GRACE,
+				'clusterWindow'  => self::CLUSTER_WINDOW,
+				'clusterHorizon' => self::CLUSTER_HORIZON,
+			],
+			'totals'         => [
+				'scanned'     => 0,
+				'due'         => 0,
+				'overdue'     => 0,
+				'recurring'   => 0,
+				'nextHour'    => 0,
+				'peakCluster' => 0,
+				'truncated'   => false,
+			],
+			'frequentHooks'  => [],
+			'guidance'       => [
+				'status'  => 'not-run',
+				'heading' => __( 'Run the first scheduled-task check', 'perform' ),
+				'message' => __( 'The check runs only when requested and does not change scheduled events.', 'perform' ),
+			],
+		];
+	}
+}

--- a/src/Admin/Settings/CronPressureAuditController.php
+++ b/src/Admin/Settings/CronPressureAuditController.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Perform - WP-Cron pressure diagnostic controller.
+ *
+ * @package Perform
+ * @subpackage Admin/Settings
+ */
+
+namespace Perform\Admin\Settings;
+
+use Throwable;
+
+// Bailout, if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles authorized refresh and reset requests.
+ */
+final class CronPressureAuditController {
+	/**
+	 * Register WordPress hooks.
+	 */
+	public function __construct() {
+		add_action( 'wp_ajax_perform_refresh_cron_pressure_audit', [ $this, 'refresh' ] );
+		add_action( 'wp_ajax_perform_clear_cron_pressure_audit', [ $this, 'clear' ] );
+	}
+
+	/**
+	 * Refresh the current-site snapshot.
+	 *
+	 * @return void
+	 */
+	public function refresh() {
+		$this->authorize();
+
+		try {
+			$audit = CronPressureAudit::refresh();
+		} catch ( Throwable $exception ) {
+			wp_send_json_error(
+				[ 'message' => esc_html__( 'The scheduled-task diagnostic could not be refreshed. Please try again.', 'perform' ) ],
+				500
+			);
+		}
+
+		wp_send_json_success(
+			[
+				'message' => esc_html__( 'Scheduled-task diagnostic refreshed.', 'perform' ),
+				'audit'   => $audit,
+			]
+		);
+	}
+
+	/**
+	 * Clear only Perform's cached snapshot.
+	 *
+	 * @return void
+	 */
+	public function clear() {
+		$this->authorize();
+		CronPressureAudit::clear();
+
+		wp_send_json_success(
+			[
+				'message' => esc_html__( 'Scheduled-task diagnostic cleared.', 'perform' ),
+				'audit'   => CronPressureAudit::get_cached_snapshot(),
+			]
+		);
+	}
+
+	/**
+	 * Enforce capability and nonce checks.
+	 *
+	 * @return void
+	 */
+	private function authorize() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => esc_html__( 'Insufficient permissions.', 'perform' ) ], 403 );
+		}
+
+		$nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['nonce'] ) ) : '';
+		if ( ! wp_verify_nonce( $nonce, 'perform_cron_pressure_audit' ) ) {
+			wp_send_json_error( [ 'message' => esc_html__( 'Security check failed.', 'perform' ) ], 403 );
+		}
+	}
+}

--- a/src/Admin/Settings/Menu.php
+++ b/src/Admin/Settings/Menu.php
@@ -51,11 +51,12 @@ class Menu {
 	 * @return array<string, string>
 	 */
 	public static function get_navigation_tabs() {
-		$tabs                  = Helpers::get_settings_tabs();
-		$tabs['inventory']     = esc_html__( 'Site Inventory', 'perform' );
-		$tabs['database']      = esc_html__( 'Database', 'perform' );
-		$tabs['admin-monitor'] = esc_html__( 'Admin Monitor', 'perform' );
-		$tabs['cache-stats']   = esc_html__( 'Cache Stats', 'perform' );
+		$tabs                    = Helpers::get_settings_tabs();
+		$tabs['inventory']       = esc_html__( 'Site Inventory', 'perform' );
+		$tabs['database']        = esc_html__( 'Database', 'perform' );
+		$tabs['admin-monitor']   = esc_html__( 'Admin Monitor', 'perform' );
+		$tabs['scheduled-tasks'] = esc_html__( 'Scheduled Tasks', 'perform' );
+		$tabs['cache-stats']     = esc_html__( 'Cache Stats', 'perform' );
 
 		return $tabs;
 	}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -55,6 +55,7 @@ final class Plugin {
 		new Settings\AutoloadOptionsAuditController();
 		new Settings\SiteInventoryController();
 		new Settings\AdminPerformanceMonitorController();
+		new Settings\CronPressureAuditController();
 		new Admin\Actions();
 		new Admin\Filters();
 

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -149,6 +149,34 @@ test( 'Site Inventory refresh is private, bounded, and responsive', async ( { pa
 	expect( hasHorizontalOverflow ).toBeFalsy();
 } );
 
+test( 'Scheduled-task pressure is bounded, private, resettable, and responsive', async ( { page } ) => {
+	await login( page );
+	await openAdminPage( page, '/wp-admin/options-general.php?page=perform_settings&tab=scheduled-tasks' );
+
+	await expect( page.getByRole( 'tab', { name: 'Scheduled Tasks' } ) ).toHaveAttribute( 'aria-selected', 'true' );
+	await expect( page.getByText( 'Read-only and bounded' ) ).toBeVisible();
+	await expect( page.getByText( /excludes hook arguments, payloads, URLs, and user data/ ) ).toBeVisible();
+	await page.getByRole( 'button', { name: /Run check|Refresh check/ } ).click();
+	await expect( page.getByRole( 'status' ) ).toContainText( 'Scheduled-task diagnostic refreshed.' );
+	await expect( page.getByText( 'Most frequent scheduled hooks' ) ).toBeVisible();
+	await expect( page.getByText( /Frequency does not prove that a hook is harmful/ ) ).toBeVisible();
+	await expect( page.getByRole( 'button', { name: 'Save Settings' } ) ).toHaveCount( 0 );
+
+	await mkdir( 'test-results/proof', { recursive: true } );
+	await page.screenshot( { path: 'test-results/proof/cron-pressure-desktop.png', fullPage: true } );
+	await page.setViewportSize( { width: 390, height: 844 } );
+	await page.screenshot( { path: 'test-results/proof/cron-pressure-mobile.png', fullPage: true } );
+	const hasHorizontalOverflow = await page.evaluate(
+		() => document.documentElement.scrollWidth > document.documentElement.clientWidth
+	);
+	expect( hasHorizontalOverflow ).toBeFalsy();
+
+	page.once( 'dialog', ( dialog ) => dialog.accept() );
+	await page.getByRole( 'button', { name: 'Clear snapshot' } ).click();
+	await expect( page.getByRole( 'status' ) ).toContainText( 'Scheduled-task diagnostic cleared.' );
+	await expect( page.getByRole( 'button', { name: 'Run check' } ) ).toBeVisible();
+} );
+
 test( 'Admin Performance Monitor is opt-in, bounded, private, clearable, and responsive', async ( { page } ) => {
 	await login( page );
 	await openAdminPage( page, '/wp-admin/options-general.php?page=perform_settings&tab=advanced' );
@@ -304,4 +332,13 @@ test( 'lower-privilege users cannot access the legacy or canonical Cache Stats r
 	} );
 	expect( adminMonitorResponse.status() ).toBe( 403 );
 	expect( await adminMonitorResponse.json() ).toMatchObject( { success: false } );
+
+	const cronAuditResponse = await page.request.post( '/wp-admin/admin-ajax.php', {
+		form: {
+			action: 'perform_refresh_cron_pressure_audit',
+			nonce: 'invalid-for-editor-capability-check',
+		},
+	} );
+	expect( cronAuditResponse.status() ).toBe( 403 );
+	expect( await cronAuditResponse.json() ).toMatchObject( { success: false } );
 } );

--- a/tests/unit-tests/tests-cron-pressure-audit.php
+++ b/tests/unit-tests/tests-cron-pressure-audit.php
@@ -1,0 +1,160 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Perform\Admin\Settings\CronPressureAudit;
+use Perform\Admin\Settings\CronPressureAuditController;
+
+final class Tests_Cron_Pressure_Audit extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['perform_test_options']          = [];
+		$GLOBALS['perform_test_filters']          = [];
+		$GLOBALS['perform_test_current_user_can'] = [ 'manage_options' => true ];
+		$GLOBALS['perform_test_nonce_valid']      = true;
+		$GLOBALS['perform_test_is_multisite']     = false;
+		$GLOBALS['perform_test_blog_id']          = 1;
+		$_POST                                    = [];
+	}
+
+	protected function tearDown(): void {
+		unset(
+			$GLOBALS['perform_test_options'],
+			$GLOBALS['perform_test_filters'],
+			$GLOBALS['perform_test_current_user_can'],
+			$GLOBALS['perform_test_nonce_valid'],
+			$GLOBALS['perform_test_is_multisite'],
+			$GLOBALS['perform_test_blog_id'],
+			$GLOBALS['perform_test_json_response']
+		);
+		$_POST = [];
+	}
+
+	public function test_refresh_collects_bounded_aggregate_pressure_without_arguments() {
+		$now = time();
+		$GLOBALS['perform_test_filters']['perform_cron_pressure_events'] = [
+			$now - 600 => [
+				'private_hook' => [
+					'first'  => [
+						'schedule' => 'hourly',
+						'args'     => [ 'secret-token' ],
+					],
+					'second' => [
+						'schedule' => false,
+						'args'     => [ 'customer@example.com' ],
+					],
+				],
+			],
+			$now - 10  => [
+				'other_hook' => [
+					'third' => [
+						'schedule' => false,
+						'args'     => [ 'private-url' ],
+					],
+				],
+			],
+			$now + 120 => [
+				'private_hook' => [
+					'fourth' => [
+						'schedule' => 'hourly',
+						'interval' => 3600,
+					],
+					'fifth'  => [
+						'schedule' => 'hourly',
+						'interval' => 3600,
+					],
+					'sixth'  => [
+						'schedule' => 'hourly',
+						'interval' => 3600,
+					],
+				],
+			],
+		];
+
+		$audit = CronPressureAudit::refresh();
+		$json  = wp_json_encode( $audit );
+
+		$this->assertSame( 6, $audit['totals']['scanned'] );
+		$this->assertSame( 3, $audit['totals']['due'] );
+		$this->assertSame( 2, $audit['totals']['overdue'] );
+		$this->assertSame( 4, $audit['totals']['recurring'] );
+		$this->assertSame( 3, $audit['totals']['nextHour'] );
+		$this->assertSame( 3, $audit['totals']['peakCluster'] );
+		$this->assertSame( 'private_hook', $audit['frequentHooks'][0]['hook'] );
+		$this->assertSame( 5, $audit['frequentHooks'][0]['count'] );
+		$this->assertStringNotContainsString( 'secret-token', $json );
+		$this->assertStringNotContainsString( 'customer@example.com', $json );
+		$this->assertStringNotContainsString( 'private-url', $json );
+		$this->assertSame( $audit, $GLOBALS['perform_test_options'][ CronPressureAudit::OPTION_NAME ] );
+	}
+
+	public function test_refresh_hard_caps_large_schedules() {
+		$instances = [];
+		for ( $index = 0; $index <= CronPressureAudit::EVENT_LIMIT; ++$index ) {
+			$instances[ 'signature-' . $index ] = [ 'schedule' => 'hourly' ];
+		}
+		$GLOBALS['perform_test_filters']['perform_cron_pressure_events'] = [
+			time() + 60 => [ 'large_hook' => $instances ],
+		];
+
+		$audit = CronPressureAudit::refresh();
+
+		$this->assertSame( CronPressureAudit::EVENT_LIMIT, $audit['totals']['scanned'] );
+		$this->assertTrue( $audit['totals']['truncated'] );
+		$this->assertSame( 'review', $audit['guidance']['status'] );
+	}
+
+	public function test_cached_snapshot_is_per_site_stale_and_clearable() {
+		$GLOBALS['perform_test_is_multisite']                              = true;
+		$GLOBALS['perform_test_blog_id']                                   = 9;
+		$GLOBALS['perform_test_options'][ CronPressureAudit::OPTION_NAME ] = [
+			'schemaVersion' => CronPressureAudit::SCHEMA_VERSION,
+			'status'        => 'ready',
+			'expiresAt'     => time() - 1,
+		];
+
+		$audit = CronPressureAudit::get_cached_snapshot();
+		$this->assertTrue( $audit['isStale'] );
+
+		CronPressureAudit::clear();
+		$empty = CronPressureAudit::get_cached_snapshot();
+		$this->assertSame( 'not-run', $empty['status'] );
+		$this->assertTrue( $empty['isMultisite'] );
+		$this->assertSame( 9, $empty['siteId'] );
+	}
+
+	public function test_refresh_endpoint_requires_capability_and_nonce() {
+		$GLOBALS['perform_test_current_user_can']['manage_options'] = false;
+		$this->run_controller_request( 'refresh' );
+		$this->assertFalse( $GLOBALS['perform_test_json_response']['success'] );
+		$this->assertSame( 'Insufficient permissions.', $GLOBALS['perform_test_json_response']['data']['message'] );
+
+		$GLOBALS['perform_test_current_user_can']['manage_options'] = true;
+		$GLOBALS['perform_test_nonce_valid']                        = false;
+		$_POST['nonce'] = 'invalid';
+		$this->run_controller_request( 'refresh' );
+		$this->assertFalse( $GLOBALS['perform_test_json_response']['success'] );
+		$this->assertSame( 'Security check failed.', $GLOBALS['perform_test_json_response']['data']['message'] );
+	}
+
+	public function test_controller_refresh_and_clear_return_safe_snapshots() {
+		$_POST['nonce'] = 'valid';
+		$GLOBALS['perform_test_filters']['perform_cron_pressure_events'] = [];
+
+		$this->run_controller_request( 'refresh' );
+		$this->assertTrue( $GLOBALS['perform_test_json_response']['success'] );
+		$this->assertSame( 'ready', $GLOBALS['perform_test_json_response']['data']['audit']['status'] );
+
+		$this->run_controller_request( 'clear' );
+		$this->assertTrue( $GLOBALS['perform_test_json_response']['success'] );
+		$this->assertSame( 'not-run', $GLOBALS['perform_test_json_response']['data']['audit']['status'] );
+	}
+
+	private function run_controller_request( $method ) {
+		try {
+			$controller = new CronPressureAuditController();
+			$controller->{$method}();
+			$this->fail( 'Expected the JSON response to end the request.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'perform_test_json_response', $exception->getMessage() );
+		}
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -33,6 +33,7 @@ function perform_handle_plugin_uninstall() {
 		'perform_autoload_options_audit',
 		'perform_site_inventory',
 		'perform_admin_performance_monitor',
+		'perform_cron_pressure_audit',
 	];
 
 	$remove_data_on_uninstall = false;


### PR DESCRIPTION
Closes #143.

## Summary

- adds an opt-in, read-only Scheduled Tasks diagnostic tab
- reports bounded WP-Cron pressure signals, overdue work, near-term clustering, and frequent hooks without exposing task arguments or payload data
- stores a per-site snapshot for one hour with nonce/capability-protected refresh and clear actions
- explains `DISABLE_WP_CRON` accurately without claiming an external runner is configured
- adds responsive admin UI, documentation, unit coverage, and hosted browser proof

## Safety

- no scheduled task is run, deleted, rescheduled, or otherwise mutated
- scans at most 5,000 event instances and reports at most 20 aggregate hook rows
- no hook arguments, URLs, nonces, credentials, or user data are collected
- clear removes only Perform's diagnostic snapshot

## Validation

- `composer test` — 126 tests, 389 assertions
- `composer lint` — 81 PHP files
- `composer phpstan`
- `npm run test:js` — 31 tests
- `npm run lint:js`
- `npm run lint:css`
- scoped PHPCS
- `npm run build`
- `git diff --check`

Hosted Playwright proof covers desktop/mobile layout, manual audit and clear flows, privacy/read-only copy, horizontal overflow, and lower-privilege denial.
