### PR TITLE
Add read-only Action Scheduler diagnostics

### DIFF
--- a/assets/src/css/admin/settings.css
+++ b/assets/src/css/admin/settings.css
@@ -2095,6 +2095,172 @@
 	}
 }
 
+.perform-action-scheduler {
+	display: grid;
+	gap: 24px;
+	max-width: 1080px;
+	margin: 0 auto;
+}
+
+.perform-action-scheduler__heading,
+.perform-action-scheduler__actions,
+.perform-action-scheduler__storage,
+.perform-action-scheduler__grids {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+}
+
+.perform-action-scheduler__heading h2 {
+	margin: 4px 0 8px;
+	font-size: 28px;
+	line-height: 1.2;
+}
+
+.perform-action-scheduler__heading p,
+.perform-action-scheduler__privacy p,
+.perform-action-scheduler__guidance,
+.perform-action-scheduler__limitation {
+	margin: 0;
+	color: var(--perform-color-text-muted);
+	line-height: 1.6;
+}
+
+.perform-action-scheduler__limitation {
+	margin: -12px 0 0;
+	font-size: 12px;
+}
+
+.perform-action-scheduler__actions {
+	flex: 0 0 auto;
+}
+
+.perform-action-scheduler__privacy,
+.perform-action-scheduler__guidance {
+	padding: 18px 20px;
+	border-left: 4px solid var(--perform-color-primary);
+	background: var(--perform-color-surface-subtle);
+}
+
+.perform-action-scheduler__privacy strong {
+	display: block;
+	margin-bottom: 6px;
+}
+
+.perform-action-scheduler__message {
+	padding: 12px 16px;
+	border: 1px solid var(--perform-color-border);
+	background: var(--perform-color-surface);
+}
+
+.perform-action-scheduler__message.is-success {
+	border-color: #68a76f;
+}
+
+.perform-action-scheduler__message.is-error {
+	border-color: #d63638;
+}
+
+.perform-action-scheduler__summary {
+	display: grid;
+	grid-template-columns: repeat(5, minmax(0, 1fr));
+	border-top: 1px solid var(--perform-color-border);
+	border-bottom: 1px solid var(--perform-color-border);
+}
+
+.perform-action-scheduler__summary > div,
+.perform-action-scheduler__storage > div {
+	display: grid;
+	gap: 6px;
+	min-width: 0;
+	padding: 18px;
+	border-right: 1px solid var(--perform-color-border);
+}
+
+.perform-action-scheduler__summary > div:last-child,
+.perform-action-scheduler__storage > div:last-child {
+	border-right: 0;
+}
+
+.perform-action-scheduler__summary span,
+.perform-action-scheduler__storage span {
+	color: var(--perform-color-text-muted);
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.perform-action-scheduler__summary strong {
+	font-size: 26px;
+}
+
+.perform-action-scheduler__storage {
+	border: 1px solid var(--perform-color-border);
+	border-radius: 8px;
+}
+
+.perform-action-scheduler__storage > div {
+	flex: 1 1 0;
+}
+
+.perform-action-scheduler__grids > .components-card {
+	flex: 1 1 0;
+	min-width: 0;
+}
+
+.perform-action-scheduler__table-wrap {
+	overflow-x: auto;
+}
+
+.perform-action-scheduler__table-wrap table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.perform-action-scheduler__table-wrap th,
+.perform-action-scheduler__table-wrap td {
+	padding: 12px;
+	border-bottom: 1px solid var(--perform-color-border);
+	text-align: left;
+}
+
+@media (max-width: 782px) {
+
+	.perform-action-scheduler__heading,
+	.perform-action-scheduler__actions,
+	.perform-action-scheduler__storage,
+	.perform-action-scheduler__grids {
+		flex-direction: column;
+	}
+
+	.perform-action-scheduler__actions,
+	.perform-action-scheduler__actions .components-button,
+	.perform-action-scheduler__grids > .components-card,
+	.perform-action-scheduler__storage > div {
+		width: 100%;
+	}
+
+	.perform-action-scheduler__actions .components-button {
+		justify-content: center;
+	}
+
+	.perform-action-scheduler__summary {
+		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.perform-action-scheduler__summary > div,
+	.perform-action-scheduler__storage > div {
+		box-sizing: border-box;
+		border-right: 0;
+		border-bottom: 1px solid var(--perform-color-border);
+	}
+
+	.perform-action-scheduler__summary > div:last-child,
+	.perform-action-scheduler__storage > div:last-child {
+		border-bottom: 0;
+	}
+}
+
 @media (prefers-reduced-motion: reduce) {
 
 	.perform-settings-page *,

--- a/assets/src/js/admin/ActionSchedulerPanel.jsx
+++ b/assets/src/js/admin/ActionSchedulerPanel.jsx
@@ -1,0 +1,274 @@
+import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const SETTINGS = window.performwpSettings || {};
+
+const formatAge = ( seconds ) => {
+	if ( seconds < 3600 ) {
+		return __( 'Less than one hour', 'perform' );
+	}
+	if ( seconds < 86400 ) {
+		return `${ Math.floor( seconds / 3600 ) } ${ __( 'hours', 'perform' ) }`;
+	}
+	return `${ Math.floor( seconds / 86400 ) } ${ __( 'days', 'perform' ) }`;
+};
+
+const CountTable = ( { title, description, items, emptyLabel } ) => (
+	<Card>
+		<CardHeader>
+			<div>
+				<h3 className="perform-card-title">{ title }</h3>
+				<p className="perform-card-description">{ description }</p>
+			</div>
+		</CardHeader>
+		<CardBody>
+			<div className="perform-action-scheduler__table-wrap">
+				<table>
+					<thead>
+						<tr>
+							<th scope="col">{ __( 'Name', 'perform' ) }</th>
+							<th scope="col">{ __( 'Actions', 'perform' ) }</th>
+						</tr>
+					</thead>
+					<tbody>
+						{ 0 === items.length && (
+							<tr>
+								<td colSpan="2">{ emptyLabel }</td>
+							</tr>
+						) }
+						{ items.map( ( item ) => (
+							<tr key={ item.name }>
+								<th scope="row">
+									<code>{ item.name }</code>
+								</th>
+								<td>{ item.count }</td>
+							</tr>
+						) ) }
+					</tbody>
+				</table>
+			</div>
+		</CardBody>
+	</Card>
+);
+
+const ActionSchedulerPanel = ( { initialAudit = SETTINGS.actionScheduler || {} } ) => {
+	const [ audit, setAudit ] = useState( initialAudit );
+	const [ working, setWorking ] = useState( '' );
+	const [ message, setMessage ] = useState( null );
+	const hasAudit = [ 'ready', 'not-available' ].includes( audit.status );
+	const isReady = 'ready' === audit.status;
+	const counts = audit.counts || {};
+	const storage = audit.storage || {};
+	let refreshLabel = hasAudit ? __( 'Refresh check', 'perform' ) : __( 'Run check', 'perform' );
+	if ( 'refresh' === working ) {
+		refreshLabel = __( 'Checking queue…', 'perform' );
+	}
+
+	const request = async ( action ) => {
+		const isClear = 'perform_clear_action_scheduler_audit' === action;
+		setWorking( isClear ? 'clear' : 'refresh' );
+		setMessage( {
+			type: 'status',
+			text: isClear
+				? __( 'Clearing the saved diagnostic…', 'perform' )
+				: __( 'Checking the Action Scheduler queue…', 'perform' ),
+		} );
+		try {
+			const response = await fetch( window.ajaxurl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+				},
+				body: new URLSearchParams( {
+					action,
+					nonce: SETTINGS.actionSchedulerNonce || '',
+				} ),
+			} );
+			const result = await response.json();
+			if ( ! response.ok || ! result?.success || ! result.data?.audit ) {
+				throw new Error(
+					result?.data?.message || __( 'The Action Scheduler diagnostic could not be updated.', 'perform' )
+				);
+			}
+			setAudit( result.data.audit );
+			setMessage( { type: 'success', text: result.data.message } );
+		} catch ( error ) {
+			setMessage( {
+				type: 'error',
+				text: error?.message || __( 'The Action Scheduler diagnostic could not be updated.', 'perform' ),
+			} );
+		} finally {
+			setWorking( '' );
+		}
+	};
+
+	const clearAudit = () => {
+		if (
+			// eslint-disable-next-line no-alert -- Clearing the saved aggregate requires explicit administrator confirmation.
+			window.confirm(
+				__( 'Clear the saved Action Scheduler diagnostic? No queued actions will be changed.', 'perform' )
+			)
+		) {
+			request( 'perform_clear_action_scheduler_audit' );
+		}
+	};
+
+	return (
+		<div className="perform-action-scheduler">
+			<div className="perform-action-scheduler__heading">
+				<div>
+					<p className="perform-dashboard-eyebrow">{ __( 'Background queues', 'perform' ) }</p>
+					<h2>{ __( 'Action Scheduler', 'perform' ) }</h2>
+					<p>
+						{ __(
+							'Review queue pressure used by commerce and other extensions without reading action arguments or changing queued work.',
+							'perform'
+						) }
+					</p>
+				</div>
+				<div className="perform-action-scheduler__actions">
+					<Button
+						variant="primary"
+						onClick={ () => request( 'perform_refresh_action_scheduler_audit' ) }
+						disabled={ Boolean( working ) }
+						isBusy={ 'refresh' === working }
+					>
+						{ refreshLabel }
+					</Button>
+					{ hasAudit && (
+						<Button variant="tertiary" onClick={ clearAudit } disabled={ Boolean( working ) }>
+							{ 'clear' === working ? __( 'Clearing…', 'perform' ) : __( 'Clear snapshot', 'perform' ) }
+						</Button>
+					) }
+				</div>
+			</div>
+
+			<div className="perform-action-scheduler__privacy">
+				<strong>{ __( 'Read-only and private', 'perform' ) }</strong>
+				<p>
+					{ __(
+						'Perform stores aggregate queue counts for one hour. It does not read action arguments, payloads, or log messages, and it never runs, cancels, or deletes queued work.',
+						'perform'
+					) }
+				</p>
+			</div>
+			{ message && (
+				<div
+					className={ `perform-action-scheduler__message is-${ message.type }` }
+					role={ 'error' === message.type ? 'alert' : 'status' }
+					aria-live="polite"
+				>
+					{ message.text }
+				</div>
+			) }
+
+			{ ! hasAudit && (
+				<Card>
+					<CardBody>
+						<h3>{ __( 'Run the first queue check', 'perform' ) }</h3>
+						<p>
+							{ __(
+								'The check starts only when requested and saves aggregate counts for this site.',
+								'perform'
+							) }
+						</p>
+					</CardBody>
+				</Card>
+			) }
+			{ 'not-available' === audit.status && (
+				<Card>
+					<CardBody>
+						<h3>{ __( 'Action Scheduler is not available', 'perform' ) }</h3>
+						<p>
+							{ __(
+								'No Action Scheduler actions table was found for this site. There is no queue to inspect.',
+								'perform'
+							) }
+						</p>
+					</CardBody>
+				</Card>
+			) }
+
+			{ isReady && (
+				<>
+					<div
+						className="perform-action-scheduler__summary"
+						aria-label={ __( 'Action Scheduler queue summary', 'perform' ) }
+					>
+						<div>
+							<span>{ __( 'Pending', 'perform' ) }</span>
+							<strong>{ counts.pending || 0 }</strong>
+						</div>
+						<div>
+							<span>{ __( 'Running', 'perform' ) }</span>
+							<strong>{ counts.running || 0 }</strong>
+						</div>
+						<div>
+							<span>{ __( 'Failed', 'perform' ) }</span>
+							<strong>{ counts.failed || 0 }</strong>
+						</div>
+						<div>
+							<span>{ __( 'Complete', 'perform' ) }</span>
+							<strong>{ counts.complete || 0 }</strong>
+						</div>
+						<div>
+							<span>{ __( 'Canceled', 'perform' ) }</span>
+							<strong>{ counts.canceled || 0 }</strong>
+						</div>
+					</div>
+					<div className="perform-action-scheduler__storage">
+						<div>
+							<span>{ __( 'Oldest pending action', 'perform' ) }</span>
+							<strong>
+								{ audit.oldestPending?.available
+									? formatAge( audit.oldestPending.ageSeconds || 0 )
+									: __( 'None pending', 'perform' ) }
+							</strong>
+						</div>
+						<div>
+							<span>{ __( 'Stored actions', 'perform' ) }</span>
+							<strong>{ storage.actionCount || 0 }</strong>
+						</div>
+						<div>
+							<span>{ __( 'Stored log rows', 'perform' ) }</span>
+							<strong>
+								{ null === storage.logCount || undefined === storage.logCount
+									? __( 'Not available', 'perform' )
+									: storage.logCount }
+							</strong>
+						</div>
+					</div>
+					<p className="perform-action-scheduler__guidance">
+						{ __(
+							'Counts describe the current queue, not whether a hook is harmful. Compare repeated snapshots and consult the responsible extension before changing retention or runner settings.',
+							'perform'
+						) }
+					</p>
+					<p className="perform-action-scheduler__limitation">
+						{ __(
+							'Failed-action trend is not shown because deriving it reliably would require reading or interpreting private log messages.',
+							'perform'
+						) }
+					</p>
+					<div className="perform-action-scheduler__grids">
+						<CountTable
+							title={ __( 'Largest hooks', 'perform' ) }
+							description={ __( 'Aggregate counts only; action arguments are never read.', 'perform' ) }
+							items={ audit.topHooks || [] }
+							emptyLabel={ __( 'No hook counts were returned.', 'perform' ) }
+						/>
+						<CountTable
+							title={ __( 'Largest groups', 'perform' ) }
+							description={ __( 'Group names and aggregate counts only.', 'perform' ) }
+							items={ audit.topGroups || [] }
+							emptyLabel={ __( 'No group counts were returned.', 'perform' ) }
+						/>
+					</div>
+				</>
+			) }
+		</div>
+	);
+};
+
+export default ActionSchedulerPanel;

--- a/assets/src/js/admin/ActionSchedulerPanel.test.jsx
+++ b/assets/src/js/admin/ActionSchedulerPanel.test.jsx
@@ -1,0 +1,55 @@
+/* eslint-env jest */
+
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import ActionSchedulerPanel from './ActionSchedulerPanel';
+
+describe( 'ActionSchedulerPanel', () => {
+	beforeEach( () => {
+		window.performwpSettings = { actionSchedulerNonce: 'nonce' };
+		window.ajaxurl = '/wp-admin/admin-ajax.php';
+		window.confirm = jest.fn( () => true );
+	} );
+
+	it( 'handles an absent Action Scheduler installation cleanly', () => {
+		render( <ActionSchedulerPanel initialAudit={ { status: 'not-available' } } /> );
+		expect( screen.getByText( 'Action Scheduler is not available' ) ).toBeInTheDocument();
+		expect( screen.getByText( /never runs, cancels, or deletes/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows queue counts and bounded hook evidence without cleanup actions', () => {
+		render(
+			<ActionSchedulerPanel
+				initialAudit={ {
+					status: 'ready',
+					counts: { pending: 12, failed: 4 },
+					oldestPending: { available: true, ageSeconds: 7200 },
+					storage: { actionCount: 40, logCount: 90 },
+					topHooks: [ { name: 'safe_hook', count: 12 } ],
+					topGroups: [],
+				} }
+			/>
+		);
+		expect( screen.getByText( 'safe_hook' ) ).toBeInTheDocument();
+		expect( screen.getByText( '2 hours' ) ).toBeInTheDocument();
+		expect( screen.getByText( /Failed-action trend is not shown/ ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /delete|cleanup|cancel/i } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'surfaces refresh failures and restores actions', async () => {
+		global.fetch = jest.fn( () =>
+			Promise.resolve( {
+				ok: false,
+				json: () =>
+					Promise.resolve( {
+						success: false,
+						data: { message: 'Synthetic failure' },
+					} ),
+			} )
+		);
+		render( <ActionSchedulerPanel initialAudit={ { status: 'not-run' } } /> );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Run check' } ) );
+		await waitFor( () => expect( screen.getByRole( 'alert' ) ).toHaveTextContent( 'Synthetic failure' ) );
+		expect( screen.getByRole( 'button', { name: 'Run check' } ) ).toBeEnabled();
+	} );
+} );

--- a/assets/src/js/admin/SettingsApp.jsx
+++ b/assets/src/js/admin/SettingsApp.jsx
@@ -17,6 +17,7 @@ const ADMIN_PERFORMANCE = SETTINGS.adminPerformance || {};
 const CRON_PRESSURE = SETTINGS.cronPressure || {};
 const ADMIN_ASSET_AUDIT = SETTINGS.adminAssetAudit || {};
 const PLUGIN_IMPACT = SETTINGS.pluginImpact || {};
+const ACTION_SCHEDULER = SETTINGS.actionScheduler || {};
 const TAB_KEYS = [ 'dashboard', ...Object.keys( SETTINGS_TABS ) ];
 
 const normalizeTab = ( tab ) => ( TAB_KEYS.includes( tab ) ? tab : 'dashboard' );
@@ -187,6 +188,7 @@ const SettingsApp = () => {
 				cronPressure={ CRON_PRESSURE }
 				adminAssetAudit={ ADMIN_ASSET_AUDIT }
 				pluginImpact={ PLUGIN_IMPACT }
+				actionScheduler={ ACTION_SCHEDULER }
 				activeTab={ activeTab }
 				onTabChange={ handleTabChange }
 				fieldValues={ fieldValues }
@@ -202,6 +204,7 @@ const SettingsApp = () => {
 				'scheduled-tasks',
 				'admin-assets',
 				'plugin-impact',
+				'action-scheduler',
 			].includes( activeTab ) && (
 				<Footer dirty={ isDirty } saving={ saving } message={ message } onSave={ handleSave } />
 			) }

--- a/assets/src/js/admin/SettingsNav.jsx
+++ b/assets/src/js/admin/SettingsNav.jsx
@@ -8,6 +8,7 @@ import SiteInventoryPanel from './SiteInventoryPanel';
 import CronPressurePanel from './CronPressurePanel';
 import AdminAssetAuditPanel from './AdminAssetAuditPanel';
 import PluginImpactPanel from './PluginImpactPanel';
+import ActionSchedulerPanel from './ActionSchedulerPanel';
 import SettingsFieldRow from './settings/SettingsFieldRow';
 
 const SETTINGS = window.performwpSettings || {};
@@ -24,6 +25,7 @@ const SettingsNav = ( {
 	cronPressure,
 	adminAssetAudit,
 	pluginImpact,
+	actionScheduler,
 	activeTab: propActiveTab,
 	onTabChange: propOnTabChange,
 	fieldValues: propFieldValues,
@@ -140,6 +142,8 @@ const SettingsNav = ( {
 						);
 					} else if ( 'plugin-impact' === selectedTabName ) {
 						content = <PluginImpactPanel report={ pluginImpact } onNavigate={ onTabChange } />;
+					} else if ( 'action-scheduler' === selectedTabName ) {
+						content = <ActionSchedulerPanel initialAudit={ actionScheduler } />;
 					} else if ( 'cache-stats' === selectedTabName ) {
 						content = <CacheStatsPanel />;
 					}

--- a/docs/action-scheduler-diagnostic.md
+++ b/docs/action-scheduler-diagnostic.md
@@ -1,0 +1,7 @@
+# Action Scheduler diagnostic
+
+The Action Scheduler diagnostic is a manual, read-only current-site snapshot. It reports aggregate action status counts, the age of the oldest pending action, the largest hook and group counts, and action/log row counts when the corresponding tables are available.
+
+The diagnostic never reads action arguments, payloads, or log messages. It does not run, cancel, delete, reschedule, or clean queue entries. A missing Action Scheduler table is reported as a normal unavailable state.
+
+Results are bounded to 20 hook and group aggregates and cached for one hour. Any future cleanup workflow must be specified separately with preview, confirmation, recovery, and optimization-history contracts.

--- a/languages/perform.pot
+++ b/languages/perform.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: PerformWP <hello@performwp.com>\n"
-"POT-Creation-Date: 2026-08-11 05:00+0000\n"
+"POT-Creation-Date: 2026-08-11 05:16+0000\n"
 "Report-Msgid-Bugs-To: https://github.com/performwp/perform/issues/new\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
@@ -16,63 +16,63 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/Admin/Actions.php:102
+#: src/Admin/Actions.php:105
 msgid "Activity actions"
 msgstr ""
 
-#: src/Admin/Actions.php:103
+#: src/Admin/Actions.php:106
 msgid "Export cache activity for review or clear the collected metrics."
 msgstr ""
 
-#: src/Admin/Actions.php:104
+#: src/Admin/Actions.php:107
 msgid "Export CSV"
 msgstr ""
 
-#: src/Admin/Actions.php:105
+#: src/Admin/Actions.php:108
 msgid "Exporting…"
 msgstr ""
 
-#: src/Admin/Actions.php:106
+#: src/Admin/Actions.php:109
 msgid "Cache activity exported."
 msgstr ""
 
-#: src/Admin/Actions.php:107
+#: src/Admin/Actions.php:110
 msgid "Cache activity could not be exported."
 msgstr ""
 
-#: src/Admin/Actions.php:108
+#: src/Admin/Actions.php:111
 msgid "Clear activity"
 msgstr ""
 
-#: src/Admin/Actions.php:109
+#: src/Admin/Actions.php:112
 msgid "Clearing…"
 msgstr ""
 
-#: src/Admin/Actions.php:110
+#: src/Admin/Actions.php:113
 msgid "Clear all collected cache activity? This does not clear cached pages."
 msgstr ""
 
-#: src/Admin/Actions.php:111, src/Modules/Cache/PageCache.php:828, src/Modules/Cache/PageCache.php:1090
+#: src/Admin/Actions.php:114, src/Modules/Cache/PageCache.php:828, src/Modules/Cache/PageCache.php:1090
 msgid "Cache activity cleared."
 msgstr ""
 
-#: src/Admin/Actions.php:112
+#: src/Admin/Actions.php:115
 msgid "Cache activity could not be cleared."
 msgstr ""
 
-#: src/Admin/Actions.php:141
+#: src/Admin/Actions.php:144
 msgid "Close Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:138, src/Modules/Assets/AssetsManager.php:274
+#: src/Admin/Actions.php:141, src/Modules/Assets/AssetsManager.php:274
 msgid "Assets Manager"
 msgstr ""
 
-#: src/Admin/Actions.php:148, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:254
+#: src/Admin/Actions.php:151, src/Admin/Settings/Menu.php:40, src/Admin/Settings/Menu.php:41, src/Modules/Assets/AssetsManager.php:254
 msgid "Perform"
 msgstr ""
 
-#: src/Admin/Actions.php:168
+#: src/Admin/Actions.php:171
 msgid "Support Forum"
 msgstr ""
 
@@ -696,12 +696,40 @@ msgstr ""
 msgid "Enabling this will cache WooCommerce pages for better performance."
 msgstr ""
 
-#: src/Admin/Settings/AdminAssetAuditController.php:24
-msgid "You are not allowed to clear admin asset audit data."
+#: src/Admin/Settings/ActionSchedulerAudit.php:53
+msgid "The database is unavailable."
 msgstr ""
 
-#: src/Admin/Settings/AdminAssetAuditController.php:29, src/Admin/Settings/AdminPerformanceMonitorController.php:36, src/Admin/Settings/AutoloadOptionsAuditController.php:48, src/Admin/Settings/CronPressureAuditController.php:84, src/Admin/Settings/Menu.php:126
+#: src/Admin/Settings/ActionSchedulerAudit.php:104
+msgid "The Action Scheduler diagnostic could not be completed."
+msgstr ""
+
+#: src/Admin/Settings/ActionSchedulerAudit.php:281
+msgid "The Action Scheduler diagnostic could not be saved."
+msgstr ""
+
+#: src/Admin/Settings/ActionSchedulerAuditController.php:31
+msgid "The Action Scheduler diagnostic could not be refreshed. Please try again."
+msgstr ""
+
+#: src/Admin/Settings/ActionSchedulerAuditController.php:35
+msgid "Action Scheduler diagnostic refreshed."
+msgstr ""
+
+#: src/Admin/Settings/ActionSchedulerAuditController.php:47
+msgid "Action Scheduler diagnostic cleared."
+msgstr ""
+
+#: src/Admin/Settings/ActionSchedulerAuditController.php:56, src/Admin/Settings/AutoloadOptionsAuditController.php:38, src/Admin/Settings/CronPressureAuditController.php:79, src/Admin/Settings/Menu.php:116, src/Admin/Settings/SiteInventoryController.php:59
+msgid "Insufficient permissions."
+msgstr ""
+
+#: src/Admin/Settings/ActionSchedulerAuditController.php:60, src/Admin/Settings/AdminAssetAuditController.php:29, src/Admin/Settings/AdminPerformanceMonitorController.php:36, src/Admin/Settings/AutoloadOptionsAuditController.php:48, src/Admin/Settings/CronPressureAuditController.php:84, src/Admin/Settings/Menu.php:127
 msgid "Security check failed."
+msgstr ""
+
+#: src/Admin/Settings/AdminAssetAuditController.php:24
+msgid "You are not allowed to clear admin asset audit data."
 msgstr ""
 
 #: src/Admin/Settings/AdminAssetAuditController.php:35
@@ -742,10 +770,6 @@ msgstr ""
 
 #: src/Admin/Settings/AutoloadOptionsAudit.php:180
 msgid "Unknown"
-msgstr ""
-
-#: src/Admin/Settings/AutoloadOptionsAuditController.php:38, src/Admin/Settings/CronPressureAuditController.php:79, src/Admin/Settings/Menu.php:115, src/Admin/Settings/SiteInventoryController.php:59
-msgid "Insufficient permissions."
 msgstr ""
 
 #: src/Admin/Settings/AutoloadOptionsAuditController.php:59
@@ -849,14 +873,18 @@ msgid "Scheduled Tasks"
 msgstr ""
 
 #: src/Admin/Settings/Menu.php:61
+msgid "Action Scheduler"
+msgstr ""
+
+#: src/Admin/Settings/Menu.php:62
 msgid "Cache Stats"
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:242
+#: src/Admin/Settings/Menu.php:243
 msgid "Unable to save the settings. Please try again."
 msgstr ""
 
-#: src/Admin/Settings/Menu.php:234
+#: src/Admin/Settings/Menu.php:235
 msgid "Settings saved successfully."
 msgstr ""
 

--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -22,6 +22,7 @@ use Perform\Admin\Settings\SiteInventory;
 use Perform\Admin\Settings\SystemHealth;
 use Perform\Admin\Settings\CronPressureAudit;
 use Perform\Admin\Settings\PluginImpactReport;
+use Perform\Admin\Settings\ActionSchedulerAudit;
 
 // Bailout, if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -88,6 +89,8 @@ class Actions {
 					'systemHealth'         => SystemHealth::get_data(),
 					'cronPressure'         => CronPressureAudit::get_cached_snapshot(),
 					'cronPressureNonce'    => wp_create_nonce( 'perform_cron_pressure_audit' ),
+					'actionScheduler'      => ActionSchedulerAudit::get_cached_snapshot(),
+					'actionSchedulerNonce' => wp_create_nonce( 'perform_action_scheduler_audit' ),
 					'restNonce'            => wp_create_nonce( 'wp_rest' ),
 					'sensitiveKeys'        => ClientPayload::get_sensitive_keys(),
 					'maskedSecretValue'    => ClientPayload::MASKED_SECRET,

--- a/src/Admin/Settings/ActionSchedulerAudit.php
+++ b/src/Admin/Settings/ActionSchedulerAudit.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * Perform - Action Scheduler diagnostics.
+ *
+ * @package Perform
+ * @subpackage Admin/Settings
+ */
+
+namespace Perform\Admin\Settings;
+
+use RuntimeException;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Collects a bounded, read-only Action Scheduler queue snapshot.
+ */
+final class ActionSchedulerAudit {
+	const OPTION_NAME    = 'perform_action_scheduler_audit';
+	const SCHEMA_VERSION = 1;
+	const CACHE_TTL      = 3600;
+	const RESULT_LIMIT   = 20;
+
+	/**
+	 * Return the saved snapshot without querying Action Scheduler tables.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function get_cached_snapshot() {
+		$snapshot = get_option( self::OPTION_NAME, [] );
+
+		if ( ! is_array( $snapshot ) || self::SCHEMA_VERSION !== (int) ( $snapshot['schemaVersion'] ?? 0 ) ) {
+			return self::get_empty_snapshot();
+		}
+
+		$snapshot['isStale'] = time() >= (int) ( $snapshot['expiresAt'] ?? 0 );
+
+		return $snapshot;
+	}
+
+	/**
+	 * Run and save a fresh aggregate snapshot for the current site.
+	 *
+	 * @return array<string, mixed>
+	 * @throws RuntimeException When the database cannot provide a safe snapshot.
+	 */
+	public static function refresh() {
+		global $wpdb;
+
+		if ( ! is_object( $wpdb ) || empty( $wpdb->prefix ) ) {
+			throw new RuntimeException( __( 'The database is unavailable.', 'perform' ) );
+		}
+
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$groups_table  = $wpdb->prefix . 'actionscheduler_groups';
+		$logs_table    = $wpdb->prefix . 'actionscheduler_logs';
+		$has_actions   = self::table_exists( $wpdb, $actions_table );
+		$has_groups    = self::table_exists( $wpdb, $groups_table );
+		$has_logs      = self::table_exists( $wpdb, $logs_table );
+
+		if ( ! $has_actions ) {
+			return self::persist( self::get_unavailable_snapshot() );
+		}
+
+		// Table names are derived from the current wpdb prefix. Dynamic status
+		// values and limits are passed through prepare below.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$status_query = $wpdb->prepare(
+			"SELECT status, COUNT(*) AS action_count FROM {$actions_table} WHERE status IN (%s, %s, %s, %s, %s) GROUP BY status",
+			[ 'pending', 'in-progress', 'complete', 'failed', 'canceled' ]
+		);
+		$status_rows  = $wpdb->get_results( $status_query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Read-only aggregate persisted below.
+
+		$oldest_query   = $wpdb->prepare(
+			"SELECT MIN(scheduled_date_gmt) FROM {$actions_table} WHERE status = %s",
+			'pending'
+		);
+		$oldest_pending = $wpdb->get_var( $oldest_query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Read-only aggregate persisted below.
+
+		$hooks_query = $wpdb->prepare(
+			"SELECT hook, COUNT(*) AS action_count FROM {$actions_table} GROUP BY hook ORDER BY action_count DESC, hook ASC LIMIT %d",
+			self::RESULT_LIMIT
+		);
+		$hook_rows   = $wpdb->get_results( $hooks_query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded aggregate persisted below.
+
+		$group_rows = [];
+		if ( $has_groups ) {
+			$groups_query = $wpdb->prepare(
+				"SELECT action_group.slug AS group_name, COUNT(*) AS action_count FROM {$actions_table} action_queue INNER JOIN {$groups_table} action_group ON action_group.group_id = action_queue.group_id GROUP BY action_group.slug ORDER BY action_count DESC, action_group.slug ASC LIMIT %d",
+				self::RESULT_LIMIT
+			);
+			$group_rows   = $wpdb->get_results( $groups_query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded aggregate persisted below.
+		}
+
+		$log_count = null;
+		if ( $has_logs ) {
+			$log_count = $wpdb->get_var( "SELECT COUNT(*) FROM {$logs_table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- wpdb-prefix table; count only, no log messages read.
+		}
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		if ( ! is_array( $status_rows ) || ! is_array( $hook_rows ) || ! is_array( $group_rows ) || ! empty( $wpdb->last_error ) ) {
+			throw new RuntimeException( __( 'The Action Scheduler diagnostic could not be completed.', 'perform' ) );
+		}
+
+		$counts = [
+			'pending'  => 0,
+			'running'  => 0,
+			'complete' => 0,
+			'failed'   => 0,
+			'canceled' => 0,
+		];
+		foreach ( $status_rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$status = sanitize_key( (string) ( $row['status'] ?? '' ) );
+			$key    = 'in-progress' === $status ? 'running' : $status;
+			if ( array_key_exists( $key, $counts ) ) {
+				$counts[ $key ] = max( 0, (int) ( $row['action_count'] ?? 0 ) );
+			}
+		}
+
+		$generated_at = time();
+		$snapshot     = [
+			'schemaVersion' => self::SCHEMA_VERSION,
+			'status'        => 'ready',
+			'generatedAt'   => $generated_at,
+			'expiresAt'     => $generated_at + self::CACHE_TTL,
+			'isStale'       => false,
+			'isMultisite'   => is_multisite(),
+			'siteId'        => get_current_blog_id(),
+			'counts'        => $counts,
+			'oldestPending' => self::normalize_oldest_pending( $oldest_pending, $generated_at ),
+			'topHooks'      => self::normalize_counts( $hook_rows, 'hook' ),
+			'topGroups'     => self::normalize_counts( $group_rows, 'group_name' ),
+			'storage'       => [
+				'actionCount' => array_sum( $counts ),
+				'logCount'    => null === $log_count ? null : max( 0, (int) $log_count ),
+				'logsPresent' => $has_logs,
+			],
+			'failedTrend'   => [
+				'state'  => 'not-available',
+				'reason' => 'requires-log-message-inference',
+			],
+			'limits'        => [ 'resultLimit' => self::RESULT_LIMIT ],
+			'privacy'       => [
+				'argumentsRead'   => false,
+				'logMessagesRead' => false,
+			],
+		];
+
+		return self::persist( $snapshot );
+	}
+
+	/**
+	 * Delete only Perform's saved aggregate.
+	 *
+	 * @return void
+	 */
+	public static function clear() {
+		delete_option( self::OPTION_NAME );
+	}
+
+	/**
+	 * @param object $wpdb WordPress database object.
+	 * @param string $table Table name.
+	 * @return bool
+	 */
+	private static function table_exists( $wpdb, $table ) {
+		$query = $wpdb->prepare( 'SHOW TABLES LIKE %s', $table );
+		return $table === $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Feature detection only.
+	}
+
+	/**
+	 * @param mixed $value Oldest pending GMT value.
+	 * @param int $now Current timestamp.
+	 * @return array<string, mixed>
+	 */
+	private static function normalize_oldest_pending( $value, $now ) {
+		$timestamp = is_scalar( $value ) ? strtotime( (string) $value . ' UTC' ) : false;
+		return [
+			'available'  => false !== $timestamp,
+			'timestamp'  => false === $timestamp ? 0 : $timestamp,
+			'ageSeconds' => false === $timestamp ? 0 : max( 0, $now - $timestamp ),
+		];
+	}
+
+	/**
+	 * @param array<int, mixed> $rows Aggregate rows.
+	 * @param string $name_key Name field.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function normalize_counts( array $rows, $name_key ) {
+		$items = [];
+		foreach ( array_slice( $rows, 0, self::RESULT_LIMIT ) as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$raw_name = is_scalar( $row[ $name_key ] ?? null ) ? (string) $row[ $name_key ] : '';
+			$name     = sanitize_key( $raw_name );
+			if ( '' === $name || $name !== $raw_name ) {
+				continue;
+			}
+			$items[] = [
+				'name'  => substr( $name, 0, 191 ),
+				'count' => max( 0, (int) ( $row['action_count'] ?? 0 ) ),
+			];
+		}
+		return $items;
+	}
+
+	/** @return array<string, mixed> */
+	private static function get_empty_snapshot() {
+		return self::base_snapshot( 'not-run', false );
+	}
+
+	/** @return array<string, mixed> */
+	private static function get_unavailable_snapshot() {
+		return self::base_snapshot( 'not-available', false );
+	}
+
+	/**
+	 * @param string $status Snapshot status.
+	 * @param bool $is_stale Stale flag.
+	 * @return array<string, mixed>
+	 */
+	private static function base_snapshot( $status, $is_stale ) {
+		return [
+			'schemaVersion' => self::SCHEMA_VERSION,
+			'status'        => $status,
+			'generatedAt'   => 0,
+			'expiresAt'     => 0,
+			'isStale'       => $is_stale,
+			'isMultisite'   => is_multisite(),
+			'siteId'        => get_current_blog_id(),
+			'counts'        => [
+				'pending'  => 0,
+				'running'  => 0,
+				'complete' => 0,
+				'failed'   => 0,
+				'canceled' => 0,
+			],
+			'oldestPending' => [
+				'available'  => false,
+				'timestamp'  => 0,
+				'ageSeconds' => 0,
+			],
+			'topHooks'      => [],
+			'topGroups'     => [],
+			'storage'       => [
+				'actionCount' => 0,
+				'logCount'    => null,
+				'logsPresent' => false,
+			],
+			'failedTrend'   => [
+				'state'  => 'not-available',
+				'reason' => 'requires-log-message-inference',
+			],
+			'limits'        => [ 'resultLimit' => self::RESULT_LIMIT ],
+			'privacy'       => [
+				'argumentsRead'   => false,
+				'logMessagesRead' => false,
+			],
+		];
+	}
+
+	/**
+	 * @param array<string, mixed> $snapshot Snapshot.
+	 * @return array<string, mixed>
+	 * @throws RuntimeException When persistence fails.
+	 */
+	private static function persist( array $snapshot ) {
+		$generated_at            = time();
+		$snapshot['generatedAt'] = $generated_at;
+		$snapshot['expiresAt']   = $generated_at + self::CACHE_TTL;
+		$snapshot['isStale']     = false;
+		$is_saved                = update_option( self::OPTION_NAME, $snapshot, false );
+		if ( ! $is_saved && get_option( self::OPTION_NAME ) !== $snapshot ) {
+			throw new RuntimeException( __( 'The Action Scheduler diagnostic could not be saved.', 'perform' ) );
+		}
+		return $snapshot;
+	}
+}

--- a/src/Admin/Settings/ActionSchedulerAuditController.php
+++ b/src/Admin/Settings/ActionSchedulerAuditController.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Perform - Action Scheduler diagnostic controller.
+ *
+ * @package Perform
+ * @subpackage Admin/Settings
+ */
+
+namespace Perform\Admin\Settings;
+
+use Throwable;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Handles authorized refresh and reset requests. */
+final class ActionSchedulerAuditController {
+	/** Register WordPress hooks. */
+	public function __construct() {
+		add_action( 'wp_ajax_perform_refresh_action_scheduler_audit', [ $this, 'refresh' ] );
+		add_action( 'wp_ajax_perform_clear_action_scheduler_audit', [ $this, 'clear' ] );
+	}
+
+	/** @return void */
+	public function refresh() {
+		$this->authorize();
+		try {
+			$audit = ActionSchedulerAudit::refresh();
+		} catch ( Throwable $exception ) {
+			wp_send_json_error( [ 'message' => esc_html__( 'The Action Scheduler diagnostic could not be refreshed. Please try again.', 'perform' ) ], 500 );
+		}
+		wp_send_json_success(
+			[
+				'message' => esc_html__( 'Action Scheduler diagnostic refreshed.', 'perform' ),
+				'audit'   => $audit,
+			]
+		);
+	}
+
+	/** @return void */
+	public function clear() {
+		$this->authorize();
+		ActionSchedulerAudit::clear();
+		wp_send_json_success(
+			[
+				'message' => esc_html__( 'Action Scheduler diagnostic cleared.', 'perform' ),
+				'audit'   => ActionSchedulerAudit::get_cached_snapshot(),
+			]
+		);
+	}
+
+	/** @return void */
+	private function authorize() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( [ 'message' => esc_html__( 'Insufficient permissions.', 'perform' ) ], 403 );
+		}
+		$nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['nonce'] ) ) : '';
+		if ( ! wp_verify_nonce( $nonce, 'perform_action_scheduler_audit' ) ) {
+			wp_send_json_error( [ 'message' => esc_html__( 'Security check failed.', 'perform' ) ], 403 );
+		}
+	}
+}

--- a/src/Admin/Settings/Menu.php
+++ b/src/Admin/Settings/Menu.php
@@ -51,14 +51,15 @@ class Menu {
 	 * @return array<string, string>
 	 */
 	public static function get_navigation_tabs() {
-		$tabs                    = Helpers::get_settings_tabs();
-		$tabs['inventory']       = esc_html__( 'Site Inventory', 'perform' );
-		$tabs['database']        = esc_html__( 'Database', 'perform' );
-		$tabs['admin-monitor']   = esc_html__( 'Admin Monitor', 'perform' );
-		$tabs['admin-assets']    = esc_html__( 'Admin Assets', 'perform' );
-		$tabs['plugin-impact']   = esc_html__( 'Plugin Impact', 'perform' );
-		$tabs['scheduled-tasks'] = esc_html__( 'Scheduled Tasks', 'perform' );
-		$tabs['cache-stats']     = esc_html__( 'Cache Stats', 'perform' );
+		$tabs                     = Helpers::get_settings_tabs();
+		$tabs['inventory']        = esc_html__( 'Site Inventory', 'perform' );
+		$tabs['database']         = esc_html__( 'Database', 'perform' );
+		$tabs['admin-monitor']    = esc_html__( 'Admin Monitor', 'perform' );
+		$tabs['admin-assets']     = esc_html__( 'Admin Assets', 'perform' );
+		$tabs['plugin-impact']    = esc_html__( 'Plugin Impact', 'perform' );
+		$tabs['scheduled-tasks']  = esc_html__( 'Scheduled Tasks', 'perform' );
+		$tabs['action-scheduler'] = esc_html__( 'Action Scheduler', 'perform' );
+		$tabs['cache-stats']      = esc_html__( 'Cache Stats', 'perform' );
 
 		return $tabs;
 	}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -57,6 +57,7 @@ final class Plugin {
 		new Settings\AdminPerformanceMonitorController();
 		new Settings\AdminAssetAuditController();
 		new Settings\CronPressureAuditController();
+		new Settings\ActionSchedulerAuditController();
 		new Admin\Actions();
 		new Admin\Filters();
 

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -177,6 +177,32 @@ test( 'Scheduled-task pressure is bounded, private, resettable, and responsive',
 	await expect( page.getByRole( 'button', { name: 'Run check' } ) ).toBeVisible();
 } );
 
+test( 'Action Scheduler diagnostic handles an absent queue without mutation', async ( { page } ) => {
+	await login( page );
+	await openAdminPage( page, '/wp-admin/options-general.php?page=perform_settings&tab=action-scheduler' );
+
+	await expect( page.getByRole( 'tab', { name: 'Action Scheduler' } ) ).toHaveAttribute( 'aria-selected', 'true' );
+	await expect( page.getByText( 'Read-only and private' ) ).toBeVisible();
+	await expect( page.getByText( /never runs, cancels, or deletes queued work/ ) ).toBeVisible();
+	await page.getByRole( 'button', { name: /Run check|Refresh check/ } ).click();
+	await expect( page.getByRole( 'status' ) ).toContainText( 'Action Scheduler diagnostic refreshed.' );
+	await expect( page.getByRole( 'heading', { name: 'Action Scheduler is not available' } ) ).toBeVisible();
+	await expect( page.getByRole( 'button', { name: 'Save Settings' } ) ).toHaveCount( 0 );
+
+	await mkdir( 'test-results/proof', { recursive: true } );
+	await page.screenshot( { path: 'test-results/proof/action-scheduler-desktop.png', fullPage: true } );
+	await page.setViewportSize( { width: 390, height: 844 } );
+	await page.screenshot( { path: 'test-results/proof/action-scheduler-mobile.png', fullPage: true } );
+	const hasHorizontalOverflow = await page.evaluate(
+		() => document.documentElement.scrollWidth > document.documentElement.clientWidth
+	);
+	expect( hasHorizontalOverflow ).toBeFalsy();
+
+	page.once( 'dialog', ( dialog ) => dialog.accept() );
+	await page.getByRole( 'button', { name: 'Clear snapshot' } ).click();
+	await expect( page.getByRole( 'status' ) ).toContainText( 'Action Scheduler diagnostic cleared.' );
+} );
+
 test( 'Admin Performance Monitor is opt-in, bounded, private, clearable, and responsive', async ( { page } ) => {
 	await login( page );
 	await openAdminPage( page, '/wp-admin/options-general.php?page=perform_settings&tab=advanced' );
@@ -419,6 +445,15 @@ test( 'lower-privilege users cannot access the legacy or canonical Cache Stats r
 	} );
 	expect( cronAuditResponse.status() ).toBe( 403 );
 	expect( await cronAuditResponse.json() ).toMatchObject( { success: false } );
+
+	const actionSchedulerResponse = await page.request.post( '/wp-admin/admin-ajax.php', {
+		form: {
+			action: 'perform_refresh_action_scheduler_audit',
+			nonce: 'invalid-for-editor-capability-check',
+		},
+	} );
+	expect( actionSchedulerResponse.status() ).toBe( 403 );
+	expect( await actionSchedulerResponse.json() ).toMatchObject( { success: false } );
 
 	const adminAssetResponse = await page.request.post( '/wp-admin/admin-ajax.php', {
 		form: {

--- a/tests/unit-tests/tests-action-scheduler-audit.php
+++ b/tests/unit-tests/tests-action-scheduler-audit.php
@@ -1,0 +1,209 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Perform\Admin\Settings\ActionSchedulerAudit;
+use Perform\Admin\Settings\ActionSchedulerAuditController;
+
+final class Tests_Action_Scheduler_Audit extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['perform_test_options']          = [];
+		$GLOBALS['perform_test_current_user_can'] = [ 'manage_options' => true ];
+		$GLOBALS['perform_test_nonce_valid']      = true;
+		$GLOBALS['perform_test_is_multisite']     = false;
+		$GLOBALS['perform_test_blog_id']          = 1;
+		$GLOBALS['wpdb']                          = new Perform_Test_Action_Scheduler_Wpdb();
+		$_POST                                    = [];
+	}
+
+	protected function tearDown(): void {
+		unset( $GLOBALS['perform_test_options'], $GLOBALS['perform_test_current_user_can'], $GLOBALS['perform_test_nonce_valid'], $GLOBALS['perform_test_is_multisite'], $GLOBALS['perform_test_blog_id'], $GLOBALS['perform_test_json_response'], $GLOBALS['wpdb'] );
+		$_POST = [];
+	}
+
+	public function test_absent_tables_return_clean_unavailable_snapshot() {
+		$GLOBALS['wpdb']->existing_tables = [];
+		$audit                            = ActionSchedulerAudit::refresh();
+
+		$this->assertSame( 'not-available', $audit['status'] );
+		$this->assertSame( 0, $audit['storage']['actionCount'] );
+		$this->assertFalse( $audit['privacy']['argumentsRead'] );
+		$this->assertCount( 3, $GLOBALS['wpdb']->data_queries );
+	}
+
+	public function test_empty_queue_returns_zero_counts() {
+		$audit = ActionSchedulerAudit::refresh();
+
+		$this->assertSame( 'ready', $audit['status'] );
+		$this->assertSame(
+			[
+				'pending'  => 0,
+				'running'  => 0,
+				'complete' => 0,
+				'failed'   => 0,
+				'canceled' => 0,
+			],
+			$audit['counts']
+		);
+		$this->assertSame( 0, $audit['storage']['actionCount'] );
+		$this->assertSame( 0, $audit['storage']['logCount'] );
+		$this->assertFalse( $audit['oldestPending']['available'] );
+	}
+
+	public function test_large_failed_queue_is_aggregated_without_payloads() {
+		$GLOBALS['wpdb']->status_rows    = [
+			[
+				'status'       => 'pending',
+				'action_count' => 12000,
+			],
+			[
+				'status'       => 'in-progress',
+				'action_count' => 3,
+			],
+			[
+				'status'       => 'failed',
+				'action_count' => 47,
+			],
+			[
+				'status'       => 'complete',
+				'action_count' => 600000,
+			],
+		];
+		$GLOBALS['wpdb']->oldest_pending = gmdate( 'Y-m-d H:i:s', time() - 7200 );
+		$GLOBALS['wpdb']->hook_rows      = [
+			[
+				'hook'         => 'safe_hook',
+				'action_count' => 11900,
+				'args'         => 'secret-token',
+			],
+			[
+				'hook'         => 'https://private.example/?token=secret',
+				'action_count' => 2,
+			],
+		];
+		$GLOBALS['wpdb']->group_rows     = [
+			[
+				'group_name'   => 'commerce',
+				'action_count' => 12000,
+			],
+		];
+		$GLOBALS['wpdb']->log_count      = 900000;
+
+		$audit = ActionSchedulerAudit::refresh();
+		$json  = wp_json_encode( $audit );
+
+		$this->assertSame( 12000, $audit['counts']['pending'] );
+		$this->assertSame( 3, $audit['counts']['running'] );
+		$this->assertSame( 47, $audit['counts']['failed'] );
+		$this->assertSame( 612050, $audit['storage']['actionCount'] );
+		$this->assertSame( 900000, $audit['storage']['logCount'] );
+		$this->assertSame( 'requires-log-message-inference', $audit['failedTrend']['reason'] );
+		$this->assertGreaterThanOrEqual( 7100, $audit['oldestPending']['ageSeconds'] );
+		$this->assertSame( 'safe_hook', $audit['topHooks'][0]['name'] );
+		$this->assertCount( 1, $audit['topHooks'] );
+		$this->assertStringNotContainsString( 'secret-token', $json );
+		$this->assertStringNotContainsString( 'private.example', $json );
+	}
+
+	public function test_cached_snapshot_is_per_site_stale_and_clearable() {
+		$GLOBALS['perform_test_is_multisite']                                 = true;
+		$GLOBALS['perform_test_blog_id']                                      = 8;
+		$GLOBALS['perform_test_options'][ ActionSchedulerAudit::OPTION_NAME ] = [
+			'schemaVersion' => ActionSchedulerAudit::SCHEMA_VERSION,
+			'status'        => 'ready',
+			'expiresAt'     => time() - 1,
+		];
+
+		$this->assertTrue( ActionSchedulerAudit::get_cached_snapshot()['isStale'] );
+		ActionSchedulerAudit::clear();
+		$empty = ActionSchedulerAudit::get_cached_snapshot();
+		$this->assertSame( 'not-run', $empty['status'] );
+		$this->assertTrue( $empty['isMultisite'] );
+		$this->assertSame( 8, $empty['siteId'] );
+	}
+
+	public function test_endpoints_require_capability_and_nonce() {
+		$GLOBALS['perform_test_current_user_can']['manage_options'] = false;
+		$this->run_controller_request( 'refresh' );
+		$this->assertFalse( $GLOBALS['perform_test_json_response']['success'] );
+		$this->assertSame( [], $GLOBALS['wpdb']->data_queries );
+
+		$GLOBALS['perform_test_current_user_can']['manage_options'] = true;
+		$GLOBALS['perform_test_nonce_valid']                        = false;
+		$_POST['nonce'] = 'invalid';
+		$this->run_controller_request( 'refresh' );
+		$this->assertFalse( $GLOBALS['perform_test_json_response']['success'] );
+	}
+
+	public function test_controller_refresh_and_clear_never_change_queue_rows() {
+		$_POST['nonce'] = 'valid';
+		$this->run_controller_request( 'refresh' );
+		$this->assertTrue( $GLOBALS['perform_test_json_response']['success'] );
+		$this->assertSame( 0, $GLOBALS['wpdb']->mutation_count );
+
+		$this->run_controller_request( 'clear' );
+		$this->assertTrue( $GLOBALS['perform_test_json_response']['success'] );
+		$this->assertSame( 'not-run', $GLOBALS['perform_test_json_response']['data']['audit']['status'] );
+		$this->assertSame( 0, $GLOBALS['wpdb']->mutation_count );
+	}
+
+	private function run_controller_request( $method ) {
+		try {
+			$controller = new ActionSchedulerAuditController();
+			$controller->{$method}();
+			$this->fail( 'Expected the JSON response to end the request.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'perform_test_json_response', $exception->getMessage() );
+		}
+	}
+}
+
+// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound -- Focused database fixture for this service.
+final class Perform_Test_Action_Scheduler_Wpdb {
+	public $prefix          = 'wp_';
+	public $last_error      = '';
+	public $existing_tables = [ 'wp_actionscheduler_actions', 'wp_actionscheduler_groups', 'wp_actionscheduler_logs' ];
+	public $status_rows     = [];
+	public $hook_rows       = [];
+	public $group_rows      = [];
+	public $oldest_pending  = null;
+	public $log_count       = 0;
+	public $data_queries    = [];
+	public $mutation_count  = 0;
+
+	public function prepare( $query, $args ) {
+		return $query . ' /* ' . wp_json_encode( $args ) . ' */';
+	}
+
+	public function get_var( $query ) {
+		$this->data_queries[] = $query;
+		if ( false !== strpos( $query, 'SHOW TABLES LIKE' ) ) {
+			foreach ( $this->existing_tables as $table ) {
+				if ( false !== strpos( $query, $table ) ) {
+					return $table;
+				}
+			}
+			return null;
+		}
+		if ( false !== strpos( $query, 'MIN(scheduled_date_gmt)' ) ) {
+			return $this->oldest_pending;
+		}
+		if ( false !== strpos( $query, 'actionscheduler_logs' ) ) {
+			return $this->log_count;
+		}
+		return null;
+	}
+
+	public function get_results( $query, $output ) {
+		$this->data_queries[] = $query;
+		if ( false !== strpos( $query, 'GROUP BY status' ) ) {
+			return $this->status_rows;
+		}
+		if ( false !== strpos( $query, 'GROUP BY hook' ) ) {
+			return $this->hook_rows;
+		}
+		if ( false !== strpos( $query, 'GROUP BY action_group.slug' ) ) {
+			return $this->group_rows;
+		}
+		return [];
+	}
+}


### PR DESCRIPTION
Closes #181.

## Summary

- adds a manual, cached, current-site Action Scheduler diagnostic with clean absent-table handling
- reports aggregate pending/running/complete/failed/canceled counts, oldest pending age, top hooks/groups, and action/log row indicators
- never reads action arguments, payloads, or log messages and never runs, cancels, deletes, or reschedules queue entries
- explicitly leaves failed-action trend unavailable because reliable derivation would require interpreting private log messages
- keeps future cleanup separate; no cleanup workflow is included in 1.8.0

## Validation

- PHP lint and scoped PHPCS
- `composer test` — 143 tests, 471 assertions
- `npm run test:unit` — 40 tests
- `npm run lint`
- `npm run build`
- PHPStan full repository and changed-path follow-up
- `git diff --check`

Hosted WordPress smoke proof must confirm the absent-queue state, capability denial, clear-only-saved-snapshot behavior, and responsive desktop/mobile UI before merge.
