### PR TITLE
Stabilize classic menu cache keys and purge tracking

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,6 +2,9 @@
 	"plugins": [
 		"."
 	],
+	"themes": [
+		"./tests/e2e/fixtures/perform-classic-theme"
+	],
 	"config": {
 		"WP_DEBUG": true,
 		"SCRIPT_DEBUG": true

--- a/docs/menu-cache-key-contract.md
+++ b/docs/menu-cache-key-contract.md
@@ -1,0 +1,23 @@
+# Menu cache key contract
+
+Perform's classic navigation-menu cache is enabled only for anonymous frontend requests on classic themes by default. The cache signature includes the menu ID, theme location, output-affecting `wp_nav_menu()` arguments, walker/callback class identity, and locale. Full query state is intentionally excluded so the same menu can be reused across ordinary pages.
+
+Sites with a query-aware custom walker can opt into the legacy query-sensitive behavior:
+
+```php
+add_filter( 'perform_menu_cache_query_sensitive', '__return_true' );
+```
+
+Custom bounded segmentation can be supplied without exposing values in stored metadata:
+
+```php
+add_filter(
+	'perform_menu_cache_key_segments',
+	static function ( $segments ) {
+		$segments['audience'] = 'public';
+		return $segments;
+	}
+);
+```
+
+Perform tracks at most 100 signatures per menu. When a new variant exceeds that limit, the oldest tracked cache entry is evicted. Menu updates purge every valid tracked signature. Missing, malformed, or non-array tracking data is treated as an empty list without warnings.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -429,7 +429,7 @@ parameters:
 		-
 			message: '#^Access to property \$menu on an unknown class Perform\\Modules\\MenuCache\\stdClass\.$#'
 			identifier: class.notFound
-			count: 7
+			count: 6
 			path: src/Modules/MenuCache/MenuCache.php
 
 		-

--- a/src/Modules/MenuCache/MenuCache.php
+++ b/src/Modules/MenuCache/MenuCache.php
@@ -24,6 +24,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Optimized and enhanced for improved performance.
  */
 class MenuCache implements ModuleInterface {
+	const TRACKED_SIGNATURE_LIMIT = 100;
+	const CACHE_TTL               = 15552000;
 
 	/**
 	 * Log Menu Start.
@@ -183,9 +185,8 @@ class MenuCache implements ModuleInterface {
 
 		$args->menu = $menu;
 
-		// Generate a unique cache key for the menu.
-		global $wp_query;
-		$menu_signature = md5( wp_json_encode( $args ) . $wp_query->query_vars_hash );
+		// Generate a stable cache key for output-affecting menu inputs.
+		$menu_signature = $this->get_menu_signature( $args );
 
 		// Attempt to retrieve cached menu output.
 		$cached_output = get_transient( 'perform_menu_cache_' . $menu_signature );
@@ -216,27 +217,28 @@ class MenuCache implements ModuleInterface {
 			return $nav_menu;
 		}
 
-		// Generate a unique cache key for the menu.
-		global $wp_query;
-		$menu_signature = md5( wp_json_encode( $args ) . $wp_query->query_vars_hash );
+		// Generate a stable cache key for output-affecting menu inputs.
+		$menu_signature = $this->get_menu_signature( $args );
 
 		// Set menu cache with a 6-month expiration.
-		set_transient( 'perform_menu_cache_' . $menu_signature, $nav_menu, 15552000 );
+		set_transient( 'perform_menu_cache_' . $menu_signature, $nav_menu, self::CACHE_TTL );
 
 		// Store a reference to this version of the menu, so we can purge it when needed.
-		$cached_versions = get_transient( 'perform_menu_cache_menuid_' . $args->menu->term_id );
-		if ( false === $cached_versions ) {
-			$cached_versions = [];
-		} else {
-			$cached_versions = json_decode( $cached_versions, true );
-		}
+		$reference_key   = 'perform_menu_cache_menuid_' . absint( $args->menu->term_id );
+		$cached_versions = $this->get_tracked_signatures( get_transient( $reference_key ) );
 
 		if ( ! in_array( $menu_signature, $cached_versions, true ) ) {
 			$cached_versions[] = $menu_signature;
+			if ( self::TRACKED_SIGNATURE_LIMIT < count( $cached_versions ) ) {
+				$expired_signature = array_shift( $cached_versions );
+				if ( is_string( $expired_signature ) ) {
+					delete_transient( 'perform_menu_cache_' . $expired_signature );
+				}
+			}
 		}
 
 		// Update the cached versions reference with a 6-month expiration.
-		set_transient( 'perform_menu_cache_menuid_' . $args->menu->term_id, wp_json_encode( $cached_versions ), 15552000 );
+		set_transient( $reference_key, wp_json_encode( $cached_versions ), self::CACHE_TTL );
 
 		return $nav_menu;
 	}
@@ -256,27 +258,132 @@ class MenuCache implements ModuleInterface {
 	 */
 	public function update_nav_menu_cache( $menu_id, $menu_data = null ) {
 
-		if ( is_array( $menu_data ) && isset( $menu_data['menu-name'] ) ) {
-
-			$menu = wp_get_nav_menu_object( $menu_data['menu-name'] );
-
-			if ( isset( $menu->term_id ) ) {
-
-				// Get all cached versions of this menu and delete them.
-				$cached_versions = get_transient( 'perform_menu_cache_menuid_' . $menu->term_id );
-
-				if ( false !== $cached_versions ) {
-
-					$cached_versions = json_decode( $cached_versions, true );
-
-					foreach ( $cached_versions as $menu_signature ) {
-						delete_transient( 'perform_menu_cache_' . $menu_signature );
-					}
-
-					// Reset the cached versions reference.
-					set_transient( 'perform_menu_cache_menuid_' . $menu->term_id, wp_json_encode( [] ), 15552000 );
-				}
-			}
+		$menu_id = absint( $menu_id );
+		if ( 0 === $menu_id && is_array( $menu_data ) && isset( $menu_data['menu-name'] ) ) {
+			$menu    = wp_get_nav_menu_object( $menu_data['menu-name'] );
+			$menu_id = isset( $menu->term_id ) ? absint( $menu->term_id ) : 0;
 		}
+
+		if ( 0 === $menu_id ) {
+			return;
+		}
+
+		$reference_key   = 'perform_menu_cache_menuid_' . $menu_id;
+		$cached_versions = $this->get_tracked_signatures( get_transient( $reference_key ) );
+		foreach ( $cached_versions as $menu_signature ) {
+			delete_transient( 'perform_menu_cache_' . $menu_signature );
+		}
+
+		set_transient( $reference_key, wp_json_encode( [] ), self::CACHE_TTL );
+	}
+
+	/**
+	 * Build a stable signature from output-affecting menu inputs.
+	 *
+	 * Full query state is excluded by default because classic menu output does
+	 * not normally vary by page. Sites with query-aware walkers can opt in with
+	 * `perform_menu_cache_query_sensitive` or provide a bounded custom segment
+	 * through `perform_menu_cache_key_segments`.
+	 *
+	 * @param object $args wp_nav_menu() arguments.
+	 * @return string
+	 */
+	private function get_menu_signature( $args ) {
+		$menu_id = isset( $args->menu->term_id ) ? absint( $args->menu->term_id ) : 0;
+		$keys    = [
+			'menu'                 => $menu_id,
+			'theme_location'       => isset( $args->theme_location ) ? (string) $args->theme_location : '',
+			'menu_class'           => isset( $args->menu_class ) ? (string) $args->menu_class : '',
+			'menu_id'              => isset( $args->menu_id ) ? (string) $args->menu_id : '',
+			'container'            => isset( $args->container ) ? (string) $args->container : '',
+			'container_class'      => isset( $args->container_class ) ? (string) $args->container_class : '',
+			'container_id'         => isset( $args->container_id ) ? (string) $args->container_id : '',
+			'container_aria_label' => isset( $args->container_aria_label ) ? (string) $args->container_aria_label : '',
+			'before'               => isset( $args->before ) ? (string) $args->before : '',
+			'after'                => isset( $args->after ) ? (string) $args->after : '',
+			'link_before'          => isset( $args->link_before ) ? (string) $args->link_before : '',
+			'link_after'           => isset( $args->link_after ) ? (string) $args->link_after : '',
+			'depth'                => isset( $args->depth ) ? (int) $args->depth : 0,
+			'items_wrap'           => isset( $args->items_wrap ) ? (string) $args->items_wrap : '',
+			'item_spacing'         => isset( $args->item_spacing ) ? (string) $args->item_spacing : '',
+			'fallback_cb'          => $this->normalize_callable( $args->fallback_cb ?? null ),
+			'walker'               => is_object( $args->walker ?? null ) ? get_class( $args->walker ) : '',
+			'locale'               => function_exists( 'determine_locale' ) ? determine_locale() : get_locale(),
+		];
+
+		$query_sensitive = (bool) apply_filters( 'perform_menu_cache_query_sensitive', false, $args );
+		if ( $query_sensitive ) {
+			global $wp_query;
+			$keys['query'] = is_object( $wp_query ) && isset( $wp_query->query_vars_hash ) ? (string) $wp_query->query_vars_hash : '';
+		}
+
+		$segments         = apply_filters( 'perform_menu_cache_key_segments', [], $args );
+		$keys['segments'] = $this->normalize_segments( $segments );
+
+		return md5( (string) wp_json_encode( $keys ) );
+	}
+
+	/**
+	 * Normalize callback identity without serializing object state.
+	 *
+	 * @param mixed $callback Callback value.
+	 * @return string
+	 */
+	private function normalize_callable( $callback ) {
+		if ( is_string( $callback ) ) {
+			return $callback;
+		}
+		if ( is_array( $callback ) && 2 === count( $callback ) ) {
+			$owner = is_object( $callback[0] ) ? get_class( $callback[0] ) : (string) $callback[0];
+			return $owner . '::' . (string) $callback[1];
+		}
+		return is_object( $callback ) ? get_class( $callback ) : '';
+	}
+
+	/**
+	 * Normalize custom segmentation to a small scalar-only shape.
+	 *
+	 * @param mixed $segments Filtered key segments.
+	 * @return array<string, int|float|string|bool|null>
+	 */
+	private function normalize_segments( $segments ) {
+		if ( ! is_array( $segments ) ) {
+			return [];
+		}
+
+		$normalized = [];
+		foreach ( array_slice( $segments, 0, 20, true ) as $key => $value ) {
+			$key = sanitize_key( (string) $key );
+			if ( '' === $key || ! ( is_scalar( $value ) || null === $value ) ) {
+				continue;
+			}
+			$normalized[ $key ] = is_string( $value ) ? substr( $value, 0, 191 ) : $value;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Decode and validate the bounded purge reference list.
+	 *
+	 * @param mixed $stored Stored transient value.
+	 * @return array<int, string>
+	 */
+	private function get_tracked_signatures( $stored ) {
+		$decoded = is_string( $stored ) ? json_decode( $stored, true ) : $stored;
+		if ( ! is_array( $decoded ) ) {
+			return [];
+		}
+
+		$signatures = array_values(
+			array_filter(
+				$decoded,
+				static function ( $signature ) {
+					return is_string( $signature ) && 1 === preg_match( '/^[a-f0-9]{32}$/', $signature );
+				}
+			)
+		);
+
+		return array_slice( $signatures, -self::TRACKED_SIGNATURE_LIMIT );
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -409,6 +409,47 @@ if ( ! function_exists( 'wp_is_block_theme' ) ) {
 	}
 }
 
+if ( ! function_exists( 'determine_locale' ) ) {
+	function determine_locale() {
+		return isset( $GLOBALS['perform_test_locale'] ) ? (string) $GLOBALS['perform_test_locale'] : 'en_US';
+	}
+}
+
+if ( ! function_exists( 'get_locale' ) ) {
+	function get_locale() {
+		return determine_locale();
+	}
+}
+
+if ( ! function_exists( 'wp_get_nav_menu_object' ) ) {
+	function wp_get_nav_menu_object( $menu ) {
+		if ( is_object( $menu ) && isset( $menu->term_id ) ) {
+			return $menu;
+		}
+		$menus = isset( $GLOBALS['perform_test_nav_menus'] ) && is_array( $GLOBALS['perform_test_nav_menus'] ) ? $GLOBALS['perform_test_nav_menus'] : [];
+		return $menus[ (string) $menu ] ?? false;
+	}
+}
+
+if ( ! function_exists( 'get_nav_menu_locations' ) ) {
+	function get_nav_menu_locations() {
+		return isset( $GLOBALS['perform_test_nav_menu_locations'] ) && is_array( $GLOBALS['perform_test_nav_menu_locations'] ) ? $GLOBALS['perform_test_nav_menu_locations'] : [];
+	}
+}
+
+if ( ! function_exists( 'wp_get_nav_menus' ) ) {
+	function wp_get_nav_menus() {
+		return isset( $GLOBALS['perform_test_nav_menu_list'] ) && is_array( $GLOBALS['perform_test_nav_menu_list'] ) ? $GLOBALS['perform_test_nav_menu_list'] : [];
+	}
+}
+
+if ( ! function_exists( 'wp_get_nav_menu_items' ) ) {
+	function wp_get_nav_menu_items( $menu_id, $args = [] ) {
+		$items = isset( $GLOBALS['perform_test_nav_menu_items'] ) && is_array( $GLOBALS['perform_test_nav_menu_items'] ) ? $GLOBALS['perform_test_nav_menu_items'] : [];
+		return $items[ (int) $menu_id ] ?? [];
+	}
+}
+
 if ( ! function_exists( 'apply_filters' ) ) {
 	function apply_filters( $hook_name, $value, ...$args ) {
 		$filters = isset( $GLOBALS['perform_test_filters'] ) && is_array( $GLOBALS['perform_test_filters'] ) ? $GLOBALS['perform_test_filters'] : [];

--- a/tests/e2e/fixtures/perform-classic-theme/functions.php
+++ b/tests/e2e/fixtures/perform-classic-theme/functions.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Minimal classic-theme setup for disposable end-to-end tests.
+ */
+
+add_action(
+	'after_setup_theme',
+	static function () {
+		register_nav_menus( [ 'primary' => 'Primary' ] );
+	}
+);

--- a/tests/e2e/fixtures/perform-classic-theme/index.php
+++ b/tests/e2e/fixtures/perform-classic-theme/index.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Minimal classic-theme frontend used only by disposable end-to-end tests.
+ */
+
+?><!doctype html>
+<html <?php language_attributes(); ?>>
+<head><?php wp_head(); ?></head>
+<body <?php body_class(); ?>>
+<?php
+wp_nav_menu(
+	[
+		'theme_location' => 'primary',
+		'container'      => 'nav',
+		'container_id'   => 'perform-test-navigation',
+		'fallback_cb'    => false,
+	]
+);
+wp_footer();
+?>
+</body>
+</html>

--- a/tests/e2e/fixtures/perform-classic-theme/style.css
+++ b/tests/e2e/fixtures/perform-classic-theme/style.css
@@ -1,0 +1,9 @@
+/*
+Theme Name: Perform Classic Test Theme
+Version: 1.0.0
+Requires at least: 6.8
+*/
+
+body {
+	font-family: sans-serif;
+}

--- a/tests/e2e/perform-smoke.spec.js
+++ b/tests/e2e/perform-smoke.spec.js
@@ -320,6 +320,25 @@ test( 'Plugin impact report separates measured local evidence from unavailable a
 	await expect( page.getByText( /Settings saved/ ) ).toBeVisible();
 } );
 
+test( 'Classic menu cache stays functional across unrelated query variables', async ( { page } ) => {
+	await login( page );
+	await openAdminPage( page, '/wp-admin/options-general.php?page=perform_settings&tab=general' );
+	const menuCacheToggle = page.getByRole( 'checkbox', { name: 'Enable Menu Cache' } );
+	if ( ! ( await menuCacheToggle.isChecked() ) ) {
+		await menuCacheToggle.check();
+		await page.getByRole( 'button', { name: 'Save Settings' } ).click();
+		await expect( page.getByText( /Settings saved/ ) ).toBeVisible();
+	}
+
+	await page.context().clearCookies( { name: /^wordpress_/ } );
+	await page.goto( '/?unrelated=first' );
+	await expect( page.locator( '#perform-test-navigation' ).getByRole( 'link', { name: 'Home' } ) ).toBeVisible();
+	const firstMarkup = await page.locator( '#perform-test-navigation' ).innerHTML();
+	await page.goto( '/?unrelated=second' );
+	await expect( page.locator( '#perform-test-navigation' ).getByRole( 'link', { name: 'Home' } ) ).toBeVisible();
+	expect( await page.locator( '#perform-test-navigation' ).innerHTML() ).toBe( firstMarkup );
+} );
+
 test( 'Cache Stats tab preserves legacy routing, actions, and keyboard access', async ( { page } ) => {
 	await login( page );
 

--- a/tests/e2e/run-ci.mjs
+++ b/tests/e2e/run-ci.mjs
@@ -36,6 +36,27 @@ try {
 			'run',
 			'cli',
 			'wp',
+			'theme',
+			'activate',
+			'perform-classic-theme',
+		] );
+		await run( 'npm', [
+			'run',
+			'wp-env',
+			'--',
+			'run',
+			'cli',
+			'wp',
+			'eval',
+			'$menu = wp_get_nav_menu_object( "Primary" ); $menu_id = $menu ? (int) $menu->term_id : wp_create_nav_menu( "Primary" ); if ( is_wp_error( $menu_id ) ) { throw new RuntimeException( $menu_id->get_error_message() ); } if ( ! wp_get_nav_menu_items( $menu_id ) ) { wp_update_nav_menu_item( $menu_id, 0, [ "menu-item-title" => "Home", "menu-item-url" => home_url( "/" ), "menu-item-status" => "publish" ] ); } set_theme_mod( "nav_menu_locations", [ "primary" => $menu_id ] );',
+		] );
+		await run( 'npm', [
+			'run',
+			'wp-env',
+			'--',
+			'run',
+			'cli',
+			'wp',
 			'eval',
 			'if ( class_exists( "Freemius" ) ) { $perform_fs = Freemius::get_instance_by_id( 18658 ); if ( $perform_fs ) { $perform_fs->skip_connection(); } }',
 		] );

--- a/tests/unit-tests/tests-menu-cache.php
+++ b/tests/unit-tests/tests-menu-cache.php
@@ -11,10 +11,15 @@ final class Tests_Menu_Cache extends TestCase {
 			],
 		];
 		unset( $GLOBALS['perform_test_filters'], $GLOBALS['perform_test_is_block_theme'] );
+		$GLOBALS['perform_test_transients']        = [];
+		$GLOBALS['perform_test_is_admin']          = false;
+		$GLOBALS['perform_test_is_user_logged_in'] = false;
+		$GLOBALS['perform_test_locale']            = 'en_US';
+		$GLOBALS['wp_query']                       = (object) [ 'query_vars_hash' => 'query-a' ];
 	}
 
 	protected function tearDown(): void {
-		unset( $GLOBALS['perform_test_filters'], $GLOBALS['perform_test_is_block_theme'] );
+		unset( $GLOBALS['perform_test_filters'], $GLOBALS['perform_test_is_block_theme'], $GLOBALS['perform_test_transients'], $GLOBALS['perform_test_is_admin'], $GLOBALS['perform_test_is_user_logged_in'], $GLOBALS['perform_test_locale'], $GLOBALS['wp_query'] );
 	}
 
 	public function test_menu_cache_does_not_load_for_block_themes_by_default() {
@@ -34,5 +39,94 @@ final class Tests_Menu_Cache extends TestCase {
 		$menu_cache = new MenuCache();
 
 		$this->assertTrue( $menu_cache->should_load() );
+	}
+
+	public function test_default_signature_is_stable_across_irrelevant_query_vars() {
+		$menu_cache = new MenuCache();
+		$args       = $this->get_menu_args();
+
+		$this->assertSame( '<nav>Primary</nav>', $menu_cache->cache_nav_menu( '<nav>Primary</nav>', $args ) );
+		$GLOBALS['wp_query']->query_vars_hash = 'query-b';
+
+		$this->assertSame( '<nav>Primary</nav>', $menu_cache->cache_nav_menu_output( null, $this->get_menu_args() ) );
+	}
+
+	public function test_query_sensitive_filter_preserves_compatibility_for_dynamic_walkers() {
+		$GLOBALS['perform_test_filters']['perform_menu_cache_query_sensitive'] = true;
+		$menu_cache = new MenuCache();
+		$menu_cache->cache_nav_menu( '<nav>Page A</nav>', $this->get_menu_args() );
+
+		$GLOBALS['wp_query']->query_vars_hash = 'query-b';
+		$this->assertNull( $menu_cache->cache_nav_menu_output( null, $this->get_menu_args() ) );
+	}
+
+	public function test_tracking_is_bounded_and_evicts_the_oldest_variant() {
+		$menu_cache = new MenuCache();
+		$first_key  = '';
+
+		for ( $index = 0; $index <= MenuCache::TRACKED_SIGNATURE_LIMIT; ++$index ) {
+			$args             = $this->get_menu_args();
+			$args->menu_class = 'menu-' . $index;
+			$menu_cache->cache_nav_menu( '<nav>' . $index . '</nav>', $args );
+			if ( 0 === $index ) {
+				$keys      = array_keys( $GLOBALS['perform_test_transients'] );
+				$first_key = (string) current(
+					array_filter(
+						$keys,
+						static function ( $key ) {
+							return 0 === strpos( $key, 'perform_menu_cache_' ) && false === strpos( $key, 'menuid_' );
+						}
+					)
+				);
+			}
+		}
+
+		$tracked = json_decode( $GLOBALS['perform_test_transients']['perform_menu_cache_menuid_42'], true );
+		$this->assertCount( MenuCache::TRACKED_SIGNATURE_LIMIT, $tracked );
+		$this->assertArrayNotHasKey( $first_key, $GLOBALS['perform_test_transients'] );
+	}
+
+	public function test_malformed_tracking_transient_fails_quietly_and_recovers() {
+		$GLOBALS['perform_test_transients']['perform_menu_cache_menuid_42'] = '{not-json';
+		$menu_cache = new MenuCache();
+
+		$menu_cache->cache_nav_menu( '<nav>Primary</nav>', $this->get_menu_args() );
+		$tracked = json_decode( $GLOBALS['perform_test_transients']['perform_menu_cache_menuid_42'], true );
+
+		$this->assertIsArray( $tracked );
+		$this->assertCount( 1, $tracked );
+	}
+
+	public function test_menu_update_purges_every_valid_tracked_variant() {
+		$first  = md5( 'first' );
+		$second = md5( 'second' );
+		$GLOBALS['perform_test_transients'][ 'perform_menu_cache_' . $first ]  = 'one';
+		$GLOBALS['perform_test_transients'][ 'perform_menu_cache_' . $second ] = 'two';
+		$GLOBALS['perform_test_transients']['perform_menu_cache_menuid_42']    = wp_json_encode( [ $first, 'invalid', $second ] );
+
+		( new MenuCache() )->update_nav_menu_cache( 42, [] );
+
+		$this->assertArrayNotHasKey( 'perform_menu_cache_' . $first, $GLOBALS['perform_test_transients'] );
+		$this->assertArrayNotHasKey( 'perform_menu_cache_' . $second, $GLOBALS['perform_test_transients'] );
+		$this->assertSame( [], json_decode( $GLOBALS['perform_test_transients']['perform_menu_cache_menuid_42'], true ) );
+	}
+
+	private function get_menu_args() {
+		return (object) [
+			'menu'            => (object) [
+				'term_id' => 42,
+				'name'    => 'Primary',
+			],
+			'theme_location'  => 'primary',
+			'menu_class'      => 'menu',
+			'menu_id'         => 'primary-menu',
+			'container'       => 'nav',
+			'container_class' => 'site-navigation',
+			'depth'           => 2,
+			'items_wrap'      => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+			'item_spacing'    => 'preserve',
+			'fallback_cb'     => false,
+			'walker'          => null,
+		];
 	}
 }


### PR DESCRIPTION
## Summary

- replace full query-state menu cache keys with stable output-affecting signatures
- retain compatibility for query-aware walkers through an explicit filter and bounded custom segments
- cap tracked variants at 100, evict the oldest entry, recover safely from malformed tracking data, and purge by menu ID
- document the key contract and add unit plus disposable classic-theme browser coverage

## Validation

- `composer lint` (91 PHP files)
- `vendor/bin/phpunit` (148 tests, 482 assertions)
- `npm run test:js` (11 suites, 40 tests)
- `npm run lint`
- `npm run build`
- `php -d memory_limit=2G vendor/bin/phpstan analyse --no-progress --debug`
- `git diff --check`

Closes #106
