### PR TITLE
Add bounded admin asset audit

### DIFF
--- a/assets/src/css/admin/settings.css
+++ b/assets/src/css/admin/settings.css
@@ -1418,6 +1418,117 @@
 	font-size: 12px;
 }
 
+.perform-admin-assets {
+	display: grid;
+	gap: 24px;
+}
+
+.perform-admin-assets > *,
+.perform-admin-assets .components-card__body {
+	min-width: 0;
+}
+
+.perform-admin-assets__heading {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 24px;
+	padding-bottom: 24px;
+	border-bottom: 1px solid var(--perform-color-border);
+}
+
+.perform-admin-assets__heading h2 {
+	margin: 0 0 8px;
+	font-size: 24px;
+	line-height: 1.25;
+}
+
+.perform-admin-assets__heading p:not(.perform-dashboard-eyebrow) {
+	margin: 0;
+	color: var(--perform-color-text-muted);
+}
+
+.perform-admin-assets__privacy,
+.perform-admin-assets__message {
+	padding: 16px 20px;
+	border-left: 4px solid var(--perform-color-brand);
+	background: #f6f7f7;
+}
+
+.perform-admin-assets__privacy p {
+	margin: 6px 0 0;
+	color: var(--perform-color-text-muted);
+	line-height: 1.5;
+}
+
+.perform-admin-assets__message.is-success {
+	border-left-color: var(--perform-color-success);
+}
+
+.perform-admin-assets__message.is-error {
+	border-left-color: var(--perform-color-danger);
+}
+
+.perform-admin-assets__table-wrap {
+	max-width: 100%;
+	overflow-x: auto;
+}
+
+.perform-admin-assets table {
+	width: 100%;
+	border-collapse: collapse;
+	text-align: left;
+}
+
+.perform-admin-assets th,
+.perform-admin-assets td {
+	padding: 14px 12px;
+	border-bottom: 1px solid var(--perform-color-border);
+	vertical-align: top;
+}
+
+.perform-admin-assets thead th {
+	color: var(--perform-color-text-muted);
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
+.perform-admin-assets th small,
+.perform-admin-assets__chips small {
+	display: block;
+	margin-top: 4px;
+	color: var(--perform-color-text-muted);
+	font-weight: 400;
+}
+
+.perform-admin-assets code {
+	white-space: normal;
+	overflow-wrap: anywhere;
+}
+
+.perform-admin-assets__screens {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 16px;
+}
+
+.perform-admin-assets__chips {
+	display: grid;
+	gap: 10px;
+}
+
+.perform-admin-assets__chips > span {
+	min-width: 0;
+	padding-bottom: 10px;
+	border-bottom: 1px solid var(--perform-color-border);
+}
+
+.perform-admin-assets__chips > span:last-child {
+	padding-bottom: 0;
+	border-bottom: 0;
+}
+
 @media screen and (max-width: 782px) {
 
 	.perform-settings-page {
@@ -1539,6 +1650,82 @@
 	}
 
 	.perform-cron-pressure__summary > div:last-child {
+		border-bottom: 0;
+	}
+
+	.perform-admin-assets__heading {
+		flex-direction: column;
+	}
+
+	.perform-admin-assets__heading .components-button {
+		justify-content: center;
+		width: 100%;
+	}
+
+	.perform-admin-assets__screens {
+		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.perform-admin-assets__table-wrap {
+		overflow: visible;
+	}
+
+	.perform-admin-assets table,
+	.perform-admin-assets tbody,
+	.perform-admin-assets tr,
+	.perform-admin-assets th,
+	.perform-admin-assets td {
+		display: block;
+		width: 100%;
+	}
+
+	.perform-admin-assets thead {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	.perform-admin-assets tbody tr {
+		margin-top: 16px;
+		border: 1px solid var(--perform-color-border);
+		border-radius: 4px;
+	}
+
+	.perform-admin-assets tbody tr:first-child {
+		margin-top: 0;
+	}
+
+	.perform-admin-assets tbody th,
+	.perform-admin-assets tbody td {
+		box-sizing: border-box;
+		padding: 12px 14px;
+	}
+
+	.perform-admin-assets tbody th {
+		background: #f6f7f7;
+	}
+
+	.perform-admin-assets tbody td {
+		display: grid;
+		grid-template-columns: minmax(92px, 0.45fr) minmax(0, 1fr);
+		gap: 12px;
+	}
+
+	.perform-admin-assets tbody td::before {
+		content: attr(data-label);
+		color: var(--perform-color-text-muted);
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+	}
+
+	.perform-admin-assets tbody tr > :last-child {
 		border-bottom: 0;
 	}
 

--- a/assets/src/js/admin/AdminAssetAuditPanel.jsx
+++ b/assets/src/js/admin/AdminAssetAuditPanel.jsx
@@ -1,0 +1,212 @@
+import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+const SETTINGS = window.performwpSettings || {};
+
+const formatAssetCount = ( count ) =>
+	sprintf(
+		/* translators: %s: number of captured assets. */
+		__( '%s captured assets', 'perform' ),
+		count
+	);
+
+const AdminAssetAuditPanel = ( { initialSnapshot = SETTINGS.adminAssetAudit || {}, onNavigate } ) => {
+	const [ snapshot, setSnapshot ] = useState( initialSnapshot );
+	const [ clearing, setClearing ] = useState( false );
+	const [ message, setMessage ] = useState( null );
+	const screens = snapshot.screens || [];
+	const repeated = snapshot.repeated || [];
+
+	const clearAudit = async () => {
+		// eslint-disable-next-line no-alert -- Removing the diagnostic snapshot requires explicit confirmation.
+		if ( ! window.confirm( __( 'Clear the collected admin asset audit?', 'perform' ) ) ) {
+			return;
+		}
+		setClearing( true );
+		setMessage( { type: 'status', text: __( 'Clearing admin asset audit…', 'perform' ) } );
+		try {
+			const response = await fetch( window.ajaxurl, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+				body: new URLSearchParams( {
+					action: 'perform_clear_admin_asset_audit',
+					nonce: SETTINGS.adminAssetAuditNonce || '',
+				} ),
+			} );
+			const result = await response.json();
+			if ( ! response.ok || ! result?.success || ! result.data?.snapshot ) {
+				throw new Error( result?.data?.message || __( 'Admin asset audit could not be cleared.', 'perform' ) );
+			}
+			setSnapshot( result.data.snapshot );
+			setMessage( { type: 'success', text: result.data.message } );
+		} catch ( error ) {
+			setMessage( {
+				type: 'error',
+				text: error?.message || __( 'Admin asset audit could not be cleared.', 'perform' ),
+			} );
+		} finally {
+			setClearing( false );
+		}
+	};
+
+	return (
+		<div className="perform-admin-assets">
+			<div className="perform-admin-assets__heading">
+				<div>
+					<p className="perform-dashboard-eyebrow">{ __( 'Private admin diagnostics', 'perform' ) }</p>
+					<h2>{ __( 'Admin asset audit', 'perform' ) }</h2>
+					<p>
+						{ __(
+							'See which scripts and styles recur across sampled WordPress admin screens.',
+							'perform'
+						) }
+					</p>
+				</div>
+				{ snapshot.enabled ? (
+					<Button
+						variant="secondary"
+						onClick={ clearAudit }
+						disabled={ clearing || ! screens.length }
+						isBusy={ clearing }
+					>
+						{ clearing ? __( 'Clearing…', 'perform' ) : __( 'Clear audit', 'perform' ) }
+					</Button>
+				) : (
+					<Button variant="primary" onClick={ () => onNavigate?.( 'advanced' ) }>
+						{ __( 'Enable in Advanced', 'perform' ) }
+					</Button>
+				) }
+			</div>
+
+			<div className="perform-admin-assets__privacy">
+				<strong>{ __( 'Inventory only — nothing is disabled', 'perform' ) }</strong>
+				<p>
+					{ sprintf(
+						/* translators: 1: screen limit, 2: asset limit, 3: retention in days. */
+						__(
+							'Perform stores handles and likely source labels for up to %1$s screens and %2$s assets per screen for %3$s days. URLs, query strings, nonces, and user data are not stored.',
+							'perform'
+						),
+						snapshot.limits?.screens || 30,
+						snapshot.limits?.assetsPerScreen || 100,
+						snapshot.limits?.retentionDays || 7
+					) }
+				</p>
+			</div>
+
+			{ message && (
+				<div
+					className={ `perform-admin-assets__message is-${ message.type }` }
+					role={ 'error' === message.type ? 'alert' : 'status' }
+					aria-live="polite"
+				>
+					{ message.text }
+				</div>
+			) }
+
+			{ ! snapshot.enabled && (
+				<Card>
+					<CardBody>
+						<h3>{ __( 'Audit mode is off', 'perform' ) }</h3>
+						<p>
+							{ __(
+								'Disabled mode registers no asset-capture hooks and writes no audit data.',
+								'perform'
+							) }
+						</p>
+					</CardBody>
+				</Card>
+			) }
+			{ snapshot.enabled && ! screens.length && (
+				<Card>
+					<CardBody>
+						<h3>{ __( 'Visit a few admin screens', 'perform' ) }</h3>
+						<p>
+							{ __(
+								'Perform records the final script and style queues as you use WordPress admin normally.',
+								'perform'
+							) }
+						</p>
+					</CardBody>
+				</Card>
+			) }
+
+			{ repeated.length > 0 && (
+				<Card>
+					<CardHeader>
+						<div>
+							<h3 className="perform-card-title">{ __( 'Repeated across admin screens', 'perform' ) }</h3>
+							<p className="perform-card-description">
+								{ __(
+									'Repeated presence is a review signal, not proof that an asset is unnecessary or safe to disable.',
+									'perform'
+								) }
+							</p>
+						</div>
+					</CardHeader>
+					<CardBody>
+						<div className="perform-admin-assets__table-wrap">
+							<table>
+								<thead>
+									<tr>
+										<th scope="col">{ __( 'Asset', 'perform' ) }</th>
+										<th scope="col">{ __( 'Likely source', 'perform' ) }</th>
+										<th scope="col">{ __( 'Screens', 'perform' ) }</th>
+										<th scope="col">{ __( 'Confidence', 'perform' ) }</th>
+									</tr>
+								</thead>
+								<tbody>
+									{ repeated.map( ( asset ) => (
+										<tr key={ `${ asset.type }:${ asset.handle }` }>
+											<th scope="row">
+												<code>{ asset.handle }</code>
+												<small>{ asset.type }</small>
+											</th>
+											<td data-label={ __( 'Likely source', 'perform' ) }>{ asset.source }</td>
+											<td data-label={ __( 'Screens', 'perform' ) }>{ asset.screenCount }</td>
+											<td data-label={ __( 'Confidence', 'perform' ) }>{ asset.confidence }</td>
+										</tr>
+									) ) }
+								</tbody>
+							</table>
+						</div>
+					</CardBody>
+				</Card>
+			) }
+
+			{ screens.length > 0 && (
+				<div className="perform-admin-assets__screens">
+					{ screens.map( ( screen ) => (
+						<Card key={ screen.id }>
+							<CardHeader>
+								<div>
+									<h3 className="perform-card-title">
+										<code>{ screen.id }</code>
+									</h3>
+									<p className="perform-card-description">
+										{ formatAssetCount( screen.assets?.length || 0 ) }
+									</p>
+								</div>
+							</CardHeader>
+							<CardBody>
+								<div className="perform-admin-assets__chips">
+									{ ( screen.assets || [] ).map( ( asset ) => (
+										<span key={ `${ asset.type }:${ asset.handle }` }>
+											<code>{ asset.handle }</code>
+											<small>
+												{ asset.type } · { asset.source }
+											</small>
+										</span>
+									) ) }
+								</div>
+							</CardBody>
+						</Card>
+					) ) }
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default AdminAssetAuditPanel;

--- a/assets/src/js/admin/AdminAssetAuditPanel.test.jsx
+++ b/assets/src/js/admin/AdminAssetAuditPanel.test.jsx
@@ -1,0 +1,61 @@
+/* eslint-env jest */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+window.performwpSettings = { adminAssetAuditNonce: 'asset-nonce' };
+const AdminAssetAuditPanel = require( './AdminAssetAuditPanel' ).default;
+
+describe( 'AdminAssetAuditPanel', () => {
+	beforeEach( () => {
+		global.fetch = jest.fn();
+		window.confirm = jest.fn( () => true );
+	} );
+
+	it( 'explains disabled mode without presenting collected data', () => {
+		render( <AdminAssetAuditPanel initialSnapshot={ { enabled: false, screens: [], repeated: [] } } /> );
+		expect( screen.getByText( 'Audit mode is off' ) ).toBeInTheDocument();
+		expect( screen.getByText( /registers no asset-capture hooks/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows repeated assets as evidence rather than a disable recommendation', () => {
+		render(
+			<AdminAssetAuditPanel
+				initialSnapshot={ {
+					enabled: true,
+					screens: [ { id: 'dashboard', assets: [] } ],
+					repeated: [
+						{
+							type: 'script',
+							handle: 'sample-admin',
+							source: 'sample-plugin',
+							confidence: 'high',
+							screenCount: 4,
+						},
+					],
+				} }
+			/>
+		);
+		expect( screen.getByText( /not proof that an asset is unnecessary/ ) ).toBeInTheDocument();
+		expect( screen.getByText( 'sample-admin' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'sample-plugin' ) ).toBeInTheDocument();
+	} );
+
+	it( 'clears the current site snapshot after confirmation', async () => {
+		global.fetch.mockResolvedValue( {
+			ok: true,
+			json: async () => ( {
+				success: true,
+				data: { message: 'Admin asset audit cleared.', snapshot: { enabled: true, screens: [], repeated: [] } },
+			} ),
+		} );
+		render(
+			<AdminAssetAuditPanel
+				initialSnapshot={ { enabled: true, screens: [ { id: 'dashboard', assets: [] } ], repeated: [] } }
+			/>
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Clear audit' } ) );
+		await waitFor( () => expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Admin asset audit cleared.' ) );
+		expect( global.fetch.mock.calls[ 0 ][ 1 ].body.toString() ).toContain( 'perform_clear_admin_asset_audit' );
+	} );
+} );

--- a/assets/src/js/admin/SettingsApp.jsx
+++ b/assets/src/js/admin/SettingsApp.jsx
@@ -15,6 +15,7 @@ const SITE_INVENTORY = SETTINGS.siteInventory || {};
 const SYSTEM_HEALTH = SETTINGS.systemHealth || {};
 const ADMIN_PERFORMANCE = SETTINGS.adminPerformance || {};
 const CRON_PRESSURE = SETTINGS.cronPressure || {};
+const ADMIN_ASSET_AUDIT = SETTINGS.adminAssetAudit || {};
 const TAB_KEYS = [ 'dashboard', ...Object.keys( SETTINGS_TABS ) ];
 
 const normalizeTab = ( tab ) => ( TAB_KEYS.includes( tab ) ? tab : 'dashboard' );
@@ -183,15 +184,24 @@ const SettingsApp = () => {
 				systemHealth={ SYSTEM_HEALTH }
 				adminPerformance={ ADMIN_PERFORMANCE }
 				cronPressure={ CRON_PRESSURE }
+				adminAssetAudit={ ADMIN_ASSET_AUDIT }
 				activeTab={ activeTab }
 				onTabChange={ handleTabChange }
 				fieldValues={ fieldValues }
 				onFieldChange={ handleFieldChange }
 			/>
 			{ 'dashboard' === activeTab && <DiagnosticsPanel diagnostics={ diagnostics } /> }
-			{ ! [ 'dashboard', 'cache-stats', 'database', 'inventory', 'admin-monitor', 'scheduled-tasks' ].includes(
-				activeTab
-			) && <Footer dirty={ isDirty } saving={ saving } message={ message } onSave={ handleSave } /> }
+			{ ! [
+				'dashboard',
+				'cache-stats',
+				'database',
+				'inventory',
+				'admin-monitor',
+				'scheduled-tasks',
+				'admin-assets',
+			].includes( activeTab ) && (
+				<Footer dirty={ isDirty } saving={ saving } message={ message } onSave={ handleSave } />
+			) }
 		</>
 	);
 };

--- a/assets/src/js/admin/SettingsNav.jsx
+++ b/assets/src/js/admin/SettingsNav.jsx
@@ -6,6 +6,7 @@ import DashboardPanel from './DashboardPanel';
 import DatabaseAuditPanel from './DatabaseAuditPanel';
 import SiteInventoryPanel from './SiteInventoryPanel';
 import CronPressurePanel from './CronPressurePanel';
+import AdminAssetAuditPanel from './AdminAssetAuditPanel';
 import SettingsFieldRow from './settings/SettingsFieldRow';
 
 const SETTINGS = window.performwpSettings || {};
@@ -20,6 +21,7 @@ const SettingsNav = ( {
 	systemHealth,
 	adminPerformance,
 	cronPressure,
+	adminAssetAudit,
 	activeTab: propActiveTab,
 	onTabChange: propOnTabChange,
 	fieldValues: propFieldValues,
@@ -130,6 +132,10 @@ const SettingsNav = ( {
 						);
 					} else if ( 'scheduled-tasks' === selectedTabName ) {
 						content = <CronPressurePanel initialAudit={ cronPressure } />;
+					} else if ( 'admin-assets' === selectedTabName ) {
+						content = (
+							<AdminAssetAuditPanel initialSnapshot={ adminAssetAudit } onNavigate={ onTabChange } />
+						);
 					} else if ( 'cache-stats' === selectedTabName ) {
 						content = <CacheStatsPanel />;
 					}

--- a/docs/admin-asset-audit.md
+++ b/docs/admin-asset-audit.md
@@ -1,0 +1,11 @@
+# Admin asset audit
+
+The Admin Asset Audit is an opt-in, local diagnostic for scripts and styles loaded on WordPress admin screens.
+
+- It records stable screen IDs, asset handles, asset type, and a likely source label.
+- It never stores asset URLs, query strings, nonces, request data, or user data.
+- Collection is limited to 30 screens, 100 assets per screen, and seven days per site.
+- Repeated presence is a review signal. It does not prove an asset is unnecessary or safe to disable.
+- Perform does not dequeue, deregister, or otherwise modify third-party admin assets.
+
+Enable the audit under **Perform → Advanced**, visit representative admin screens, and review **Admin Assets**. Clear the snapshot when the investigation is complete.

--- a/languages/perform.pot
+++ b/languages/perform.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: PerformWP <hello@performwp.com>\n"
-"POT-Creation-Date: 2026-08-11 04:23+0000\n"
+"POT-Creation-Date: 2026-08-11 04:41+0000\n"
 "Report-Msgid-Bugs-To: https://github.com/performwp/perform/issues/new\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
@@ -16,63 +16,63 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/Admin/Actions.php:97
+#: src/Admin/Actions.php:100
 msgid "Activity actions"
 msgstr ""
 
-#: src/Admin/Actions.php:98
+#: src/Admin/Actions.php:101
 msgid "Export cache activity for review or clear the collected metrics."
 msgstr ""
 
-#: src/Admin/Actions.php:99
+#: src/Admin/Actions.php:102
 msgid "Export CSV"
 msgstr ""
 
-#: src/Admin/Actions.php:100
+#: src/Admin/Actions.php:103
 msgid "Exporting…"
 msgstr ""
 
-#: src/Admin/Actions.php:101
+#: src/Admin/Actions.php:104
 msgid "Cache activity exported."
 msgstr ""
 
-#: src/Admin/Actions.php:102
+#: src/Admin/Actions.php:105
 msgid "Cache activity could not be exported."
 msgstr ""
 
-#: src/Admin/Actions.php:103
+#: src/Admin/Actions.php:106
 msgid "Clear activity"
 msgstr ""
 
-#: src/Admin/Actions.php:104
+#: src/Admin/Actions.php:107
 msgid "Clearing…"
 msgstr ""
 
-#: src/Admin/Actions.php:105
+#: src/Admin/Actions.php:108
 msgid "Clear all collected cache activity? This does not clear cached pages."
 msgstr ""
 
-#: src/Admin/Actions.php:106, src/Modules/Cache/PageCache.php:828, src/Modules/Cache/PageCache.php:1090
+#: src/Admin/Actions.php:109, src/Modules/Cache/PageCache.php:828, src/Modules/Cache/PageCache.php:1090
 msgid "Cache activity cleared."
 msgstr ""
 
-#: src/Admin/Actions.php:107
+#: src/Admin/Actions.php:110
 msgid "Cache activity could not be cleared."
 msgstr ""
 
-#: src/Admin/Actions.php:136
+#: src/Admin/Actions.php:139
 msgid "Close Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:133, src/Modules/Assets/AssetsManager.php:274
+#: src/Admin/Actions.php:136, src/Modules/Assets/AssetsManager.php:274
 msgid "Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:143, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:254
+#: src/Admin/Actions.php:146, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:254
 msgid "Perform"
 msgstr ""
 
-#: src/Admin/Actions.php:163
+#: src/Admin/Actions.php:166
 msgid "Support Forum"
 msgstr ""
 
@@ -657,43 +657,59 @@ msgid "Collect bounded, private aggregate timing, memory, and query-count diagno
 msgstr ""
 
 #: src/Includes/Helpers.php:959
-msgid "Remove Data on Uninstall"
+msgid "Admin Asset Audit"
 msgstr ""
 
 #: src/Includes/Helpers.php:960
+msgid "Temporarily inventory script and style handles across sampled WordPress admin screens without disabling anything."
+msgstr ""
+
+#: src/Includes/Helpers.php:965
+msgid "Remove Data on Uninstall"
+msgstr ""
+
+#: src/Includes/Helpers.php:966
 msgid "Enabling this will remove all plugin data upon uninstallation."
 msgstr ""
 
-#: src/Includes/Helpers.php:973
+#: src/Includes/Helpers.php:979
 msgid "WooCommerce Settings"
 msgstr ""
 
-#: src/Includes/Helpers.php:974
+#: src/Includes/Helpers.php:980
 msgid "Settings specific to WooCommerce."
 msgstr ""
 
-#: src/Includes/Helpers.php:979
+#: src/Includes/Helpers.php:985
 msgid "Enable WooCommerce Manager"
 msgstr ""
 
-#: src/Includes/Helpers.php:980
+#: src/Includes/Helpers.php:986
 msgid "Enabling this will allow you to manage WooCommerce specific settings."
 msgstr ""
 
-#: src/Includes/Helpers.php:991
+#: src/Includes/Helpers.php:997
 msgid "Enable WooCommerce Cache"
 msgstr ""
 
-#: src/Includes/Helpers.php:992
+#: src/Includes/Helpers.php:998
 msgid "Enabling this will cache WooCommerce pages for better performance."
+msgstr ""
+
+#: src/Admin/Settings/AdminAssetAuditController.php:24
+msgid "You are not allowed to clear admin asset audit data."
+msgstr ""
+
+#: src/Admin/Settings/AdminAssetAuditController.php:29, src/Admin/Settings/AdminPerformanceMonitorController.php:36, src/Admin/Settings/AutoloadOptionsAuditController.php:48, src/Admin/Settings/CronPressureAuditController.php:84, src/Admin/Settings/Menu.php:125
+msgid "Security check failed."
+msgstr ""
+
+#: src/Admin/Settings/AdminAssetAuditController.php:35
+msgid "Admin asset audit cleared."
 msgstr ""
 
 #: src/Admin/Settings/AdminPerformanceMonitorController.php:31
 msgid "You are not allowed to clear admin performance data."
-msgstr ""
-
-#: src/Admin/Settings/AdminPerformanceMonitorController.php:36, src/Admin/Settings/AutoloadOptionsAuditController.php:48, src/Admin/Settings/CronPressureAuditController.php:84, src/Admin/Settings/Menu.php:124
-msgid "Security check failed."
 msgstr ""
 
 #: src/Admin/Settings/AdminPerformanceMonitorController.php:42
@@ -728,7 +744,7 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: src/Admin/Settings/AutoloadOptionsAuditController.php:38, src/Admin/Settings/CronPressureAuditController.php:79, src/Admin/Settings/Menu.php:113, src/Admin/Settings/SiteInventoryController.php:59
+#: src/Admin/Settings/AutoloadOptionsAuditController.php:38, src/Admin/Settings/CronPressureAuditController.php:79, src/Admin/Settings/Menu.php:114, src/Admin/Settings/SiteInventoryController.php:59
 msgid "Insufficient permissions."
 msgstr ""
 
@@ -821,18 +837,22 @@ msgid "Admin Monitor"
 msgstr ""
 
 #: src/Admin/Settings/Menu.php:58
-msgid "Scheduled Tasks"
+msgid "Admin Assets"
 msgstr ""
 
 #: src/Admin/Settings/Menu.php:59
+msgid "Scheduled Tasks"
+msgstr ""
+
+#: src/Admin/Settings/Menu.php:60
 msgid "Cache Stats"
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:240
+#: src/Admin/Settings/Menu.php:241
 msgid "Unable to save the settings. Please try again."
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:232
+#: src/Admin/Settings/Menu.php:233
 msgid "Settings saved successfully."
 msgstr ""
 

--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -14,6 +14,7 @@ use Perform\Includes\Helpers;
 use Perform\Admin\Settings\ClientPayload;
 use Perform\Admin\Settings\AutoloadOptionsAudit;
 use Perform\Admin\Settings\AdminPerformanceMonitor;
+use Perform\Admin\Settings\AdminAssetAudit;
 use Perform\Admin\Settings\DashboardPayload;
 use Perform\Admin\Settings\Menu;
 use Perform\Admin\Settings\RuntimeDiagnostics;
@@ -67,29 +68,31 @@ class Actions {
 				'perform-admin',
 				'performwpSettings',
 				[
-					'version'            => defined( 'PERFORM_VERSION' ) ? PERFORM_VERSION : '',
-					'docsUrl'            => defined( 'PERFORM_PLUGIN_DOCS_URL' ) ? PERFORM_PLUGIN_DOCS_URL : 'https://performwp.com/docs/',
-					'logoUrl'            => plugins_url( 'assets/dist/images/logo.png', PERFORM_PLUGIN_FILE ),
-					'nonce'              => wp_create_nonce( 'perform_save_settings' ),
-					'saved'              => ClientPayload::sanitize_for_client( (array) \Perform\Includes\Helpers::get_settings() ),
-					'dashboard'          => DashboardPayload::get_data(),
-					'diagnostics'        => RuntimeDiagnostics::get_results(),
-					'databaseAudit'      => AutoloadOptionsAudit::get_cached_snapshot(),
-					'adminPerformance'   => AdminPerformanceMonitor::get_snapshot(),
-					'adminMonitorNonce'  => wp_create_nonce( 'perform_clear_admin_performance_monitor' ),
-					'databaseAuditNonce' => wp_create_nonce( 'perform_refresh_autoload_options_audit' ),
-					'siteInventory'      => SiteInventory::get_cached_snapshot(),
-					'siteInventoryUrl'   => esc_url_raw( rest_url( 'perform/v1/site-inventory' ) ),
-					'systemHealth'       => SystemHealth::get_data(),
-					'cronPressure'       => CronPressureAudit::get_cached_snapshot(),
-					'cronPressureNonce'  => wp_create_nonce( 'perform_cron_pressure_audit' ),
-					'restNonce'          => wp_create_nonce( 'wp_rest' ),
-					'sensitiveKeys'      => ClientPayload::get_sensitive_keys(),
-					'maskedSecretValue'  => ClientPayload::MASKED_SECRET,
-					'tabs'               => Menu::get_navigation_tabs(),
-					'activeTab'          => Menu::get_requested_tab(),
-					'fields'             => \Perform\Includes\Helpers::get_settings_fields(), // Expose fields to JS
-					'cacheActivity'      => [
+					'version'              => defined( 'PERFORM_VERSION' ) ? PERFORM_VERSION : '',
+					'docsUrl'              => defined( 'PERFORM_PLUGIN_DOCS_URL' ) ? PERFORM_PLUGIN_DOCS_URL : 'https://performwp.com/docs/',
+					'logoUrl'              => plugins_url( 'assets/dist/images/logo.png', PERFORM_PLUGIN_FILE ),
+					'nonce'                => wp_create_nonce( 'perform_save_settings' ),
+					'saved'                => ClientPayload::sanitize_for_client( (array) \Perform\Includes\Helpers::get_settings() ),
+					'dashboard'            => DashboardPayload::get_data(),
+					'diagnostics'          => RuntimeDiagnostics::get_results(),
+					'databaseAudit'        => AutoloadOptionsAudit::get_cached_snapshot(),
+					'adminPerformance'     => AdminPerformanceMonitor::get_snapshot(),
+					'adminMonitorNonce'    => wp_create_nonce( 'perform_clear_admin_performance_monitor' ),
+					'adminAssetAudit'      => AdminAssetAudit::get_snapshot(),
+					'adminAssetAuditNonce' => wp_create_nonce( 'perform_clear_admin_asset_audit' ),
+					'databaseAuditNonce'   => wp_create_nonce( 'perform_refresh_autoload_options_audit' ),
+					'siteInventory'        => SiteInventory::get_cached_snapshot(),
+					'siteInventoryUrl'     => esc_url_raw( rest_url( 'perform/v1/site-inventory' ) ),
+					'systemHealth'         => SystemHealth::get_data(),
+					'cronPressure'         => CronPressureAudit::get_cached_snapshot(),
+					'cronPressureNonce'    => wp_create_nonce( 'perform_cron_pressure_audit' ),
+					'restNonce'            => wp_create_nonce( 'wp_rest' ),
+					'sensitiveKeys'        => ClientPayload::get_sensitive_keys(),
+					'maskedSecretValue'    => ClientPayload::MASKED_SECRET,
+					'tabs'                 => Menu::get_navigation_tabs(),
+					'activeTab'            => Menu::get_requested_tab(),
+					'fields'               => \Perform\Includes\Helpers::get_settings_fields(), // Expose fields to JS
+					'cacheActivity'        => [
 						'actionUrl'         => admin_url( 'admin-post.php' ),
 						'exportNonce'       => wp_create_nonce( 'perform_export_cache_activity' ),
 						'clearNonce'        => wp_create_nonce( 'perform_clear_cache_activity' ),

--- a/src/Admin/Settings/AdminAssetAudit.php
+++ b/src/Admin/Settings/AdminAssetAudit.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * Perform - Admin Asset Audit.
+ *
+ * @package Perform
+ * @subpackage Admin/Settings
+ */
+
+namespace Perform\Admin\Settings;
+
+use Perform\Includes\Helpers;
+
+// Bailout, if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Captures bounded script and style inventories for sampled wp-admin screens.
+ */
+final class AdminAssetAudit {
+	const OPTION_NAME      = 'perform_admin_asset_audit';
+	const SCHEMA_VERSION   = 1;
+	const RETENTION_DAYS   = 7;
+	const MAX_SCREENS      = 30;
+	const MAX_ASSETS       = 100;
+	const GLOBAL_THRESHOLD = 3;
+
+	/** @var string */
+	private $screen_id = '';
+
+	/**
+	 * Register capture hooks only when explicitly enabled.
+	 *
+	 * @param array<string, mixed>|null $settings Optional settings snapshot.
+	 */
+	public function __construct( $settings = null ) {
+		$settings = is_array( $settings ) ? $settings : Helpers::get_settings();
+		$settings = is_array( $settings ) ? $settings : [];
+		if ( empty( $settings['enable_admin_asset_audit'] ) ) {
+			return;
+		}
+
+		add_action( 'current_screen', [ $this, 'capture_screen' ] );
+		add_action( 'admin_print_footer_scripts', [ $this, 'capture_assets' ], PHP_INT_MAX );
+	}
+
+	/**
+	 * Remember a stable screen ID, never the request URL.
+	 *
+	 * @param mixed $screen Current screen object.
+	 * @return void
+	 */
+	public function capture_screen( $screen ) {
+		if ( is_object( $screen ) && isset( $screen->id ) && is_scalar( $screen->id ) ) {
+			$this->screen_id = sanitize_key( (string) $screen->id );
+		}
+	}
+
+	/**
+	 * Capture the final queues after wp-admin footer enqueue processing.
+	 *
+	 * @return void
+	 */
+	public function capture_assets() {
+		$settings = Helpers::get_settings();
+		if ( empty( $settings['enable_admin_asset_audit'] ) || '' === $this->screen_id ) {
+			return;
+		}
+
+		global $wp_scripts, $wp_styles;
+
+		$assets = array_merge(
+			self::read_queue( $wp_scripts, 'script' ),
+			self::read_queue( $wp_styles, 'style' )
+		);
+		self::record_sample( $this->screen_id, $assets );
+	}
+
+	/**
+	 * Convert a dependency queue to privacy-safe aggregate rows.
+	 *
+	 * @param mixed  $registry WordPress dependency registry.
+	 * @param string $type Asset type.
+	 * @return array<int, array<string, string>>
+	 */
+	private static function read_queue( $registry, $type ) {
+		if ( ! is_object( $registry ) || ! isset( $registry->queue ) || ! is_array( $registry->queue ) ) {
+			return [];
+		}
+
+		$assets = [];
+		foreach ( array_slice( $registry->queue, 0, self::MAX_ASSETS ) as $handle ) {
+			$handle = sanitize_key( is_scalar( $handle ) ? (string) $handle : '' );
+			if ( '' === $handle ) {
+				continue;
+			}
+
+			$src = '';
+			if ( isset( $registry->registered[ $handle ] ) && is_object( $registry->registered[ $handle ] ) && isset( $registry->registered[ $handle ]->src ) && is_scalar( $registry->registered[ $handle ]->src ) ) {
+				$src = (string) $registry->registered[ $handle ]->src;
+			}
+
+			$source   = self::classify_source( $src );
+			$assets[] = [
+				'type'       => $type,
+				'handle'     => $handle,
+				'source'     => $source['source'],
+				'confidence' => $source['confidence'],
+			];
+		}
+
+		return $assets;
+	}
+
+	/**
+	 * Record one bounded screen sample.
+	 *
+	 * @param string                            $screen_id Stable WordPress screen ID.
+	 * @param array<int, array<string, mixed>> $assets Raw assets.
+	 * @param int|null                         $now Optional test timestamp.
+	 * @return array<string, mixed>
+	 */
+	public static function record_sample( $screen_id, array $assets, $now = null ) {
+		$screen_id = sanitize_key( (string) $screen_id );
+		if ( '' === $screen_id ) {
+			return self::get_snapshot();
+		}
+
+		$now      = null === $now ? time() : max( 0, (int) $now );
+		$snapshot = self::get_stored_snapshot();
+		$screens  = is_array( $snapshot['screens'] ?? null ) ? $snapshot['screens'] : [];
+		$cutoff   = $now - ( self::RETENTION_DAYS * 86400 );
+		$screens  = array_values(
+			array_filter(
+				$screens,
+				static function ( $screen ) use ( $cutoff ) {
+					return is_array( $screen ) && (int) ( $screen['lastSeen'] ?? 0 ) >= $cutoff;
+				}
+			)
+		);
+
+		$normalized = [];
+		foreach ( array_slice( $assets, 0, self::MAX_ASSETS ) as $asset ) {
+			if ( ! is_array( $asset ) ) {
+				continue;
+			}
+			$type   = in_array( $asset['type'] ?? '', [ 'script', 'style' ], true ) ? $asset['type'] : '';
+			$handle = sanitize_key( is_scalar( $asset['handle'] ?? null ) ? (string) $asset['handle'] : '' );
+			if ( '' === $type || '' === $handle ) {
+				continue;
+			}
+
+			$raw_source         = is_scalar( $asset['source'] ?? null ) ? (string) $asset['source'] : '';
+			$source             = sanitize_key( $raw_source );
+			$source             = ( '' !== $source && $source === $raw_source ) ? $source : 'unknown';
+			$key                = $type . ':' . $handle;
+			$normalized[ $key ] = [
+				'type'       => $type,
+				'handle'     => $handle,
+				'source'     => $source,
+				'confidence' => in_array( $asset['confidence'] ?? '', [ 'high', 'medium', 'low' ], true ) ? $asset['confidence'] : 'low',
+			];
+		}
+
+		$next  = [
+			'id'       => $screen_id,
+			'lastSeen' => $now,
+			'assets'   => array_values( $normalized ),
+		];
+		$found = false;
+		foreach ( $screens as &$screen ) {
+			if ( (string) ( $screen['id'] ?? '' ) === $screen_id ) {
+				$screen = $next;
+				$found  = true;
+				break;
+			}
+		}
+		unset( $screen );
+		if ( ! $found ) {
+			$screens[] = $next;
+		}
+
+		usort(
+			$screens,
+			static function ( $left, $right ) {
+				return (int) ( $right['lastSeen'] ?? 0 ) <=> (int) ( $left['lastSeen'] ?? 0 );
+			}
+		);
+
+		$snapshot = [
+			'schemaVersion' => self::SCHEMA_VERSION,
+			'updatedAt'     => $now,
+			'screens'       => array_slice( $screens, 0, self::MAX_SCREENS ),
+		];
+		update_option( self::OPTION_NAME, $snapshot, false );
+
+		return self::prepare_snapshot( $snapshot );
+	}
+
+	/**
+	 * Classify an asset without retaining its URL or query string.
+	 *
+	 * @param string $src Registered source.
+	 * @return array{source:string,confidence:string}
+	 */
+	public static function classify_source( $src ) {
+		$path = strtolower( (string) wp_parse_url( (string) $src, PHP_URL_PATH ) );
+		if ( preg_match( '#/wp-content/plugins/([^/]+)/#', $path, $matches ) ) {
+			return [
+				'source'     => sanitize_key( $matches[1] ),
+				'confidence' => 'high',
+			];
+		}
+		if ( preg_match( '#/wp-content/(?:themes|mu-plugins)/([^/]+)/#', $path, $matches ) ) {
+			return [
+				'source'     => sanitize_key( $matches[1] ),
+				'confidence' => 'high',
+			];
+		}
+		if ( false !== strpos( $path, '/wp-admin/' ) || false !== strpos( $path, '/wp-includes/' ) ) {
+			return [
+				'source'     => 'wordpress-core',
+				'confidence' => 'high',
+			];
+		}
+
+		return [
+			'source'     => 'unknown',
+			'confidence' => 'low',
+		];
+	}
+
+	/** @return array<string, mixed> */
+	public static function get_snapshot() {
+		return self::prepare_snapshot( self::get_stored_snapshot() );
+	}
+
+	/** @return bool */
+	public static function clear() {
+		return delete_option( self::OPTION_NAME );
+	}
+
+	/** @return array<string, mixed> */
+	private static function get_stored_snapshot() {
+		$snapshot = get_option( self::OPTION_NAME, [] );
+		if ( ! is_array( $snapshot ) || self::SCHEMA_VERSION !== (int) ( $snapshot['schemaVersion'] ?? 0 ) ) {
+			$snapshot = [
+				'schemaVersion' => self::SCHEMA_VERSION,
+				'updatedAt'     => 0,
+				'screens'       => [],
+			];
+		}
+
+		return $snapshot;
+	}
+
+	/**
+	 * Derive repeated presence from the current bounded screen set.
+	 *
+	 * @param array<string, mixed> $snapshot Stored snapshot.
+	 * @return array<string, mixed>
+	 */
+	private static function prepare_snapshot( array $snapshot ) {
+		$settings = Helpers::get_settings();
+		$screens  = [];
+		foreach ( (array) ( $snapshot['screens'] ?? [] ) as $screen ) {
+			if ( ! is_array( $screen ) ) {
+				continue;
+			}
+
+			$screen_id = sanitize_key( is_scalar( $screen['id'] ?? null ) ? (string) $screen['id'] : '' );
+			if ( '' === $screen_id ) {
+				continue;
+			}
+
+			$assets = [];
+			foreach ( array_slice( (array) ( $screen['assets'] ?? [] ), 0, self::MAX_ASSETS ) as $asset ) {
+				if ( ! is_array( $asset ) ) {
+					continue;
+				}
+				$type   = in_array( $asset['type'] ?? '', [ 'script', 'style' ], true ) ? $asset['type'] : '';
+				$handle = sanitize_key( is_scalar( $asset['handle'] ?? null ) ? (string) $asset['handle'] : '' );
+				if ( '' === $type || '' === $handle ) {
+					continue;
+				}
+				$raw_source = is_scalar( $asset['source'] ?? null ) ? (string) $asset['source'] : '';
+				$source     = sanitize_key( $raw_source );
+				$source     = ( '' !== $source && $source === $raw_source ) ? $source : 'unknown';
+				$assets[]   = [
+					'type'       => $type,
+					'handle'     => $handle,
+					'source'     => $source,
+					'confidence' => in_array( $asset['confidence'] ?? '', [ 'high', 'medium', 'low' ], true ) ? $asset['confidence'] : 'low',
+				];
+			}
+
+			$screens[] = [
+				'id'       => $screen_id,
+				'lastSeen' => max( 0, (int) ( $screen['lastSeen'] ?? 0 ) ),
+				'assets'   => $assets,
+			];
+		}
+		$presence = [];
+		foreach ( $screens as $screen ) {
+			foreach ( $screen['assets'] as $asset ) {
+				$key              = $asset['type'] . ':' . $asset['handle'];
+				$presence[ $key ] = ( $presence[ $key ] ?? 0 ) + 1;
+			}
+		}
+
+		$repeated = [];
+		foreach ( $screens as &$screen ) {
+			foreach ( $screen['assets'] as &$asset ) {
+				$key                   = $asset['type'] . ':' . $asset['handle'];
+				$asset['screenCount']  = $presence[ $key ] ?? 1;
+				$asset['globalSignal'] = ( $asset['screenCount'] >= self::GLOBAL_THRESHOLD );
+				if ( $asset['globalSignal'] ) {
+					$repeated[ $key ] = $asset;
+				}
+			}
+			unset( $asset );
+		}
+		unset( $screen );
+
+		usort(
+			$repeated,
+			static function ( $left, $right ) {
+				return (int) $right['screenCount'] <=> (int) $left['screenCount'];
+			}
+		);
+
+		return [
+			'schemaVersion' => self::SCHEMA_VERSION,
+			'updatedAt'     => max( 0, (int) ( $snapshot['updatedAt'] ?? 0 ) ),
+			'enabled'       => ! empty( $settings['enable_admin_asset_audit'] ),
+			'screens'       => $screens,
+			'repeated'      => $repeated,
+			'limits'        => [
+				'screens'         => self::MAX_SCREENS,
+				'assetsPerScreen' => self::MAX_ASSETS,
+				'retentionDays'   => self::RETENTION_DAYS,
+			],
+		];
+	}
+}

--- a/src/Admin/Settings/AdminAssetAuditController.php
+++ b/src/Admin/Settings/AdminAssetAuditController.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Perform - Admin Asset Audit Controller.
+ *
+ * @package Perform
+ * @subpackage Admin/Settings
+ */
+
+namespace Perform\Admin\Settings;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class AdminAssetAuditController {
+	/** Register protected actions. */
+	public function __construct() {
+		add_action( 'wp_ajax_perform_clear_admin_asset_audit', [ $this, 'clear' ] );
+	}
+
+	/** @return void */
+	public function clear() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => __( 'You are not allowed to clear admin asset audit data.', 'perform' ) ], 403 );
+		}
+
+		$nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['nonce'] ) ) : '';
+		if ( ! wp_verify_nonce( $nonce, 'perform_clear_admin_asset_audit' ) ) {
+			wp_send_json_error( [ 'message' => __( 'Security check failed.', 'perform' ) ], 403 );
+		}
+
+		AdminAssetAudit::clear();
+		wp_send_json_success(
+			[
+				'message'  => __( 'Admin asset audit cleared.', 'perform' ),
+				'snapshot' => AdminAssetAudit::get_snapshot(),
+			]
+		);
+	}
+}

--- a/src/Admin/Settings/Menu.php
+++ b/src/Admin/Settings/Menu.php
@@ -55,6 +55,7 @@ class Menu {
 		$tabs['inventory']       = esc_html__( 'Site Inventory', 'perform' );
 		$tabs['database']        = esc_html__( 'Database', 'perform' );
 		$tabs['admin-monitor']   = esc_html__( 'Admin Monitor', 'perform' );
+		$tabs['admin-assets']    = esc_html__( 'Admin Assets', 'perform' );
 		$tabs['scheduled-tasks'] = esc_html__( 'Scheduled Tasks', 'perform' );
 		$tabs['cache-stats']     = esc_html__( 'Cache Stats', 'perform' );
 

--- a/src/Includes/Helpers.php
+++ b/src/Includes/Helpers.php
@@ -954,6 +954,12 @@ class Helpers {
 							'desc' => esc_html__( 'Collect bounded, private aggregate timing, memory, and query-count diagnostics for WordPress admin requests.', 'perform' ),
 						],
 						[
+							'id'   => 'enable_admin_asset_audit',
+							'type' => 'toggle',
+							'name' => esc_html__( 'Admin Asset Audit', 'perform' ),
+							'desc' => esc_html__( 'Temporarily inventory script and style handles across sampled WordPress admin screens without disabling anything.', 'perform' ),
+						],
+						[
 							'id'        => 'remove_data_on_uninstall',
 							'type'      => 'toggle',
 							'name'      => esc_html__( 'Remove Data on Uninstall', 'perform' ),

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -55,6 +55,7 @@ final class Plugin {
 		new Settings\AutoloadOptionsAuditController();
 		new Settings\SiteInventoryController();
 		new Settings\AdminPerformanceMonitorController();
+		new Settings\AdminAssetAuditController();
 		new Settings\CronPressureAuditController();
 		new Admin\Actions();
 		new Admin\Filters();
@@ -69,6 +70,7 @@ final class Plugin {
 		$settings = Helpers::get_settings();
 		$settings = is_array( $settings ) ? $settings : [];
 		new Settings\AdminPerformanceMonitor( $settings );
+		new Settings\AdminAssetAudit( $settings );
 
 		$loader = new Modules\Loader( $settings );
 

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -60,7 +60,7 @@ test( 'settings save, Assets Manager, and page cache smoke paths work', async ( 
 	await expect( page.getByRole( 'button', { name: 'Save Settings' } ) ).toBeVisible();
 	await expect( page ).toHaveURL( /[?&]tab=general(?:&|$)/ );
 
-	await page.getByRole( 'tab', { name: 'Assets' } ).click();
+	await page.getByRole( 'tab', { name: 'Assets', exact: true } ).click();
 	await page.getByRole( 'checkbox', { name: 'Enable Assets Manager' } ).check();
 	await page.getByRole( 'textbox', { name: 'Preconnect' } ).fill( `//ci-${ Date.now() }.example.com` );
 

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -216,6 +216,49 @@ test( 'Admin Performance Monitor is opt-in, bounded, private, clearable, and res
 	await expect( page.getByText( /Settings saved/ ) ).toBeVisible();
 } );
 
+test( 'Admin asset audit is opt-in, bounded, private, clearable, and responsive', async ( { page } ) => {
+	await login( page );
+	await openAdminPage( page, '/wp-admin/options-general.php?page=perform_settings&tab=advanced' );
+
+	const auditToggle = page.getByRole( 'checkbox', { name: 'Admin Asset Audit' } );
+	if ( ! ( await auditToggle.isChecked() ) ) {
+		await auditToggle.check();
+	}
+	await page.getByRole( 'button', { name: 'Save Settings' } ).click();
+	await expect( page.getByText( /Settings saved/ ) ).toBeVisible();
+
+	await page.goto( '/wp-admin/index.php' );
+	await page.goto( '/wp-admin/edit.php' );
+	await page.goto( '/wp-admin/plugins.php' );
+	await openAdminPage( page, '/wp-admin/options-general.php?page=perform_settings&tab=admin-assets' );
+
+	await expect( page.getByRole( 'tab', { name: 'Admin Assets' } ) ).toHaveAttribute( 'aria-selected', 'true' );
+	await expect( page.getByText( 'Inventory only — nothing is disabled' ) ).toBeVisible();
+	await expect( page.getByText( /URLs, query strings, nonces, and user data are not stored/ ) ).toBeVisible();
+	await expect( page.getByText( 'Repeated across admin screens' ) ).toBeVisible();
+	await expect( page.getByText( /not proof that an asset is unnecessary/ ) ).toBeVisible();
+	await expect( page.getByRole( 'button', { name: 'Save Settings' } ) ).toHaveCount( 0 );
+
+	await mkdir( 'test-results/proof', { recursive: true } );
+	await page.screenshot( { path: 'test-results/proof/admin-asset-audit-desktop.png', fullPage: true } );
+	await page.setViewportSize( { width: 390, height: 844 } );
+	await page.screenshot( { path: 'test-results/proof/admin-asset-audit-mobile.png', fullPage: true } );
+	const hasHorizontalOverflow = await page.evaluate(
+		() => document.documentElement.scrollWidth > document.documentElement.clientWidth
+	);
+	expect( hasHorizontalOverflow ).toBeFalsy();
+
+	page.once( 'dialog', ( dialog ) => dialog.accept() );
+	await page.getByRole( 'button', { name: 'Clear audit' } ).click();
+	await expect( page.getByRole( 'status' ) ).toContainText( 'Admin asset audit cleared.' );
+	await expect( page.getByText( 'Visit a few admin screens' ) ).toBeVisible();
+
+	await page.getByRole( 'tab', { name: 'Advanced' } ).click();
+	await page.getByRole( 'checkbox', { name: 'Admin Asset Audit' } ).uncheck();
+	await page.getByRole( 'button', { name: 'Save Settings' } ).click();
+	await expect( page.getByText( /Settings saved/ ) ).toBeVisible();
+} );
+
 test( 'Cache Stats tab preserves legacy routing, actions, and keyboard access', async ( { page } ) => {
 	await login( page );
 
@@ -341,4 +384,13 @@ test( 'lower-privilege users cannot access the legacy or canonical Cache Stats r
 	} );
 	expect( cronAuditResponse.status() ).toBe( 403 );
 	expect( await cronAuditResponse.json() ).toMatchObject( { success: false } );
+
+	const adminAssetResponse = await page.request.post( '/wp-admin/admin-ajax.php', {
+		form: {
+			action: 'perform_clear_admin_asset_audit',
+			nonce: 'invalid-for-editor-capability-check',
+		},
+	} );
+	expect( adminAssetResponse.status() ).toBe( 403 );
+	expect( await adminAssetResponse.json() ).toMatchObject( { success: false } );
 } );

--- a/tests/unit-tests/tests-admin-asset-audit.php
+++ b/tests/unit-tests/tests-admin-asset-audit.php
@@ -1,0 +1,156 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Perform\Admin\Settings\AdminAssetAudit;
+use Perform\Admin\Settings\AdminAssetAuditController;
+
+final class Tests_Admin_Asset_Audit extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['perform_test_options']          = [];
+		$GLOBALS['perform_test_actions']          = [];
+		$GLOBALS['perform_test_current_user_can'] = [ 'manage_options' => true ];
+		$GLOBALS['perform_test_nonce_valid']      = true;
+		$_POST                                    = [];
+	}
+
+	protected function tearDown(): void {
+		unset(
+			$GLOBALS['perform_test_options'],
+			$GLOBALS['perform_test_actions'],
+			$GLOBALS['perform_test_current_user_can'],
+			$GLOBALS['perform_test_nonce_valid'],
+			$GLOBALS['perform_test_json_response']
+		);
+		$_POST = [];
+	}
+
+	public function test_disabled_mode_registers_no_capture_hooks() {
+		new AdminAssetAudit( [ 'enable_admin_asset_audit' => 0 ] );
+
+		$this->assertSame( [], $GLOBALS['perform_test_actions'] );
+		$this->assertArrayNotHasKey( AdminAssetAudit::OPTION_NAME, $GLOBALS['perform_test_options'] );
+	}
+
+	public function test_enabled_mode_registers_bounded_admin_capture_hooks() {
+		new AdminAssetAudit( [ 'enable_admin_asset_audit' => 1 ] );
+
+		$this->assertSame( [ 'current_screen', 'admin_print_footer_scripts' ], array_column( $GLOBALS['perform_test_actions'], 'hook' ) );
+	}
+
+	public function test_source_attribution_strips_urls_and_has_safe_fallbacks() {
+		$this->assertSame(
+			[
+				'source'     => 'sample-plugin',
+				'confidence' => 'high',
+			],
+			AdminAssetAudit::classify_source( 'https://example.test/wp-content/plugins/sample-plugin/admin.js?nonce=secret' )
+		);
+		$this->assertSame(
+			[
+				'source'     => 'wordpress-core',
+				'confidence' => 'high',
+			],
+			AdminAssetAudit::classify_source( '/wp-includes/js/jquery/jquery.js' )
+		);
+		$this->assertSame(
+			[
+				'source'     => 'unknown',
+				'confidence' => 'low',
+			],
+			AdminAssetAudit::classify_source( 'https://cdn.example.test/file.js?token=secret' )
+		);
+	}
+
+	public function test_samples_are_deduplicated_bounded_and_mark_repeated_presence() {
+		$this->enable_audit();
+		$asset = [
+			'type'       => 'script',
+			'handle'     => 'sample-admin',
+			'source'     => 'sample-plugin',
+			'confidence' => 'high',
+		];
+		AdminAssetAudit::record_sample( 'dashboard', [ $asset, $asset ], 1700000000 );
+		AdminAssetAudit::record_sample( 'edit-post', [ $asset ], 1700000001 );
+		$snapshot = AdminAssetAudit::record_sample( 'plugins', [ $asset ], 1700000002 );
+
+		$this->assertCount( 3, $snapshot['screens'] );
+		$this->assertCount( 1, $snapshot['repeated'] );
+		$this->assertSame( 3, $snapshot['repeated'][0]['screenCount'] );
+		$this->assertSame( 'sample-plugin', $snapshot['repeated'][0]['source'] );
+		$stored = wp_json_encode( $GLOBALS['perform_test_options'][ AdminAssetAudit::OPTION_NAME ] );
+		$this->assertStringNotContainsString( 'example.test', $stored );
+		$this->assertStringNotContainsString( 'nonce', $stored );
+		$this->assertStringNotContainsString( 'secret', $stored );
+	}
+
+	public function test_retention_and_screen_limit_are_enforced() {
+		$this->enable_audit();
+		$now = 1700000000;
+		AdminAssetAudit::record_sample( 'expired', [], $now - ( 8 * 86400 ) );
+		for ( $index = 0; $index < 35; ++$index ) {
+			AdminAssetAudit::record_sample( 'screen-' . $index, [], $now + $index );
+		}
+
+		$snapshot = AdminAssetAudit::get_snapshot();
+		$this->assertCount( AdminAssetAudit::MAX_SCREENS, $snapshot['screens'] );
+		$this->assertNotContains( 'expired', array_column( $snapshot['screens'], 'id' ) );
+		$this->assertContains( 'screen-34', array_column( $snapshot['screens'], 'id' ) );
+	}
+
+	public function test_malformed_stored_rows_are_ignored_without_exposing_values() {
+		$this->enable_audit();
+		$GLOBALS['perform_test_options'][ AdminAssetAudit::OPTION_NAME ] = [
+			'schemaVersion' => AdminAssetAudit::SCHEMA_VERSION,
+			'updatedAt'     => 1700000000,
+			'screens'       => [
+				'bad',
+				[
+					'id'     => 'safe-screen',
+					'assets' => [
+						null,
+						[
+							'type'   => 'script',
+							'handle' => 'safe-handle',
+							'source' => 'unsafe source?token=secret',
+						],
+					],
+				],
+			],
+		];
+
+		$snapshot = AdminAssetAudit::get_snapshot();
+		$this->assertCount( 1, $snapshot['screens'] );
+		$this->assertSame( 'safe-screen', $snapshot['screens'][0]['id'] );
+		$this->assertSame( 'unknown', $snapshot['screens'][0]['assets'][0]['source'] );
+		$this->assertStringNotContainsString( 'secret', wp_json_encode( $snapshot ) );
+		$this->assertStringNotContainsString( '?', wp_json_encode( $snapshot ) );
+	}
+
+	public function test_clear_requires_capability_and_nonce_then_removes_snapshot() {
+		$this->enable_audit();
+		AdminAssetAudit::record_sample( 'dashboard', [], 1700000000 );
+		$GLOBALS['perform_test_current_user_can']['manage_options'] = false;
+		$this->run_clear();
+		$this->assertFalse( $GLOBALS['perform_test_json_response']['success'] );
+
+		$GLOBALS['perform_test_current_user_can']['manage_options'] = true;
+		$GLOBALS['perform_test_nonce_valid']                        = true;
+		$_POST['nonce'] = 'valid';
+		$this->run_clear();
+		$this->assertTrue( $GLOBALS['perform_test_json_response']['success'] );
+		$this->assertSame( [], $GLOBALS['perform_test_json_response']['data']['snapshot']['screens'] );
+	}
+
+	private function enable_audit() {
+		$GLOBALS['perform_test_options']['perform_settings'] = [ 'enable_admin_asset_audit' => 1 ];
+	}
+
+	private function run_clear() {
+		try {
+			( new AdminAssetAuditController() )->clear();
+			$this->fail( 'Expected JSON response.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'perform_test_json_response', $exception->getMessage() );
+		}
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -34,6 +34,7 @@ function perform_handle_plugin_uninstall() {
 		'perform_site_inventory',
 		'perform_admin_performance_monitor',
 		'perform_cron_pressure_audit',
+		'perform_admin_asset_audit',
 	];
 
 	$remove_data_on_uninstall = false;


### PR DESCRIPTION
Closes #141.

## Summary

- adds an opt-in Admin Asset Audit with a dedicated read-only report tab
- samples final WordPress admin script/style queues by stable screen ID
- reports bounded handles, asset type, likely source, confidence, and repeated cross-screen presence
- keeps collection per-site and limited to 30 screens, 100 assets per screen, and seven days
- adds a protected clear action, documentation, responsive UI, unit tests, and hosted browser proof

## Safety and privacy

- no script or style is dequeued, deregistered, or modified
- repeated presence is explicitly presented as a review signal, not proof an asset is unnecessary
- no asset URLs, query strings, nonces, request data, or user data are stored
- source attribution is high confidence only for recognizable WordPress core/plugin/theme paths and otherwise falls back to unknown
- disabled mode registers no collection hooks

## Validation

- `composer test` — 133 tests, 415 assertions
- `composer lint` — 84 PHP files
- scoped PHPCS
- `composer phpstan`
- `npm run test:unit` — 34 tests
- `npm run lint`
- `npm run build`
- `git diff --check`

Hosted Playwright proof covers opt-in sampling across representative admin screens, privacy and limitation copy, repeated-presence evidence, desktop/mobile layout, clearing, disablement, and lower-privilege denial.
